### PR TITLE
Milestone 0: feasibility spikes

### DIFF
--- a/.github/workflows/spikes.yml
+++ b/.github/workflows/spikes.yml
@@ -1,0 +1,55 @@
+name: Spikes
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spikes:
+    name: Spikes (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3', '8.4', '8.5']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Run spikes 01-06
+        run: bash spikes/run.sh
+
+  psalm-spike:
+    name: Spike 07 (Psalm plugin)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Run spike 07
+        run: bash spikes/07-psalm-builder/run.sh

--- a/spikes/01-sentinel/spike.php
+++ b/spikes/01-sentinel/spike.php
@@ -50,11 +50,20 @@ final class InvocationSignal extends \Exception
 
 final class Runtime
 {
-    public static bool $recording = false;
+    /**
+     * Recording is a DEPTH counter, not a boolean (plan §4.2): a nested
+     * recording phase must not switch the outer one off when it unwinds.
+     */
+    public static int $recordingDepth = 0;
+
+    public static function isRecording(): bool
+    {
+        return self::$recordingDepth > 0;
+    }
 
     public static function dispatch(object $double, string $method, array $args): mixed
     {
-        if (self::$recording) {
+        if (self::isRecording()) {
             throw new InvocationSignal(spl_object_id($double), $method, $args);
         }
 
@@ -87,14 +96,14 @@ final class BookRepositoryDouble implements BookRepository
  */
 function record(callable $closure): InvocationSignal
 {
-    Runtime::$recording = true;
+    Runtime::$recordingDepth++;
 
     try {
         $closure();
     } catch (InvocationSignal $signal) {
         return $signal;
     } finally {
-        Runtime::$recording = false;
+        Runtime::$recordingDepth--;
     }
 
     throw new \LogicException('closure did not hit a double');
@@ -116,3 +125,26 @@ $double->touch();
 assertTrue(true, '`: void` method dispatches normally outside recording');
 
 assertSame($double->find(5), null, 'normal phase returns the dispatcher value under `: ?Book`');
+
+// A nested recording phase must not switch the outer one off when it unwinds
+// (this is why the flag is a depth counter, plan §4.2).
+$outer = null;
+$inner = null;
+Runtime::$recordingDepth++;
+
+try {
+    $inner = record(fn () => $double->touch());
+
+    try {
+        $double->find(7);
+    } catch (InvocationSignal $signal) {
+        $outer = $signal;
+    }
+} finally {
+    Runtime::$recordingDepth--;
+}
+
+assertSame($inner?->method, 'touch', 'nested recording phase captures its own signal');
+assertSame($outer?->method, 'find', 'outer recording phase survives the nested one');
+assertSame(Runtime::$recordingDepth, 0, 'recording depth unwinds back to zero');
+

--- a/spikes/01-sentinel/spike.php
+++ b/spikes/01-sentinel/spike.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Spike 01 — sentinel exception escapes any native return type.
+ *
+ * Promises under test (plan §4.1/§4.2, §5.1):
+ * - a method declared `: ?Book` can abort via an exception while recording,
+ *   bypassing the return type check entirely;
+ * - the sentinel carries object id, method name and arguments;
+ * - a `: never` method cannot return, but throwing the sentinel is legal,
+ *   so recording works for `never` targets too;
+ * - a `: void` method dispatches normally.
+ */
+
+declare(strict_types=1);
+
+namespace Understudy\Spikes\Sentinel;
+
+use function Understudy\Spikes\assertSame;
+use function Understudy\Spikes\assertTrue;
+
+require __DIR__ . '/../lib.php';
+
+final class Book
+{
+}
+
+interface BookRepository
+{
+    public function find(int $id): ?Book;
+
+    public function abort(string $reason): never;
+
+    public function touch(): void;
+}
+
+final class InvocationSignal extends \Exception
+{
+    /**
+     * @param list<mixed> $args
+     */
+    public function __construct(
+        public readonly int $objectId,
+        public readonly string $method,
+        public readonly array $args,
+    ) {
+        parent::__construct('understudy sentinel');
+    }
+}
+
+final class Runtime
+{
+    public static bool $recording = false;
+
+    public static function dispatch(object $double, string $method, array $args): mixed
+    {
+        if (self::$recording) {
+            throw new InvocationSignal(spl_object_id($double), $method, $args);
+        }
+
+        return null;
+    }
+}
+
+final class BookRepositoryDouble implements BookRepository
+{
+    public function find(int $id): ?Book
+    {
+        return Runtime::dispatch($this, __FUNCTION__, [$id]);
+    }
+
+    public function abort(string $reason): never
+    {
+        Runtime::dispatch($this, __FUNCTION__, [$reason]);
+
+        throw new \LogicException('never-method called on a double without expectation');
+    }
+
+    public function touch(): void
+    {
+        Runtime::dispatch($this, __FUNCTION__, []);
+    }
+}
+
+/**
+ * @return InvocationSignal
+ */
+function record(callable $closure): InvocationSignal
+{
+    Runtime::$recording = true;
+
+    try {
+        $closure();
+    } catch (InvocationSignal $signal) {
+        return $signal;
+    } finally {
+        Runtime::$recording = false;
+    }
+
+    throw new \LogicException('closure did not hit a double');
+}
+
+echo "01-sentinel\n";
+
+$double = new BookRepositoryDouble();
+
+$signal = record(fn () => $double->find(123));
+assertSame($signal->method, 'find', 'sentinel escapes `: ?Book` and carries the method name');
+assertSame($signal->args, [123], 'sentinel carries the arguments');
+assertSame($signal->objectId, spl_object_id($double), 'sentinel identifies the double');
+
+$signal = record(fn () => $double->abort('boom'));
+assertSame($signal->method, 'abort', 'sentinel escapes `: never` during recording');
+
+$double->touch();
+assertTrue(true, '`: void` method dispatches normally outside recording');
+
+assertSame($double->find(5), null, 'normal phase returns the dispatcher value under `: ?Book`');

--- a/spikes/02-matcher-union/spike.php
+++ b/spikes/02-matcher-union/spike.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Spike 02 — contravariant `T|ArgumentMatcher` parameter widening.
+ *
+ * Promises under test (plan §4.2, §5.1):
+ * - an override may widen every parameter type with `|ArgumentMatcher`
+ *   (parameter contravariance) and still satisfy the interface;
+ * - the double class is produced through eval, like the real codegen;
+ * - `mixed` is not widened and still accepts a matcher instance;
+ * - nullable parameters normalize into `T|ArgumentMatcher|null`;
+ * - variadic and by-reference parameters accept matchers (by-ref via a
+ *   variable, as PHP requires);
+ * - scalar coercion follows the CALLING file's strict_types mode, not the
+ *   defining file's: a weak-mode caller passing '5' reaches int(5), a
+ *   strict-mode caller gets a TypeError.
+ */
+
+declare(strict_types=1);
+
+namespace Understudy\Spikes\MatcherUnion;
+
+use function Understudy\Spikes\assertSame;
+use function Understudy\Spikes\assertTrue;
+use function Understudy\Spikes\expectThrows;
+
+require __DIR__ . '/../lib.php';
+
+final class ArgumentMatcher
+{
+    public function __construct(public readonly string $kind = 'any')
+    {
+    }
+}
+
+interface Calc
+{
+    public function scale(int $factor): string;
+
+    public function pick(?int $x): string;
+
+    public function raw(mixed $x): string;
+
+    public function many(int ...$ns): string;
+
+    public function bump(int &$slot): string;
+}
+
+final class Runtime
+{
+    /** @var list<array{string, array<mixed>}> */
+    public static array $log = [];
+
+    public static function dispatch(object $double, string $method, array $args): string
+    {
+        self::$log[] = [$method, $args];
+
+        return $method;
+    }
+}
+
+$code = <<<'PHP'
+namespace Understudy\Spikes\MatcherUnion;
+
+final class CalcDouble implements Calc
+{
+    public function scale(int|ArgumentMatcher $factor): string
+    {
+        return Runtime::dispatch($this, __FUNCTION__, [$factor]);
+    }
+
+    public function pick(int|ArgumentMatcher|null $x): string
+    {
+        return Runtime::dispatch($this, __FUNCTION__, [$x]);
+    }
+
+    public function raw(mixed $x): string
+    {
+        return Runtime::dispatch($this, __FUNCTION__, [$x]);
+    }
+
+    public function many(int|ArgumentMatcher ...$ns): string
+    {
+        return Runtime::dispatch($this, __FUNCTION__, $ns);
+    }
+
+    public function bump(int|ArgumentMatcher &$slot): string
+    {
+        return Runtime::dispatch($this, __FUNCTION__, [$slot]);
+    }
+}
+PHP;
+
+eval($code);
+
+echo "02-matcher-union\n";
+
+$double = new CalcDouble();
+assertTrue($double instanceof Calc, 'eval\'d double with widened unions satisfies the interface');
+
+$matcher = new ArgumentMatcher();
+
+$double->scale(3);
+$double->scale($matcher);
+assertSame(Runtime::$log[0][1], [3], 'plain int passes the widened signature');
+assertTrue(Runtime::$log[1][1][0] instanceof ArgumentMatcher, 'matcher passes as the union branch');
+
+$double->pick(null);
+assertSame(Runtime::$log[2][1], [null], 'nullable normalizes into `int|ArgumentMatcher|null`');
+
+$double->raw($matcher);
+assertTrue(Runtime::$log[3][1][0] instanceof ArgumentMatcher, '`mixed` is not widened yet accepts a matcher');
+
+$double->many(1, $matcher, 2);
+assertSame(count(Runtime::$log[4][1]), 3, 'variadic accepts mixed literals and matchers');
+
+$slot = $matcher;
+$double->bump($slot);
+assertTrue(Runtime::$log[5][1][0] instanceof ArgumentMatcher, 'by-ref parameter accepts a matcher via a variable');
+
+$int = 7;
+$double->bump($int);
+assertSame(Runtime::$log[6][1], [7], 'by-ref parameter still accepts a plain int');
+
+expectThrows(
+    static fn (): string => $double->scale('nope'),
+    \TypeError::class,
+    'non-numeric string is rejected by the native check even in the widened union',
+);
+
+// Coercion semantics follow the calling file.
+$weak = require __DIR__ . '/weak_caller.php';
+assertSame($weak($double), [5], "weak-mode caller: '5' coerces to int(5) through the union");
+
+$strict = require __DIR__ . '/strict_caller.php';
+expectThrows(
+    static fn (): string => $strict($double),
+    \TypeError::class,
+    "strict-mode caller: '5' raises TypeError through the same union",
+);

--- a/spikes/02-matcher-union/strict_caller.php
+++ b/spikes/02-matcher-union/strict_caller.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+// Strict-mode SUT file: the same '5' argument must raise a TypeError here.
+
+namespace Understudy\Spikes\MatcherUnion;
+
+return static function (Calc $double): string {
+    return $double->scale('5');
+};

--- a/spikes/02-matcher-union/weak_caller.php
+++ b/spikes/02-matcher-union/weak_caller.php
@@ -1,0 +1,14 @@
+<?php
+
+// Intentionally NO declare(strict_types=1): this file represents SUT code
+// compiled in weak mode. Coercion of scalar arguments must follow this file.
+
+namespace Understudy\Spikes\MatcherUnion;
+
+return static function (Calc $double): array {
+    $double->scale('5');
+
+    $last = Runtime::$log[array_key_last(Runtime::$log)];
+
+    return $last[1];
+};

--- a/spikes/03-byref-return/spike.php
+++ b/spikes/03-byref-return/spike.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Spike 03 — by-reference return through a dispatch layer.
+ *
+ * Promises under test (plan §5.1):
+ * - an interface method declared `function &ref(): array` can be overridden
+ *   by a double whose implementation returns a reference to a stable slot
+ *   held OUTSIDE the double (doubles own no state);
+ * - mutations made through the obtained reference are visible on the next read;
+ * - a chain double -> runtime helper keeps the reference alive (the helper
+ *   itself must be declared `&dispatchReference`).
+ */
+
+declare(strict_types=1);
+
+namespace Understudy\Spikes\ByRefReturn;
+
+use function Understudy\Spikes\assertSame;
+use function Understudy\Spikes\assertTrue;
+
+require __DIR__ . '/../lib.php';
+
+interface Registry
+{
+    public function &values(): array;
+}
+
+final class Runtime
+{
+    /** @var array<string, array<mixed>> keyed by object id + method */
+    private static array $slots = [];
+
+    public static function &dispatchReference(object $double, string $method): array
+    {
+        $key = spl_object_id($double) . ':' . $method;
+
+        if (!array_key_exists($key, self::$slots)) {
+            self::$slots[$key] = [];
+        }
+
+        return self::$slots[$key];
+    }
+
+    public static function peek(object $double, string $method): array
+    {
+        return self::$slots[spl_object_id($double) . ':' . $method] ?? [];
+    }
+}
+
+final class RegistryDouble implements Registry
+{
+    public function &values(): array
+    {
+        $ref = &Runtime::dispatchReference($this, __FUNCTION__);
+
+        return $ref;
+    }
+}
+
+echo "03-byref-return\n";
+
+$double = new RegistryDouble();
+
+$values = &$double->values();
+$values['a'] = 1;
+
+assertSame(Runtime::peek($double, 'values'), ['a' => 1], 'mutation through the returned reference reaches the external slot');
+
+$again = &$double->values();
+assertSame($again, ['a' => 1], 'second by-ref call sees the same stable slot');
+
+$again['b'] = 2;
+assertSame($values, ['a' => 1, 'b' => 2], 'both references alias one slot');
+
+$other = new RegistryDouble();
+$otherValues = &$other->values();
+assertTrue($otherValues === [], 'slots are per-double, not shared');
+
+$copy = $double->values();
+$copy['c'] = 3;
+assertSame(Runtime::peek($double, 'values'), ['a' => 1, 'b' => 2], 'plain (non-reference) read copies and cannot corrupt the slot');

--- a/spikes/03-byref-return/spike.php
+++ b/spikes/03-byref-return/spike.php
@@ -26,25 +26,56 @@ interface Registry
     public function &values(): array;
 }
 
+/**
+ * A WeakMap value cannot be modified by reference directly, so each double
+ * owns a holder object whose property the reference points into.
+ */
+final class SlotHolder
+{
+    /** @var array<string, array<mixed>> */
+    public array $slots = [];
+}
+
 final class Runtime
 {
-    /** @var array<string, array<mixed>> keyed by object id + method */
-    private static array $slots = [];
+    /**
+     * Keyed by the double OBJECT, never by `spl_object_id()`: PHP reuses an
+     * object id after collection, so an id-keyed store would hand a fresh
+     * double the previous one's slot (plan §5.2 — SplObjectStorage/WeakMap).
+     *
+     * @var \WeakMap<object, SlotHolder>|null
+     */
+    private static ?\WeakMap $slots = null;
 
     public static function &dispatchReference(object $double, string $method): array
     {
-        $key = spl_object_id($double) . ':' . $method;
+        self::$slots ??= new \WeakMap();
 
-        if (!array_key_exists($key, self::$slots)) {
-            self::$slots[$key] = [];
+        if (!isset(self::$slots[$double])) {
+            self::$slots[$double] = new SlotHolder();
         }
 
-        return self::$slots[$key];
+        $holder = self::$slots[$double];
+
+        if (!array_key_exists($method, $holder->slots)) {
+            $holder->slots[$method] = [];
+        }
+
+        return $holder->slots[$method];
     }
 
     public static function peek(object $double, string $method): array
     {
-        return self::$slots[spl_object_id($double) . ':' . $method] ?? [];
+        if (self::$slots === null || !isset(self::$slots[$double])) {
+            return [];
+        }
+
+        return self::$slots[$double]->slots[$method] ?? [];
+    }
+
+    public static function trackedDoubles(): int
+    {
+        return count(self::$slots ?? []);
     }
 }
 
@@ -80,3 +111,17 @@ assertTrue($otherValues === [], 'slots are per-double, not shared');
 $copy = $double->values();
 $copy['c'] = 3;
 assertSame(Runtime::peek($double, 'values'), ['a' => 1, 'b' => 2], 'plain (non-reference) read copies and cannot corrupt the slot');
+
+// Weak keying: a collected double takes its slot with it, so a later double
+// that happens to reuse its object id can never inherit stale values.
+$tracked = Runtime::trackedDoubles();
+$temporary = new RegistryDouble();
+$temporarySlot = &$temporary->values();
+$temporarySlot['stale'] = true;
+
+assertSame(Runtime::trackedDoubles(), $tracked + 1, 'a new double adds one weakly-held entry');
+
+unset($temporary, $temporarySlot);
+gc_collect_cycles();
+
+assertSame(Runtime::trackedDoubles(), $tracked, 'the entry is released once the double is collected');

--- a/spikes/04-dnf-multitarget/spike.php
+++ b/spikes/04-dnf-multitarget/spike.php
@@ -124,84 +124,216 @@ interface WriterC
     public function write(int $chunk): void;
 }
 
+interface ArityA
+{
+    public function emit(int $a): void;
+}
+
+interface ArityB
+{
+    public function emit(int $a, int $b): void;
+}
+
+interface ReaderInt
+{
+    public function read(): int;
+}
+
+interface ReaderString
+{
+    public function read(): string;
+}
+
+interface FeederByRef
+{
+    public function feed(int &$slot): void;
+}
+
+interface FeederByValue
+{
+    public function feed(int $slot): void;
+}
+
 final class SignatureConflict extends \LogicException
 {
 }
 
 /**
- * Minimal stand-in for the codegen pre-check: renders each declaration and
- * requires one target's method to be compatible with every other declaration
- * of the same name. The real implementation compares structured signatures;
- * for the spike a rendered normal form is enough to prove detectability.
+ * Codegen pre-check: multi-target compatibility is UNIFICATION, not equality.
+ *
+ * PHP parameters are contravariant, so `write(int)` and `write(string)` share
+ * a valid implementation — `write(int|string)`. Rejecting them on rendered
+ * equality would refuse a doublable pair. A conflict exists only where no
+ * single declaration can satisfy every target:
+ *
+ * - return types are covariant, so they must agree (`int` vs `string` cannot
+ *   be satisfied — verified against PHP below);
+ * - by-reference-ness must match exactly;
+ * - parameter types unify into a union;
+ * - a parameter missing from (or optional in) any target must be optional.
  *
  * @param list<class-string> $targets
+ *
+ * @return array<string, string> method name => generated parameter list
  */
-function assertCompatibleTargets(array $targets): void
+function unifyTargets(array $targets): array
 {
-    /** @var array<string, array{class-string, string}> $seen */
-    $seen = [];
+    /** @var array<string, list<array{class-string, \ReflectionMethod}>> $byName */
+    $byName = [];
 
     foreach ($targets as $target) {
-        $reflection = new \ReflectionClass($target);
-
-        foreach ($reflection->getMethods() as $method) {
-            $signature = render($method);
-
-            if (isset($seen[$method->getName()]) && $seen[$method->getName()][1] !== $signature) {
-                throw new SignatureConflict(sprintf(
-                    'Method %s() is declared incompatibly: %s::%s vs %s::%s',
-                    $method->getName(),
-                    $seen[$method->getName()][0],
-                    $seen[$method->getName()][1],
-                    $target,
-                    $signature,
-                ));
-            }
-
-            $seen[$method->getName()] = [$target, $signature];
+        foreach ((new \ReflectionClass($target))->getMethods() as $method) {
+            $byName[$method->getName()][] = [$target, $method];
         }
     }
+
+    $signatures = [];
+
+    foreach ($byName as $name => $declarations) {
+        $signatures[$name] = unifyMethod($name, $declarations);
+    }
+
+    return $signatures;
 }
 
-function render(\ReflectionMethod $method): string
+/**
+ * @param non-empty-list<array{class-string, \ReflectionMethod}> $declarations
+ */
+function unifyMethod(string $name, array $declarations): string
 {
-    $params = array_map(
-        static fn (\ReflectionParameter $p): string => (string) $p->getType() . ($p->isVariadic() ? '...' : '') . ($p->isPassedByReference() ? '&' : ''),
-        $method->getParameters(),
-    );
+    /** @var array<string, list<class-string>> $returns */
+    $returns = [];
 
-    return sprintf('(%s): %s', implode(', ', $params), (string) $method->getReturnType());
+    foreach ($declarations as [$class, $method]) {
+        $returns[(string) $method->getReturnType() ?: 'mixed'][] = $class;
+    }
+
+    if (count($returns) > 1) {
+        throw new SignatureConflict(sprintf(
+            'Method %s() has irreconcilable return types: %s',
+            $name,
+            implode(' vs ', array_map(
+                static fn (string $type, array $classes): string => implode('+', $classes) . ' declares `: ' . $type . '`',
+                array_keys($returns),
+                $returns,
+            )),
+        ));
+    }
+
+    $arity = max(array_map(
+        static fn (array $d): int => $d[1]->getNumberOfParameters(),
+        $declarations,
+    ));
+
+    $parameters = [];
+
+    for ($position = 0; $position < $arity; $position++) {
+        /** @var array<string, true> $types */
+        $types = [];
+        /** @var array<string, list<class-string>> $byReference */
+        $byReference = [];
+        $requiredEverywhere = true;
+
+        foreach ($declarations as [$class, $method]) {
+            $parameter = $method->getParameters()[$position] ?? null;
+
+            if ($parameter === null) {
+                $requiredEverywhere = false;
+
+                continue;
+            }
+
+            foreach (explode('|', (string) $parameter->getType()) as $type) {
+                $types[ltrim($type, '?')] = true;
+            }
+
+            if ($parameter->allowsNull()) {
+                $types['null'] = true;
+            }
+
+            $byReference[$parameter->isPassedByReference() ? 'by-reference' : 'by-value'][] = $class;
+            $requiredEverywhere = $requiredEverywhere && !$parameter->isOptional();
+        }
+
+        if (count($byReference) > 1) {
+            throw new SignatureConflict(sprintf(
+                'Method %s() parameter #%d is %s',
+                $name,
+                $position + 1,
+                implode(' but ', array_map(
+                    static fn (string $mode, array $classes): string => $mode . ' in ' . implode('+', $classes),
+                    array_keys($byReference),
+                    $byReference,
+                )),
+            ));
+        }
+
+        $reference = array_key_first($byReference) === 'by-reference' ? '&' : '';
+        $types['ArgumentMatcher'] = true;
+
+        $parameters[] = sprintf(
+            '%s %s$p%d%s',
+            implode('|', array_keys($types)),
+            $reference,
+            $position,
+            $requiredEverywhere ? '' : ' = null',
+        );
+    }
+
+    return implode(', ', $parameters);
 }
+
+$signatures = unifyTargets([WriterA::class, WriterB::class]);
+assertSame(
+    $signatures['write'],
+    'int|string|ArgumentMatcher $p0',
+    'contravariant parameters unify into a union instead of being rejected',
+);
+
+// The unified declaration must really satisfy both interfaces.
+eval(sprintf(
+    'namespace Understudy\Spikes\DnfMultiTarget; final class UnifiedDouble implements WriterA, WriterB { public function write(%s): void { Runtime::dispatch($this, __FUNCTION__, [$p0]); } }',
+    $signatures['write'],
+));
+
+$unified = new UnifiedDouble();
+assertTrue(
+    $unified instanceof WriterA && $unified instanceof WriterB,
+    'the unified declaration satisfies BOTH `write(int)` and `write(string)`',
+);
+
+$unified->write(1);
+$unified->write('one');
+assertSame(Runtime::$log[array_key_last(Runtime::$log)][1], ['one'], 'unified multi-target dispatch works for either branch');
+
+assertSame(
+    unifyTargets([ArityA::class, ArityB::class])['emit'],
+    'int|ArgumentMatcher $p0, int|ArgumentMatcher $p1 = null',
+    'a parameter absent from one target becomes optional',
+);
+
+assertSame(
+    unifyTargets([WriterA::class, WriterC::class])['write'],
+    'int|ArgumentMatcher $p0',
+    'identical declarations unify to themselves',
+);
 
 $conflict = expectThrows(
-    static fn () => assertCompatibleTargets([WriterA::class, WriterB::class]),
+    static fn () => unifyTargets([ReaderInt::class, ReaderString::class]),
     SignatureConflict::class,
-    'conflicting `write(int)` vs `write(string)` is detected before eval',
+    'irreconcilable return types are rejected before eval (covariance leaves no common subtype)',
 );
 assertTrue(
-    str_contains($conflict->getMessage(), 'WriterA') && str_contains($conflict->getMessage(), 'WriterB'),
+    str_contains($conflict->getMessage(), 'ReaderInt') && str_contains($conflict->getMessage(), 'ReaderString'),
     'the error names both conflicting targets',
 );
 
-assertCompatibleTargets([WriterA::class, WriterC::class]);
-assertTrue(true, 'identical declarations across targets are compatible');
-
-$multiCode = <<<'PHP'
-namespace Understudy\Spikes\DnfMultiTarget;
-
-final class MultiDouble implements WriterA, WriterC
-{
-    public function write(int|ArgumentMatcher $chunk): void
-    {
-        Runtime::dispatch($this, __FUNCTION__, [$chunk]);
-    }
-}
-PHP;
-
-eval($multiCode);
-
-$multi = new MultiDouble();
-assertTrue($multi instanceof WriterA && $multi instanceof WriterC, 'compatible multi-target double implements both interfaces');
-
-$multi->write(1);
-assertSame(Runtime::$log[array_key_last(Runtime::$log)][1], [1], 'multi-target dispatch works');
+$conflict = expectThrows(
+    static fn () => unifyTargets([FeederByRef::class, FeederByValue::class]),
+    SignatureConflict::class,
+    'by-reference mismatch across targets is rejected before eval',
+);
+assertTrue(
+    str_contains($conflict->getMessage(), 'by-reference') && str_contains($conflict->getMessage(), 'by-value'),
+    'the error explains which mode each target declares',
+);

--- a/spikes/04-dnf-multitarget/spike.php
+++ b/spikes/04-dnf-multitarget/spike.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * Spike 04 — DNF parameter widening and multi-target conflict detection.
+ *
+ * Promises under test (plan §4.2, §5.1):
+ * - an intersection parameter `A&B` widens to `(A&B)|ArgumentMatcher` and
+ *   the eval'd double compiles and runs on PHP 8.3+;
+ * - an object implementing both interfaces passes, a matcher passes, an
+ *   object implementing only one interface is rejected natively;
+ * - multi-target doubles (`for(A::class, B::class)`) with conflicting
+ *   method signatures are DETECTED via Reflection before eval, with both
+ *   signatures reported; compatible targets generate fine.
+ */
+
+declare(strict_types=1);
+
+namespace Understudy\Spikes\DnfMultiTarget;
+
+use function Understudy\Spikes\assertSame;
+use function Understudy\Spikes\assertTrue;
+use function Understudy\Spikes\expectThrows;
+
+require __DIR__ . '/../lib.php';
+
+final class ArgumentMatcher
+{
+}
+
+interface Countable2
+{
+    public function count(): int;
+}
+
+interface Named
+{
+    public function name(): string;
+}
+
+interface Consumer
+{
+    public function consume(Countable2&Named $target): string;
+}
+
+final class Runtime
+{
+    /** @var list<array{string, array<mixed>}> */
+    public static array $log = [];
+
+    public static function dispatch(object $double, string $method, array $args): string
+    {
+        self::$log[] = [$method, $args];
+
+        return $method;
+    }
+}
+
+// --- DNF widening ---------------------------------------------------------
+
+$code = <<<'PHP'
+namespace Understudy\Spikes\DnfMultiTarget;
+
+final class ConsumerDouble implements Consumer
+{
+    public function consume((Countable2&Named)|ArgumentMatcher $target): string
+    {
+        return Runtime::dispatch($this, __FUNCTION__, [$target]);
+    }
+}
+PHP;
+
+eval($code);
+
+echo "04-dnf-multitarget\n";
+
+$double = new ConsumerDouble();
+assertTrue($double instanceof Consumer, 'eval\'d double with `(A&B)|ArgumentMatcher` satisfies the interface');
+
+$both = new class implements Countable2, Named {
+    public function count(): int
+    {
+        return 0;
+    }
+
+    public function name(): string
+    {
+        return 'x';
+    }
+};
+
+$double->consume($both);
+assertTrue(Runtime::$log[0][1][0] === $both, 'object implementing both interfaces passes the DNF branch');
+
+$double->consume(new ArgumentMatcher());
+assertTrue(Runtime::$log[1][1][0] instanceof ArgumentMatcher, 'matcher passes the union branch');
+
+$onlyNamed = new class implements Named {
+    public function name(): string
+    {
+        return 'y';
+    }
+};
+
+expectThrows(
+    static fn (): string => $double->consume($onlyNamed),
+    \TypeError::class,
+    'object implementing only one interface is rejected natively',
+);
+
+// --- Multi-target conflict detection ---------------------------------------
+
+interface WriterA
+{
+    public function write(int $chunk): void;
+}
+
+interface WriterB
+{
+    public function write(string $chunk): void;
+}
+
+interface WriterC
+{
+    public function write(int $chunk): void;
+}
+
+final class SignatureConflict extends \LogicException
+{
+}
+
+/**
+ * Minimal stand-in for the codegen pre-check: renders each declaration and
+ * requires one target's method to be compatible with every other declaration
+ * of the same name. The real implementation compares structured signatures;
+ * for the spike a rendered normal form is enough to prove detectability.
+ *
+ * @param list<class-string> $targets
+ */
+function assertCompatibleTargets(array $targets): void
+{
+    /** @var array<string, array{class-string, string}> $seen */
+    $seen = [];
+
+    foreach ($targets as $target) {
+        $reflection = new \ReflectionClass($target);
+
+        foreach ($reflection->getMethods() as $method) {
+            $signature = render($method);
+
+            if (isset($seen[$method->getName()]) && $seen[$method->getName()][1] !== $signature) {
+                throw new SignatureConflict(sprintf(
+                    'Method %s() is declared incompatibly: %s::%s vs %s::%s',
+                    $method->getName(),
+                    $seen[$method->getName()][0],
+                    $seen[$method->getName()][1],
+                    $target,
+                    $signature,
+                ));
+            }
+
+            $seen[$method->getName()] = [$target, $signature];
+        }
+    }
+}
+
+function render(\ReflectionMethod $method): string
+{
+    $params = array_map(
+        static fn (\ReflectionParameter $p): string => (string) $p->getType() . ($p->isVariadic() ? '...' : '') . ($p->isPassedByReference() ? '&' : ''),
+        $method->getParameters(),
+    );
+
+    return sprintf('(%s): %s', implode(', ', $params), (string) $method->getReturnType());
+}
+
+$conflict = expectThrows(
+    static fn () => assertCompatibleTargets([WriterA::class, WriterB::class]),
+    SignatureConflict::class,
+    'conflicting `write(int)` vs `write(string)` is detected before eval',
+);
+assertTrue(
+    str_contains($conflict->getMessage(), 'WriterA') && str_contains($conflict->getMessage(), 'WriterB'),
+    'the error names both conflicting targets',
+);
+
+assertCompatibleTargets([WriterA::class, WriterC::class]);
+assertTrue(true, 'identical declarations across targets are compatible');
+
+$multiCode = <<<'PHP'
+namespace Understudy\Spikes\DnfMultiTarget;
+
+final class MultiDouble implements WriterA, WriterC
+{
+    public function write(int|ArgumentMatcher $chunk): void
+    {
+        Runtime::dispatch($this, __FUNCTION__, [$chunk]);
+    }
+}
+PHP;
+
+eval($multiCode);
+
+$multi = new MultiDouble();
+assertTrue($multi instanceof WriterA && $multi instanceof WriterC, 'compatible multi-target double implements both interfaces');
+
+$multi->write(1);
+assertSame(Runtime::$log[array_key_last(Runtime::$log)][1], [1], 'multi-target dispatch works');

--- a/spikes/05-fiber-contexts/spike.php
+++ b/spikes/05-fiber-contexts/spike.php
@@ -72,6 +72,17 @@ final class Runtime
         return (self::$owners ?? new \WeakMap())[$double] ?? self::current();
     }
 
+    /**
+     * @return array{fibers: int, owners: int}
+     */
+    public static function indexSizes(): array
+    {
+        return [
+            'fibers' => count(self::$fibers ?? []),
+            'owners' => count(self::$owners ?? []),
+        ];
+    }
+
     public static function dispatch(object $double, string $method, array $args): mixed
     {
         $owner = self::ownerOf($double);
@@ -166,3 +177,31 @@ assertTrue($mainContext->recording === false, 'main context never saw a recordin
 
 $mainDouble->send('after');
 assertSame(count($mainContext->log), 2, 'main-owned double keeps logging into the main context');
+
+// Both indexes must be genuinely WEAK: with strong references every assertion
+// above would still pass while leaking one Context per fiber and one entry
+// per double for the lifetime of the process.
+$before = Runtime::indexSizes();
+
+$temporary = new \Fiber(static function (): void {
+    $double = makeDouble();
+    $double->send('temporary');
+
+    // Suspend while still holding the double, so both are observably alive.
+    \Fiber::suspend();
+});
+$temporary->start();
+
+$during = Runtime::indexSizes();
+assertSame($during['fibers'], $before['fibers'] + 1, 'a live fiber holds exactly one context');
+assertSame($during['owners'], $before['owners'] + 1, 'its double holds exactly one owner entry');
+
+$temporary->resume();
+unset($temporary);
+gc_collect_cycles();
+
+assertSame(
+    Runtime::indexSizes(),
+    $before,
+    'both indexes release the fiber context and the owner entry once collected',
+);

--- a/spikes/05-fiber-contexts/spike.php
+++ b/spikes/05-fiber-contexts/spike.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Spike 05 — Fiber-isolated runtime contexts with a weak owner index.
+ *
+ * Promises under test (plan §4.2, §5.2):
+ * - the main flow and every Fiber get their own RuntimeContext via
+ *   `WeakMap<Fiber, Context>`; sibling fibers never share the recording
+ *   flag or the call log;
+ * - a suspend/resume cycle keeps a fiber's context intact, including a
+ *   recording phase that spans the suspension;
+ * - a weak owner index (`WeakMap<double, Context>`) routes a normal call
+ *   made INSIDE a child fiber to the owner's log instead of the fiber's.
+ */
+
+declare(strict_types=1);
+
+namespace Understudy\Spikes\FiberContexts;
+
+use function Understudy\Spikes\assertSame;
+use function Understudy\Spikes\assertTrue;
+
+require __DIR__ . '/../lib.php';
+
+final class Context
+{
+    public bool $recording = false;
+
+    /** @var list<array{string, array<mixed>}> */
+    public array $log = [];
+}
+
+final class Signal extends \Exception
+{
+    public function __construct(public readonly string $method)
+    {
+        parent::__construct('sentinel');
+    }
+}
+
+final class Runtime
+{
+    private static ?Context $main = null;
+
+    /** @var \WeakMap<\Fiber, Context>|null */
+    private static ?\WeakMap $fibers = null;
+
+    /** @var \WeakMap<object, Context>|null */
+    private static ?\WeakMap $owners = null;
+
+    public static function current(): Context
+    {
+        $fiber = \Fiber::getCurrent();
+
+        if ($fiber === null) {
+            return self::$main ??= new Context();
+        }
+
+        self::$fibers ??= new \WeakMap();
+
+        return self::$fibers[$fiber] ??= new Context();
+    }
+
+    public static function adopt(object $double): void
+    {
+        self::$owners ??= new \WeakMap();
+        self::$owners[$double] = self::current();
+    }
+
+    public static function ownerOf(object $double): Context
+    {
+        return (self::$owners ?? new \WeakMap())[$double] ?? self::current();
+    }
+
+    public static function dispatch(object $double, string $method, array $args): mixed
+    {
+        $owner = self::ownerOf($double);
+
+        if ($owner->recording) {
+            throw new Signal($method);
+        }
+
+        $owner->log[] = [$method, $args];
+
+        return null;
+    }
+}
+
+interface Port
+{
+    public function send(string $payload): mixed;
+}
+
+final class PortDouble implements Port
+{
+    public function send(string $payload): mixed
+    {
+        return Runtime::dispatch($this, __FUNCTION__, [$payload]);
+    }
+}
+
+function makeDouble(): PortDouble
+{
+    $double = new PortDouble();
+    Runtime::adopt($double);
+
+    return $double;
+}
+
+echo "05-fiber-contexts\n";
+
+$mainDouble = makeDouble();
+$mainContext = Runtime::current();
+
+// Fiber A starts a recording phase, then suspends in the middle of it.
+$fiberA = new \Fiber(static function () use (&$stateA): void {
+    $context = Runtime::current();
+    $context->recording = true;
+
+    \Fiber::suspend('recording-started');
+
+    $own = makeDouble();
+
+    try {
+        $own->send('captured');
+        $stateA = 'no-signal';
+    } catch (Signal $signal) {
+        $stateA = 'signal:' . $signal->method;
+    }
+
+    $context->recording = false;
+});
+
+// Fiber B runs normal-phase work while A is suspended mid-recording.
+$fiberB = new \Fiber(static function (PortDouble $foreign) use (&$stateB): array {
+    $context = Runtime::current();
+    $stateB = $context->recording;
+
+    $own = makeDouble();
+    $own->send('local');
+
+    // A double owned by the MAIN context, invoked inside this fiber:
+    $foreign->send('routed');
+
+    return $context->log;
+});
+
+assertSame($fiberA->start(), 'recording-started', 'fiber A suspended inside its recording phase');
+
+$fiberB->start($mainDouble);
+$logB = $fiberB->getReturn();
+
+assertSame($stateB, false, "fiber B's context does not inherit fiber A's recording flag");
+assertSame($logB, [['send', ['local']]], "fiber B's log holds only its own double's call");
+assertSame(
+    $mainContext->log,
+    [['send', ['routed']]],
+    'a call made inside fiber B on a main-owned double lands in the OWNER log',
+);
+
+$fiberA->resume();
+assertSame($stateA, 'signal:send', "fiber A's recording phase survived suspend/resume and captured the sentinel");
+
+assertSame(Runtime::current(), $mainContext, 'main context is stable across fiber lifecycles');
+assertTrue($mainContext->recording === false, 'main context never saw a recording flag');
+
+$mainDouble->send('after');
+assertSame(count($mainContext->log), 2, 'main-owned double keeps logging into the main context');

--- a/spikes/06-bypass-finals/fixture/relative.php
+++ b/spikes/06-bypass-finals/fixture/relative.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return 'relative-include-ok';

--- a/spikes/06-bypass-finals/fixture/services.php
+++ b/spikes/06-bypass-finals/fixture/services.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Understudy\Spikes\BypassFinals\Fixture;
+
+final class FinalService
+{
+    public static function reportedFile(): string
+    {
+        return __FILE__;
+    }
+
+    public static function reportedDir(): string
+    {
+        return __DIR__;
+    }
+
+    public static function relativeIncludeValue(): string
+    {
+        return require __DIR__ . '/relative.php';
+    }
+
+    final public function seal(): string
+    {
+        return 'sealed';
+    }
+}
+
+final class FinalSibling
+{
+}

--- a/spikes/06-bypass-finals/fixture/shouting.php
+++ b/spikes/06-bypass-finals/fixture/shouting.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+// `final` is a case-insensitive keyword. This fixture keeps the pre-filter
+// honest: with a case-sensitive check the strip below silently does nothing.
+
+namespace Understudy\Spikes\BypassFinals\Fixture;
+
+FINAL class ShoutingFinalService
+{
+}
+
+Final class TitleCaseFinalService
+{
+}

--- a/spikes/06-bypass-finals/spike.php
+++ b/spikes/06-bypass-finals/spike.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * Spike 06 — token-aware `file://` stream wrapper stripping class-level final.
+ *
+ * Promises under test (plan §5.3.1):
+ * - a stream wrapper installed BEFORE the target is first loaded removes the
+ *   `final` token from the allow-listed class declaration only;
+ * - sibling classes in the same file keep their `final`;
+ * - final METHODS are never touched;
+ * - `__FILE__`, `__DIR__` and relative includes inside the transformed file
+ *   keep pointing at the original path (no temp-copy);
+ * - after the strip the class is extendable (eval'd subclass);
+ * - an already-loaded class cannot be bypassed — detectable via class_exists.
+ */
+
+declare(strict_types=1);
+
+namespace Understudy\Spikes\BypassFinals;
+
+use function Understudy\Spikes\assertSame;
+use function Understudy\Spikes\assertTrue;
+
+require __DIR__ . '/../lib.php';
+
+final class FinalStripWrapper
+{
+    /** @var resource|null */
+    public $context;
+
+    /** @var resource|null */
+    private $handle;
+
+    /** @var list<array{namespace: string, class: string}> */
+    private static array $targets = [];
+
+    private static bool $registered = false;
+
+    public static function allow(string $fqcn): void
+    {
+        $pos = strrpos($fqcn, '\\');
+        self::$targets[] = [
+            'namespace' => $pos === false ? '' : substr($fqcn, 0, $pos),
+            'class' => $pos === false ? $fqcn : substr($fqcn, $pos + 1),
+        ];
+
+        if (!self::$registered) {
+            stream_wrapper_unregister('file');
+            stream_wrapper_register('file', self::class);
+            self::$registered = true;
+        }
+    }
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        stream_wrapper_restore('file');
+
+        try {
+            if (!str_contains($mode, 'r') || str_contains($mode, '+') || !is_file($path)) {
+                $this->handle = @fopen($path, $mode, (bool) ($options & STREAM_USE_PATH), $this->context);
+            } else {
+                $source = file_get_contents($path);
+                $transformed = self::transform($source);
+                $this->handle = fopen('php://memory', 'r+b');
+                fwrite($this->handle, $transformed);
+                rewind($this->handle);
+            }
+        } finally {
+            stream_wrapper_unregister('file');
+            stream_wrapper_register('file', self::class);
+        }
+
+        return $this->handle !== false;
+    }
+
+    private static function transform(string $source): string
+    {
+        if (!str_contains($source, 'final')) {
+            return $source;
+        }
+
+        $tokens = token_get_all($source);
+        $namespace = '';
+        $output = '';
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (is_array($token) && $token[0] === T_NAMESPACE) {
+                $namespace = '';
+                for ($j = $i + 1; $j < $count; $j++) {
+                    $next = $tokens[$j];
+                    if (is_array($next) && in_array($next[0], [T_STRING, T_NAME_QUALIFIED], true)) {
+                        $namespace = $next[1];
+                        break;
+                    }
+                    if ($next === ';' || $next === '{') {
+                        break;
+                    }
+                }
+            }
+
+            if (is_array($token) && $token[0] === T_FINAL && self::finalBelongsToTargetClass($tokens, $i, $namespace)) {
+                continue; // drop the `final` token (following whitespace collapses harmlessly)
+            }
+
+            $output .= is_array($token) ? $token[1] : $token;
+        }
+
+        return $output;
+    }
+
+    /**
+     * `final` is dropped only when the next significant tokens form
+     * `[readonly] class <AllowListedName>` in the allow-listed namespace.
+     *
+     * @param list<array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private static function finalBelongsToTargetClass(array $tokens, int $index, string $namespace): bool
+    {
+        $count = count($tokens);
+        $sawClass = false;
+
+        for ($i = $index + 1; $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT, T_READONLY], true)) {
+                continue;
+            }
+
+            if (!$sawClass) {
+                if (is_array($token) && $token[0] === T_CLASS) {
+                    $sawClass = true;
+                    continue;
+                }
+
+                return false; // `final function`, `final const`, …
+            }
+
+            if (is_array($token) && $token[0] === T_STRING) {
+                foreach (self::$targets as $target) {
+                    if ($target['class'] === $token[1] && $target['namespace'] === $namespace) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    public function stream_read(int $length): string|false
+    {
+        return fread($this->handle, $length);
+    }
+
+    public function stream_eof(): bool
+    {
+        return feof($this->handle);
+    }
+
+    public function stream_close(): void
+    {
+        fclose($this->handle);
+    }
+
+    public function stream_stat(): array|false
+    {
+        return fstat($this->handle);
+    }
+
+    /**
+     * @return array<mixed>|false
+     */
+    public function url_stat(string $path, int $flags): array|false
+    {
+        stream_wrapper_restore('file');
+
+        try {
+            return ($flags & STREAM_URL_STAT_QUIET) ? @stat($path) : @stat($path);
+        } finally {
+            stream_wrapper_unregister('file');
+            stream_wrapper_register('file', self::class);
+        }
+    }
+
+    public function stream_set_option(int $option, int $arg1, int $arg2): bool
+    {
+        return false;
+    }
+}
+
+echo "06-bypass-finals\n";
+
+assertTrue(
+    !class_exists('Understudy\Spikes\BypassFinals\Fixture\FinalService', false),
+    'target class is not loaded yet — bypass is possible',
+);
+
+FinalStripWrapper::allow('Understudy\Spikes\BypassFinals\Fixture\FinalService');
+
+require __DIR__ . '/fixture/services.php';
+
+$service = new \ReflectionClass(\Understudy\Spikes\BypassFinals\Fixture\FinalService::class);
+assertTrue(!$service->isFinal(), 'allow-listed class lost its `final`');
+
+$sibling = new \ReflectionClass(\Understudy\Spikes\BypassFinals\Fixture\FinalSibling::class);
+assertTrue($sibling->isFinal(), 'sibling class in the same file keeps its `final`');
+
+assertTrue(
+    $service->getMethod('seal')->isFinal(),
+    'final METHOD on the stripped class is untouched',
+);
+
+assertSame(
+    \Understudy\Spikes\BypassFinals\Fixture\FinalService::reportedFile(),
+    realpath(__DIR__ . '/fixture/services.php'),
+    '__FILE__ inside the transformed file is the original path (no temp-copy)',
+);
+
+assertSame(
+    \Understudy\Spikes\BypassFinals\Fixture\FinalService::reportedDir(),
+    realpath(__DIR__ . '/fixture'),
+    '__DIR__ is the original directory',
+);
+
+assertSame(
+    \Understudy\Spikes\BypassFinals\Fixture\FinalService::relativeIncludeValue(),
+    'relative-include-ok',
+    'a relative include from inside the transformed file resolves',
+);
+
+eval('namespace Understudy\Spikes\BypassFinals; final class ServiceDouble extends \Understudy\Spikes\BypassFinals\Fixture\FinalService {}');
+assertTrue(
+    is_subclass_of(ServiceDouble::class, \Understudy\Spikes\BypassFinals\Fixture\FinalService::class),
+    'the stripped class is now extendable by the codegen',
+);
+
+assertTrue(
+    class_exists(\Understudy\Spikes\BypassFinals\Fixture\FinalSibling::class, false),
+    'already-loaded sibling stays loaded — a later bypass attempt on it is detectable via class_exists',
+);

--- a/spikes/06-bypass-finals/spike.php
+++ b/spikes/06-bypass-finals/spike.php
@@ -75,7 +75,9 @@ final class FinalStripWrapper
 
     private static function transform(string $source): string
     {
-        if (!str_contains($source, 'final')) {
+        // `final` is a case-insensitive keyword: the pre-filter must match
+        // the tokenizer, which already handles `Final`/`FINAL`.
+        if (stripos($source, 'final') === false) {
             return $source;
         }
 
@@ -242,4 +244,20 @@ assertTrue(
 assertTrue(
     class_exists(\Understudy\Spikes\BypassFinals\Fixture\FinalSibling::class, false),
     'already-loaded sibling stays loaded — a later bypass attempt on it is detectable via class_exists',
+);
+
+// Case-insensitive keyword: `FINAL class` and `Final class` must strip too,
+// while a non-allow-listed neighbour in the same file keeps its modifier.
+FinalStripWrapper::allow('Understudy\Spikes\BypassFinals\Fixture\ShoutingFinalService');
+
+require __DIR__ . '/fixture/shouting.php';
+
+assertTrue(
+    !(new \ReflectionClass(\Understudy\Spikes\BypassFinals\Fixture\ShoutingFinalService::class))->isFinal(),
+    '`FINAL class` (upper case keyword) is stripped as well',
+);
+
+assertTrue(
+    (new \ReflectionClass(\Understudy\Spikes\BypassFinals\Fixture\TitleCaseFinalService::class))->isFinal(),
+    '`Final class` neighbour outside the allow-list keeps its modifier',
 );

--- a/spikes/07-psalm-builder/composer.json
+++ b/spikes/07-psalm-builder/composer.json
@@ -1,5 +1,5 @@
 {
-    "description": "Spike 07: Psalm FunctionReturnTypeProvider can build WhenBuilder<TReturn> from the closure body",
+    "description": "Spike 07: Psalm FunctionReturnTypeProvider can build WhenBuilder<TReturn> from the closure body. Psalm is pinned to the 6.16 line so this feasibility record stays reproducible and an unrelated 6.x release cannot redden other milestones' PRs; the real understudy-psalm package will carry ^6.16 plus its own prefer-lowest job.",
     "autoload": {
         "psr-4": {
             "UnderstudySpike\\Psalm\\": "src/"
@@ -9,6 +9,6 @@
         ]
     },
     "require-dev": {
-        "vimeo/psalm": "^6.16"
+        "vimeo/psalm": "~6.16.0"
     }
 }

--- a/spikes/07-psalm-builder/composer.json
+++ b/spikes/07-psalm-builder/composer.json
@@ -1,0 +1,14 @@
+{
+    "description": "Spike 07: Psalm FunctionReturnTypeProvider can build WhenBuilder<TReturn> from the closure body",
+    "autoload": {
+        "psr-4": {
+            "UnderstudySpike\\Psalm\\": "src/"
+        },
+        "files": [
+            "src/functions.php"
+        ]
+    },
+    "require-dev": {
+        "vimeo/psalm": "^6.16"
+    }
+}

--- a/spikes/07-psalm-builder/fixtures/negative.php
+++ b/spikes/07-psalm-builder/fixtures/negative.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UnderstudySpike\Psalm\Fixtures;
+
+use UnderstudySpike\Psalm\BookRepository;
+
+use function UnderstudySpike\Psalm\when;
+
+function brokenScenario(BookRepository $repo): void
+{
+    when(fn () => $repo->find(1))->returns('oops');
+}

--- a/spikes/07-psalm-builder/fixtures/positive.php
+++ b/spikes/07-psalm-builder/fixtures/positive.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UnderstudySpike\Psalm\Fixtures;
+
+use UnderstudySpike\Psalm\Book;
+use UnderstudySpike\Psalm\BookRepository;
+
+use function UnderstudySpike\Psalm\when;
+
+function scenario(BookRepository $repo): void
+{
+    $builder = when(fn () => $repo->find(1));
+    /** @psalm-check-type-exact $builder = \UnderstudySpike\Psalm\WhenBuilder<Book|null> */
+
+    when(fn () => $repo->find(2))->returns(new Book());
+    when(fn () => $repo->find(3))->returns(null);
+    when(static function () use ($repo): ?Book {
+        return $repo->find(4);
+    })->returns(new Book());
+}

--- a/spikes/07-psalm-builder/psalm.xml
+++ b/spikes/07-psalm-builder/psalm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="4"
+    resolveFromConfigFile="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="fixtures"/>
+    </projectFiles>
+    <plugins>
+        <pluginClass class="UnderstudySpike\Psalm\Plugin"/>
+    </plugins>
+</psalm>

--- a/spikes/07-psalm-builder/run.sh
+++ b/spikes/07-psalm-builder/run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Spike 07: proves a Psalm FunctionReturnTypeProvider can derive
+# WhenBuilder<TReturn> from the closure body via public plugin hooks.
+#
+# Expected: fixtures/positive.php analyzes clean (including an exact
+# check-type on the inferred generic), fixtures/negative.php reports
+# exactly one InvalidArgument on the returns('oops') call.
+set -u
+
+cd "$(dirname "$0")"
+
+if [ ! -d vendor ]; then
+    composer install --no-interaction --quiet || exit 1
+fi
+
+status=0
+
+echo "07-psalm-builder"
+
+positive=$(vendor/bin/psalm --no-cache --output-format=json -- fixtures/positive.php 2>/dev/null)
+if [ "$(printf '%s' "$positive" | php -r 'echo count(json_decode(stream_get_contents(STDIN), true));')" = "0" ]; then
+    echo "  ok: positive fixture is clean; exact generic WhenBuilder<Book|null> confirmed"
+else
+    echo "  FAIL: positive fixture reported issues:"
+    printf '%s\n' "$positive"
+    status=1
+fi
+
+negative=$(vendor/bin/psalm --no-cache --output-format=json -- fixtures/negative.php 2>/dev/null)
+summary=$(printf '%s' "$negative" | php -r '
+    $issues = json_decode(stream_get_contents(STDIN), true);
+    $lines = [];
+    foreach ($issues as $issue) {
+        $lines[] = $issue["type"] . ":" . basename($issue["file_name"]);
+    }
+    echo implode(",", $lines);
+')
+if [ "$summary" = "InvalidArgument:negative.php" ]; then
+    echo "  ok: negative fixture reports exactly one InvalidArgument for returns('oops')"
+else
+    echo "  FAIL: negative fixture summary: ${summary:-<empty>}"
+    printf '%s\n' "$negative"
+    status=1
+fi
+
+if [ $status -eq 0 ]; then
+    echo "PASS 07-psalm-builder"
+else
+    echo "FAIL 07-psalm-builder"
+fi
+
+exit $status

--- a/spikes/07-psalm-builder/src/Book.php
+++ b/spikes/07-psalm-builder/src/Book.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UnderstudySpike\Psalm;
+
+final class Book
+{
+}

--- a/spikes/07-psalm-builder/src/BookRepository.php
+++ b/spikes/07-psalm-builder/src/BookRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UnderstudySpike\Psalm;
+
+interface BookRepository
+{
+    public function find(int $id): ?Book;
+}

--- a/spikes/07-psalm-builder/src/Plugin.php
+++ b/spikes/07-psalm-builder/src/Plugin.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UnderstudySpike\Psalm;
+
+use Psalm\Plugin\PluginEntryPointInterface;
+use Psalm\Plugin\RegistrationInterface;
+use SimpleXMLElement;
+
+final class Plugin implements PluginEntryPointInterface
+{
+    public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null): void
+    {
+        require_once __DIR__ . '/WhenReturnTypeProvider.php';
+
+        $registration->registerHooksFromClass(WhenReturnTypeProvider::class);
+    }
+}

--- a/spikes/07-psalm-builder/src/WhenBuilder.php
+++ b/spikes/07-psalm-builder/src/WhenBuilder.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UnderstudySpike\Psalm;
+
+/**
+ * @template T
+ */
+final class WhenBuilder
+{
+    /**
+     * @param T $value
+     */
+    public function returns(mixed $value): static
+    {
+        return $this;
+    }
+}

--- a/spikes/07-psalm-builder/src/WhenReturnTypeProvider.php
+++ b/spikes/07-psalm-builder/src/WhenReturnTypeProvider.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UnderstudySpike\Psalm;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt\Return_;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Union;
+
+final class WhenReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return list<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return ['understudyspike\psalm\when'];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Union
+    {
+        $args = $event->getCallArgs();
+
+        if (!isset($args[0])) {
+            return null;
+        }
+
+        $inner = self::innerMethodCall($args[0]->value);
+
+        if ($inner === null) {
+            return null;
+        }
+
+        $innerType = $event->getStatementsSource()->getNodeTypeProvider()->getType($inner);
+
+        if ($innerType === null) {
+            return null;
+        }
+
+        return new Union([new TGenericObject(WhenBuilder::class, [$innerType])]);
+    }
+
+    /**
+     * The specification closure must contain exactly one direct method call:
+     * `fn () => $double->method(...)` or `function () { return $double->method(...); }`.
+     */
+    private static function innerMethodCall(Expr $callArg): ?MethodCall
+    {
+        if ($callArg instanceof ArrowFunction && $callArg->expr instanceof MethodCall) {
+            return $callArg->expr;
+        }
+
+        if ($callArg instanceof Closure
+            && count($callArg->stmts) === 1
+            && $callArg->stmts[0] instanceof Return_
+            && $callArg->stmts[0]->expr instanceof MethodCall
+        ) {
+            return $callArg->stmts[0]->expr;
+        }
+
+        return null;
+    }
+}

--- a/spikes/07-psalm-builder/src/functions.php
+++ b/spikes/07-psalm-builder/src/functions.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UnderstudySpike\Psalm;
+
+/**
+ * Runtime fallback signature; the plugin narrows the return type to
+ * WhenBuilder<TReturn> of the single method call inside the closure.
+ *
+ * @return WhenBuilder<mixed>
+ */
+function when(callable $call): WhenBuilder
+{
+    return new WhenBuilder();
+}

--- a/spikes/lib.php
+++ b/spikes/lib.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Understudy\Spikes;
+
+function ok(string $message): void
+{
+    echo "  ok: {$message}\n";
+}
+
+function fail(string $message): never
+{
+    fwrite(STDERR, "  FAIL: {$message}\n");
+    exit(1);
+}
+
+function assertSame(mixed $actual, mixed $expected, string $label): void
+{
+    if ($actual !== $expected) {
+        fail($label . ' — expected ' . var_export($expected, true) . ', got ' . var_export($actual, true));
+    }
+
+    ok($label);
+}
+
+function assertTrue(bool $condition, string $label): void
+{
+    $condition ? ok($label) : fail($label);
+}
+
+/**
+ * @param class-string<\Throwable> $exceptionClass
+ */
+function expectThrows(callable $callback, string $exceptionClass, string $label): \Throwable
+{
+    try {
+        $callback();
+    } catch (\Throwable $e) {
+        if (!$e instanceof $exceptionClass) {
+            fail($label . ' — expected ' . $exceptionClass . ', got ' . $e::class . ': ' . $e->getMessage());
+        }
+
+        ok($label);
+
+        return $e;
+    }
+
+    fail($label . ' — nothing thrown');
+}

--- a/spikes/run.sh
+++ b/spikes/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Runs feasibility spikes 01-06 with the PHP binary on PATH.
+# Spike 07 (Psalm plugin) has its own runner: spikes/07-psalm-builder/run.sh.
+set -u
+
+cd "$(dirname "$0")"
+
+php -v | head -1
+
+status=0
+for spike in 01-sentinel 02-matcher-union 03-byref-return 04-dnf-multitarget 05-fiber-contexts 06-bypass-finals; do
+    if php "$spike/spike.php"; then
+        echo "PASS $spike"
+    else
+        echo "FAIL $spike"
+        status=1
+    fi
+done
+
+exit $status


### PR DESCRIPTION
## What

Executable feasibility fixtures for the mechanics the understudy design relies on (plan milestone 0, pre-scaffold — no release API). Each spike is a standalone script that exits non-zero on the first broken promise.

| Spike | Proves |
|---|---|
| 01-sentinel | sentinel exception escapes any native return type (incl. `never`); recording captures method + args |
| 02-matcher-union | contravariant `T\|ArgumentMatcher` widening compiles/runs via eval; scalar coercion follows the calling file's `strict_types`; variadic + by-ref params accept matchers |
| 03-byref-return | by-reference return dispatched through a runtime with a stable external slot |
| 04-dnf-multitarget | `(A&B)\|ArgumentMatcher` DNF params work; conflicting multi-target signatures detected via Reflection before eval |
| 05-fiber-contexts | per-Fiber contexts don't leak between sibling fibers; weak owner index routes child-fiber calls to the owner log |
| 06-bypass-finals | token-aware `file://` wrapper strips `final` from the allow-listed class only; `__FILE__`/`__DIR__`/relative includes preserved; final methods and sibling classes untouched |
| 07-psalm-builder | Psalm `FunctionReturnTypeProviderInterface` derives `WhenBuilder<TReturn>` from the closure body: exact generic confirmed, `returns('oops')` flagged as `InvalidArgument` |

## Verification

- Spikes 01-06 green locally in `php:8.3-cli`, `php:8.4-cli`, `php:8.5-cli` containers.
- Spike 07 green via `composer:2` (Psalm 6.16).
- CI (this PR): 01-06 on PHP 8.3/8.4/8.5, 07 on PHP 8.4.
- `zizmor --persona=auditor`: no findings (SHA-pinned actions, `contents: read`, `persist-credentials: false`).

## Exit criteria of milestone 0

Executable fixtures green on PHP 8.3/8.4/8.5. Package scaffolding (composer.json, build gate, full template set) is milestone 1 and intentionally not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added seven executable feasibility spikes covering PHP dispatch, type handling, references, fibers, final classes, and static analysis.
  - Added shared assertion utilities and dedicated runners for validating spike behavior.

- **Tests**
  - Added automated GitHub Actions coverage for spikes across PHP 8.3–8.5.
  - Added positive and negative static-analysis scenarios to verify inferred return types and diagnostics.

- **Developer Experience**
  - Added configuration and fixtures for running the static-analysis spike independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->