### PR TITLE
Milestone 1: package scaffold and the core engine

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.github export-ignore
+/.php-cs-fixer.php export-ignore
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/examples export-ignore
+/infection.json5 export-ignore
+/psalm.xml export-ignore
+/rector.php export-ignore
+/testo.php export-ignore
+/tests export-ignore
+/benchmarks export-ignore
+/build export-ignore
+/Makefile export-ignore

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something doesn't work the way the docs say it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **Everything you paste here is public.** Before submitting, redact
+        credentials, API keys, tokens, signing secrets, connection strings and
+        personal data from error messages, stack traces, reproduction code and
+        configuration snippets — replace them with a placeholder such as
+        `<REDACTED>`.
+
+  - type: input
+    id: package-version
+    attributes:
+      label: Package version
+      description: The exact version (or commit) you installed, e.g. `2.1.0` or `dev-master@abc1234`
+      placeholder: "2.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP version
+      placeholder: "8.3.12"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      description: Full error message / stack trace if there is one, with secrets redacted
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: >
+        A short script or code snippet that reproduces the problem from a
+        clean install. Issues without a reproduction are much harder to act
+        on and may be closed if one can't be worked out together.
+      render: php
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: Relevant config (with secrets redacted), related packages and their versions, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Something you need this package to do that it doesn't yet
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do
+      description: >
+        Describe the task, not the API you imagine solving it. The concrete
+        problem is what makes a good design possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Why the current API doesn't cover it
+      description: What you tried, and where it fell short or forced a workaround.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API (optional)
+      description: A sketch of the method/class signature you'd expect, if you have one.
+      render: php
+    validations:
+      required: false
+
+  - type: dropdown
+    id: pr
+    attributes:
+      label: Would you be willing to open a PR for this?
+      options:
+        - "Yes"
+        - "No"
+        - "Maybe, with some guidance"
+    validations:
+      required: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,274 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Relevant changes
+    runs-on: ubuntu-latest
+
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+      mutation: ${{ steps.filter.outputs.mutation }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE="$BASE_SHA"
+          elif [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            # First push to a new branch: there is no base to diff against, so
+            # every filter says yes. Both outputs must be set here — an unset
+            # one reads as false downstream and silently skips its job.
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "mutation=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          else
+            BASE="$BEFORE_SHA"
+          fi
+
+          if git diff --quiet "$BASE" "$GITHUB_SHA" -- \
+            src tests config examples composer.json testo.php psalm.xml \
+            rector.php .php-cs-fixer.php infection.json5 \
+            .github/workflows/build.yml; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Mutation is by far the most expensive job, so it gets a narrower
+          # filter than the rest: only what can change which mutants exist or
+          # which tests kill them. Style and static-analysis configs, examples
+          # and this workflow cannot. Explicit trade: editing the mutation STEP
+          # here no longer re-runs it — a break surfaces on the next source
+          # change or a manual re-run, which beats paying the full mutation run
+          # on every docs and CI edit.
+          if git diff --quiet "$BASE" "$GITHUB_SHA" -- \
+            src tests composer.json testo.php infection.json5; then
+            echo "mutation=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "mutation=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Not gated on 'changes' like the other jobs below: when a matrix job's own
+  # `if` is false, GitHub Actions skips it as ONE unit and posts a single
+  # check run named literally "PHP ${{ matrix.php }}" (the unexpanded
+  # template), never the per-version names ("PHP 8.3" etc.) that branch
+  # protection requires. Those required checks then sit in Pending forever
+  # and the PR is permanently unmergeable. Non-matrix jobs don't have this
+  # problem, so they stay gated.
+  build:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '8.3'
+          - '8.4'
+          - '8.5'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: json, mbstring
+          tools: composer:v2
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Build
+        run: composer build
+
+  prefer-lowest:
+    name: Prefer lowest
+    needs: changes
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.run == 'true') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          extensions: json, mbstring
+          tools: composer:v2
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: composer update --prefer-lowest --prefer-stable --no-interaction --no-progress
+
+      - name: Build
+        run: composer build
+
+  coverage:
+    name: Coverage & Mutation
+    needs: changes
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.mutation == 'true') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.4'
+          coverage: pcov
+          extensions: json, mbstring
+          tools: composer:v2
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Test with coverage
+        run: composer test:coverage:ci
+
+      - name: Mutation testing
+        run: composer mutation
+
+  compatibility:
+    name: Backward compatibility
+    needs: changes
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.run == 'true') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          extensions: json, mbstring, bcmath, intl
+          tools: composer:v2
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Backward compatibility check
+        # Real breaks pass only across an intentional compatibility boundary:
+        # a higher major after 1.0, or a higher minor while the package is
+        # still below 1.0. The top version heading in CHANGELOG.md declares
+        # that boundary; patch releases stay gated on a clean report.
+        #
+        # A report made up ENTIRELY of "[BC] SKIPPED: ..." lines is also a
+        # pass: SKIPPED means roave/better-reflection could not statically
+        # parse a construct (observed for enum-case and `new Expr()` default
+        # values in promoted constructor properties) - it is not a detected
+        # break. Once a class contains this pattern, EVERY future run reports
+        # the identical SKIPPED finding against ANY --from tag, including a
+        # diff against itself, so gating on it would permanently block every
+        # subsequent PR regardless of content. A single genuine
+        # "[BC] CHANGED:"/"[BC] REMOVED:"/"[BC] ADDED:" line anywhere in the
+        # report still fails the build.
+        run: |
+          LATEST="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -z "$LATEST" ]; then
+            echo "No previous tag - skipping BC check"
+            exit 0
+          fi
+          CODE=0
+          OUTPUT="$(composer bc-check -- --from="$LATEST" --install-development-dependencies 2>&1)" || CODE=$?
+          printf '%s\n' "$OUTPUT"
+          if [ "$CODE" -eq 0 ]; then
+            exit 0
+          fi
+          NEXT="$(grep -m1 -oE '## [0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+          LATEST_VERSION="${LATEST#v}"
+          LATEST_MAJOR="${LATEST_VERSION%%.*}"
+          LATEST_MINOR="${LATEST_VERSION#*.}"; LATEST_MINOR="${LATEST_MINOR%%.*}"
+          NEXT_MAJOR="${NEXT%%.*}"
+          NEXT_MINOR="${NEXT#*.}"; NEXT_MINOR="${NEXT_MINOR%%.*}"
+          # Only code 3 means "breaks detected". Anything else is roave itself
+          # failing (128 when it cannot clone or resolve the old tag), and a
+          # crash must never be waved through by a CHANGELOG heading or a
+          # SKIPPED-only report.
+          if [ "$CODE" -eq 3 ] && [ -n "$NEXT_MAJOR" ] && {
+            [ "$NEXT_MAJOR" -gt "$LATEST_MAJOR" ] ||
+            { [ "$LATEST_MAJOR" -eq 0 ] && [ "$NEXT_MAJOR" -eq 0 ] && [ "$NEXT_MINOR" -gt "$LATEST_MINOR" ]; }
+          }; then
+            echo "CHANGELOG declares $NEXT - an intentional compatibility boundary over $LATEST; BC breaks are expected, treating as pass."
+            exit 0
+          fi
+          if [ "$CODE" -eq 3 ]; then
+            TOTAL="$(printf '%s\n' "$OUTPUT" | { grep -cE '^\[BC\] ' || true; })"
+            SKIPPED="$(printf '%s\n' "$OUTPUT" | { grep -cE '^\[BC\] SKIPPED:' || true; })"
+            if [ "$TOTAL" -gt 0 ] && [ "$TOTAL" -eq "$SKIPPED" ]; then
+              echo "All $TOTAL finding(s) are roave/better-reflection SKIPPED entries (a static-analysis limitation, not a detected break); treating as pass."
+              exit 0
+            fi
+          fi
+          exit "$CODE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+# A pushed tag is the release. Without this job the repository sidebar reads
+# "no releases" forever: Packagist works off tags, but GitHub only shows what
+# a Release object declares, and writing those by hand never happens.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create the GitHub release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Extract the changelog section for this tag
+        env:
+          TAG: ${{ github.ref_name }}
+          NOTES_FILE: ${{ runner.temp }}/release-notes.md
+        run: |
+          version="${TAG#v}"
+          # Matched as text, never as a pattern: a tag is user input, and one
+          # carrying `.` or `*` would otherwise pick up a different section.
+          # The heading is compared with its optional Keep-a-Changelog brackets
+          # stripped, and the version must be followed by nothing, a space or a
+          # `]` — so `1.0.0` never matches the `1.0.0-rc1` section above it.
+          # The section runs to the next heading; a tag with no section still
+          # releases, with a pointer to the changelog.
+          notes=$(awk -v v="$version" '
+            substr($0, 1, 3) == "## " {
+              if (found) { exit }
+              h = substr($0, 4)
+              sub(/^\[/, "", h)
+              sep = substr(h, length(v) + 1, 1)
+              if (substr(h, 1, length(v)) == v && (sep == "" || sep == " " || sep == "]")) {
+                found = 1
+              }
+              next
+            }
+            found { print }
+          ' CHANGELOG.md)
+          if [ -z "$(printf '%s' "$notes" | tr -d '[:space:]')" ]; then
+            notes="See [CHANGELOG.md](CHANGELOG.md)."
+          fi
+          # Through a file rather than GITHUB_OUTPUT: a multiline output needs a
+          # delimiter, and any fixed one the notes happen to contain on a line
+          # of its own truncates the release body at that point.
+          printf '%s\n' "$notes" > "$NOTES_FILE"
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          NOTES_FILE: ${{ runner.temp }}/release-notes.md
+        run: |
+          # Idempotent: a re-run of the workflow must not fail on an existing
+          # release, and a release is never re-created (Packagist blocks
+          # re-tagged versions forever).
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists"
+            exit 0
+          fi
+          # --verify-tag, because without it gh creates the missing tag itself
+          # from the default branch — a release pointing at a commit that is not
+          # the one the tag was pushed for.
+          gh release create "$TAG" --verify-tag --title "$TAG" --notes-file "$NOTES_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,35 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      # Packagist publishes on the tag itself, so by the time this job runs the
+      # package is already out — blocking the GitHub Release cannot unpublish
+      # it, and re-running the whole test suite here would only look like a
+      # gate. What is still worth enforcing is the release rule the process
+      # actually depends on: the tag names a commit that reached master through
+      # a pull request, with its build green.
+      - name: Verify the tag points at validated master history
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          if ! git merge-base --is-ancestor "$SHA" origin/master; then
+            echo "::error::$TAG points at $SHA, which is not an ancestor of master." \
+              "Tag a commit that was merged through a pull request."
+            exit 1
+          fi
+
+          conclusion=$(gh api "repos/$REPO/commits/$SHA/check-runs" \
+            --jq '[.check_runs[] | select(.name | startswith("PHP "))] | if length == 0 then "missing" else (map(.conclusion) | unique | join(",")) end')
+
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::$SHA has no successful build (matrix conclusion: $conclusion)." \
+              "A release must not be published for a commit whose CI did not pass."
+            exit 1
+          fi
 
       - name: Extract the changelog section for this tag
         env:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,87 @@
+name: static analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Relevant changes
+    runs-on: ubuntu-latest
+
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE="$BASE_SHA"
+          elif [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          else
+            BASE="$BEFORE_SHA"
+          fi
+
+          if git diff --quiet "$BASE" "$GITHUB_SHA" -- \
+            src tests config examples composer.json testo.php psalm.xml \
+            rector.php .php-cs-fixer.php infection.json5 \
+            .github/workflows/static-analysis.yml; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  psalm:
+    name: Psalm
+    needs: changes
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.run == 'true') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          extensions: json, mbstring
+          tools: composer:v2
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Psalm
+        run: composer psalm

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: GitHub Actions security
+
+on:
+  pull_request:
+    paths: &paths
+      - '.github/**/*.yml'
+      - '.github/**/*.yaml'
+  push:
+    branches:
+      - master
+    paths: *paths
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Audit GitHub Actions
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          annotations: true
+          online-audits: false
+          persona: auditor
+          version: 1.25.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+vendor/
+composer.lock
+.php-cs-fixer.cache
+/build/*
+!/build/.gitkeep
+
 /spikes/07-psalm-builder/vendor/
 /spikes/07-psalm-builder/composer.lock

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = (new Finder())
+    ->in([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+        __DIR__ . '/examples',
+    ]);
+
+return (new Config())
+    ->setUsingCache(false)
+    ->setRules([
+        '@PER-CS3.0' => true,
+        '@PHP83Migration' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']],
+        'no_unused_imports' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
+        'blank_line_before_statement' => ['statements' => ['return', 'throw', 'try']],
+    ])
+    ->setFinder($finder);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md — understudy
+
+Guidance for AI agents working on this package. Read before changing code.
+
+## What this is
+
+`rasuvaeff/understudy` is a test double library for PHP 8.3+ whose defining
+trait is that a configured call is a **real call**: `when(fn () =>
+$repo->find(123))->returns($book)`. There are no method-name strings and no
+service methods on the double itself.
+
+Public API lives in `Rasuvaeff\Understudy`: the `Understudy` facade, the free
+functions `when()`/`verify()` in `src/functions.php`, `Arg`, `Invocation`,
+`Outcome`, `WhenBuilder`, and the exceptions under `Exception\`. Everything
+under `Codegen\`, `Runtime\`, `Expectation\`, `Defaults\` and `Matcher\` is
+`@internal`.
+
+The design and its milestones live in the monorepo at
+`_plans/UNDERSTUDY-PLAN.md`. `spikes/` holds the executable feasibility
+fixtures the design rests on — they are not tests of this package's API, and
+they must keep passing on PHP 8.3/8.4/8.5.
+
+## Golden rules
+
+1. **Verification is mandatory.** Never claim "done" without a fresh green
+   `composer build`. "Should work" does not count.
+2. **No suppressions.** No `@psalm-suppress`, no baseline. Fix the root cause.
+3. **A double exposes nothing beyond its contract.** Every member added to a
+   generated class is a name the doubled interface can no longer use. New
+   operations go on the `Understudy` facade or into a free function — never
+   onto the double. This is the reason the library exists; a change that
+   breaks it is not a trade-off, it is a different library.
+4. **Preserve the public contract.** Update README + tests with any API change.
+
+## Commands
+
+No PHP/Composer on the host — run in Docker via the `composer:2` image.
+
+```bash
+docker run --rm -v "$PWD":/app -w /app composer:2 composer build
+docker run --rm -v "$PWD":/app -w /app composer:2 composer cs:fix
+docker run --rm -v "$PWD":/app -w /app composer:2 composer psalm
+docker run --rm -v "$PWD":/app -w /app composer:2 composer test
+docker run --rm -v "$PWD":/app -w /app composer:2 composer release-check
+```
+
+Or with Make:
+
+```bash
+make build
+make cs-fix
+make psalm
+make test
+make test-coverage
+make mutation
+make release-check
+```
+
+`make test-coverage` and `make mutation` bootstrap `pcov` inside the
+`composer:2` container because the base image has no coverage driver.
+
+## Invariants & gotchas
+
+- **State is keyed by the double object, never by `spl_object_id()`.** PHP
+  reuses an object id after collection, so an id-keyed store would hand a
+  fresh double the previous one's state. `Runtime` uses `WeakMap`s and
+  `RuntimeContext` uses `SplObjectStorage`.
+- **Recording is a depth counter, not a boolean.** A nested recording phase
+  must not switch the enclosing one off when it unwinds.
+- **Multi-target methods are unified, not compared.** Parameters are
+  contravariant, so `write(int)` and `write(string)` share the implementation
+  `write(int|string)`; refusing them on signature difference would reject a
+  doublable pair. Only genuinely unsatisfiable combinations are conflicts:
+  divergent return types (covariant) and by-reference mismatches.
+- **Generated methods collect arguments by name, never `func_get_args()`**,
+  which omits parameters left at their default — `tag('alpha')` and
+  `tag('alpha', 1)` must record as the same call.
+- **`= null` on a non-nullable parameter is a deprecated implicit nullable.**
+  When a parameter becomes optional through unification, `null` joins the type.
+- **Mutation numbers lie unless every class has its own `#[Covers]` test.**
+  Infection's mutant-to-test mapping is `#[Covers]`-driven: with one test class
+  covering one class, the run reported 56 mutants at 93% MSI while the honest
+  figures were 406 and 68%. Check the mutant count, not just the MSI.
+- **Rector and Psalm pull in opposite directions here.** `RemoveUselessVarTag`
+  and `FlipTypeControlToUseExclusiveType` are skipped in `rector.php` with the
+  reasons written down; do not add skips beyond those without the same.
+- Code: `declare(strict_types=1)`, `final readonly class` where nothing
+  mutates, `#[\Override]`, explicit types, named arguments.
+- `examples/` is part of the public contract: keep scripts runnable and update
+  `examples/README.md` when example usage changes.
+- **CI workflows are SHA-pinned.** Every `uses:` in `.github/workflows/*.yml`
+  references a 40-char commit SHA with a `# vN` trailing comment. Never revert
+  to floating `@vN` tags. Updates go through Dependabot. Workflows carry
+  `permissions: { contents: read }` and `persist-credentials: false` on every
+  checkout. Verify with `zizmor --persona=auditor .github/`.
+
+## When you finish
+
+- Update `README.md` **and `README.ru.md`** (both languages, same commit; and
+  `examples/` if usage changed); update `CHANGELOG.md` when releasing.
+- Re-run `composer build`; if the change affects public API or release safety,
+  also run `make release-check`. Paste the output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Unreleased
+
+- Initial engine: interface doubles generated from Reflection, the sentinel
+  recording mechanism behind the call-closure API, `when()` with
+  `returns()`/`throws()`/`answers()`, `verify()` with count bounds,
+  `Understudy::calls()`, `unused()`, `label()`, loose and strict modes,
+  type-safe loose defaults, recorded call outcomes, and failure messages that
+  mark the argument that differed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2026, Victor Razuvaev
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,92 @@
+DOCKER := docker run --rm -v "$(PWD)":/app -w /app composer:2
+DOCKER_HOST := docker run --rm --network host -v "$(PWD)":/app -w /app
+PCOV_BOOTSTRAP := apk add --no-cache $$PHPIZE_DEPS >/dev/null && pecl install pcov >/dev/null && docker-php-ext-enable pcov
+
+.PHONY: bench build cs cs-fix psalm test mutation rector rector-fix install normalize require-checker \
+       test-coverage test-coverage-ci update-deps release-check bc-check audit-package help
+
+install:
+	$(DOCKER) composer install --no-interaction --no-progress --prefer-dist
+
+bench:
+	$(DOCKER) composer bench
+
+build:
+	$(DOCKER) composer build
+
+cs:
+	$(DOCKER) composer cs
+
+cs-fix:
+	$(DOCKER) composer cs:fix
+
+psalm:
+	$(DOCKER) composer psalm
+
+test:
+	$(DOCKER) composer test
+
+test-coverage:
+	$(DOCKER) sh -lc '$(PCOV_BOOTSTRAP) && composer test:coverage'
+
+test-coverage-ci:
+	$(DOCKER) sh -lc '$(PCOV_BOOTSTRAP) && composer test:coverage:ci'
+
+mutation:
+	$(DOCKER) sh -lc '$(PCOV_BOOTSTRAP) && composer mutation'
+
+rector:
+	$(DOCKER) composer rector
+
+rector-fix:
+	$(DOCKER) composer rector:fix
+
+normalize:
+	$(DOCKER) sh -c 'git config --global --add safe.directory /app; composer normalize'
+
+require-checker:
+	$(DOCKER) composer require-checker
+
+update-deps:
+	$(DOCKER) sh -c 'git config --global --add safe.directory /app; composer update -q; composer normalize'
+
+# composer's release-check chain ends in bc-check, which shells out to git —
+# without safe.directory the container's git refuses the bind-mounted repo
+# ("dubious ownership") and the whole target dies with exit 128
+release-check:
+	$(DOCKER) sh -c 'git config --global --add safe.directory "*"; composer release-check'
+	$(MAKE) mutation
+
+bc-check:
+	$(DOCKER) sh -c 'git config --global --add safe.directory "*"; \
+	  LATEST=$$(git describe --tags --abbrev=0 2>/dev/null || true); \
+	  if [ -n "$$LATEST" ]; then \
+	    composer bc-check -- --from=$$LATEST; \
+	  else \
+	    echo "No previous tag - skipping BC check"; \
+	  fi'
+
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Targets:"
+	@echo "  install          composer install"
+	@echo "  bench            run benchmarks (Benchmarks suite)"
+	@echo "  build            full gate (validate + normalize + cs + psalm + test)"
+	@echo "  cs               check code style (dry-run)"
+	@echo "  cs-fix           fix code style"
+	@echo "  psalm            static analysis"
+	@echo "  test             run testo (Unit suite)"
+	@echo "  test-coverage    run testo with coverage"
+	@echo "  test-coverage-ci run testo coverage for CI artifacts"
+	@echo "  mutation         mutation testing"
+	@echo "  rector           check rector (dry-run)"
+	@echo "  rector-fix       apply rector fixes"
+	@echo "  normalize        normalize composer.json"
+	@echo "  require-checker  check composer dependencies"
+	@echo "  update-deps      composer update + normalize"
+	@echo "  bc-check         check backward compatibility against latest tag"
+	@echo "  release-check    build + rector + bc-check + mutation"
+
+audit-package:
+	@if [ -f ../bin/package-audit ]; then bash ../bin/package-audit "$(CURDIR)"; else echo "package-audit: available only inside the monorepo"; fi

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ update-deps:
 # without safe.directory the container's git refuses the bind-mounted repo
 # ("dubious ownership") and the whole target dies with exit 128
 release-check:
-	$(DOCKER) sh -c 'git config --global --add safe.directory "*"; composer release-check'
+	$(DOCKER) sh -c 'git config --global --add safe.directory /app; composer release-check'
 	$(MAKE) mutation
 
 bc-check:
-	$(DOCKER) sh -c 'git config --global --add safe.directory "*"; \
+	$(DOCKER) sh -c 'git config --global --add safe.directory /app; \
 	  LATEST=$$(git describe --tags --abbrev=0 2>/dev/null || true); \
 	  if [ -n "$$LATEST" ]; then \
 	    composer bc-check -- --from=$$LATEST; \

--- a/README.md
+++ b/README.md
@@ -1,51 +1,184 @@
 # rasuvaeff/understudy
 
-> **Work in progress — pre-release.** No stable API yet. The package will be
-> published to Packagist with `v0.1.0`; until then everything here may change
-> without notice.
+> **Pre-release.** The API is not stable until `v0.1.0`. See
+> [CHANGELOG.md](CHANGELOG.md) for what has landed so far.
 
-Test double library for PHP 8.3+ with a call-closure API:
+Test double library for PHP where the call you configure is a **real call**:
 
 ```php
-when(fn () => $repo->find(123))->returns($book);
+when(fn () => $repository->find(123))->returns($book);
 ```
 
-- **Call-closure API** — method and arguments are specified by a real call
-  inside a closure, not by a string. Refactoring and IDE navigation work
-  out of the box; a typo in a method name is impossible by construction.
-- **Zero reserved methods** — a double carries no service methods
-  (`expects`/`allows`/…); configuration lives in free functions.
-- **Framework-agnostic core** — thin `-testo` / `-phpunit` adapters and a
-  separate `-psalm` plugin follow, mirroring the
-  [`rasuvaeff/property-testing-*`](https://packagist.org/packages/rasuvaeff/property-testing-core)
-  split family.
+No method-name strings, so refactoring and IDE navigation work without a
+plugin, and a typo in a method name cannot happen. No service methods on the
+double either — every one of them would be a name the doubled contract can no
+longer use.
 
-## Current state: milestone 0 — feasibility spikes
+> Using an AI coding assistant? [llms.txt](llms.txt) is a compact API reference
+> written for it.
 
-`spikes/` contains executable feasibility fixtures for the mechanics the
-design relies on. Each spike is a standalone script that exits non-zero on
-the first broken promise. CI runs them on PHP 8.3, 8.4 and 8.5.
+## Why another one
 
-| Spike | Proves |
-|---|---|
-| `01-sentinel` | a sentinel exception escapes any native return type, including `never`; recording captures method + args |
-| `02-matcher-union` | contravariant `T\|ArgumentMatcher` parameter widening compiles and runs; scalar coercion follows the calling file's `strict_types`; variadic and by-reference parameters accept matchers |
-| `03-byref-return` | by-reference returns can be dispatched through a runtime with a stable external slot |
-| `04-dnf-multitarget` | `(A&B)\|ArgumentMatcher` DNF parameters work; conflicting multi-target signatures are detected via Reflection before `eval` |
-| `05-fiber-contexts` | per-Fiber runtime contexts don't leak between sibling fibers; a double owned by the main context records calls made inside a child fiber into the owner log |
-| `06-bypass-finals` | a token-aware `file://` stream wrapper strips `final` from an allow-listed class only, preserving `__FILE__`, `__DIR__`, relative includes and sibling classes |
-| `07-psalm-builder` | a Psalm `FunctionReturnTypeProviderInterface` hook can derive `WhenBuilder<TReturn>` from the closure body and flag a `returns()` type mismatch |
+| | Understudy | Mockery / PHPUnit / double |
+|---|---|---|
+| Specifying a call | a real call in a closure | a method-name string |
+| Members added to the double | none | `shouldReceive`, `expects`, `allows`, … |
+| Test runner | any (thin adapters) | tied to PHPUnit/Pest, or none |
+| Fibers | one context per fiber | shared static state |
 
-Run locally (no PHP on the host required):
+The call-closure form comes from [MockK](https://mockk.io) (Kotlin),
+[FakeItEasy](https://fakeiteasy.github.io) and [moq](https://github.com/moq/moq)
+(C#), and [mocktail](https://pub.dev/packages/mocktail) (Dart). No PHP library
+had it.
+
+## Requirements
+
+- PHP 8.3 – 8.5
+- `ext-mbstring`
+
+No runtime dependencies beyond that.
+
+## Installation
 
 ```bash
-docker run --rm -v "$PWD":/app -w /app php:8.3-cli bash spikes/run.sh
-docker run --rm -v "$PWD":/app -w /app php:8.4-cli bash spikes/run.sh
-docker run --rm -v "$PWD":/app -w /app php:8.5-cli bash spikes/run.sh
-# Psalm spike:
-docker run --rm -v "$PWD":/app -w /app composer:2 bash spikes/07-psalm-builder/run.sh
+composer require --dev rasuvaeff/understudy
 ```
+
+## Usage
+
+### Creating a double
+
+```php
+use Rasuvaeff\Understudy\Understudy;
+
+$repository = Understudy::for(BookRepository::class);
+```
+
+`for()` returns the contract's own type, so your IDE and static analyser treat
+`$repository` as a `BookRepository`. Several interfaces can be combined:
+
+```php
+$double = Understudy::for(BookRepository::class, Countable::class);
+```
+
+Interfaces are supported today; class targets and `bypassFinals()` are being
+built next.
+
+### Stubbing
+
+```php
+use function Rasuvaeff\Understudy\when;
+
+when(fn () => $repository->find(123))->returns($book);
+when(fn () => $repository->find(404))->throws(new NotFound());
+when(fn () => $repository->find(Arg::any()))->answers(
+    fn (Invocation $call) => new Book(title: (string) $call->args[0]),
+);
+
+// One value per call, then the last one repeats.
+when(fn () => $repository->mode())->returns('fast', 'slow');
+```
+
+A later stub for the same call wins; earlier ones stay reachable as fallbacks,
+so a broad `Arg::any()` stub can sit underneath a specific one.
+
+### Verifying
+
+```php
+use function Rasuvaeff\Understudy\verify;
+
+verify(fn () => $repository->save($book));                 // at least once
+verify(fn () => $repository->save($book), times: 2);       // exactly twice
+verify(fn () => $repository->save($book), minimum: 2);     // no upper bound
+verify(fn () => $repository->ping(), never: true);
+
+Understudy::unused($repository);                           // nothing at all
+```
+
+Every double records every call, so verification never has to be set up in
+advance.
+
+### Reading the call log
+
+```php
+$calls = Understudy::calls(fn () => $repository->find(Arg::any()));
+
+$calls[0]->args;          // [123]
+$calls[0]->didReturn();   // true
+$calls[0]->returned();    // the value it answered with
+$calls[1]->thrown();      // the throwable, if it threw
+```
+
+`null` is a valid return value, which is why the outcome is asked about
+(`didReturn()`) rather than inferred from the value.
+
+### Modes
+
+| Mode | Unmatched call answers with |
+|---|---|
+| Loose (default) | a type-safe default: `null`, `0`, `''`, `[]`, an empty generator … |
+| Strict (`Understudy::strict($double)`) | an immediate failure naming the method |
+
+A loose double never invents a value by running someone else's constructor and
+never hands back an object whose constructor was skipped. Where no safe value
+exists it says so, and names the way out.
+
+### Failure messages
+
+```
+Understudy `BookRepository` expected `tag('alpha', 2)` to be called exactly 1 time,
+but it was never called.
+
+The following calls to `tag` were made during this test:
+    tag(*'beta'*, 2)
+```
+
+The asterisks mark the argument that differed — borrowed from
+[NSubstitute](https://nsubstitute.github.io). `Understudy::label($double, '…')`
+names a double when several of the same contract are in play.
+
+### Cleaning up
+
+```php
+Understudy::reset();
+```
+
+Adapters for Testo and PHPUnit will call this for you; until they exist, call
+it in your own teardown.
+
+## Security
+
+Understudy generates a class per set of contracts and evaluates it once per
+process. It never loads code from user input, never touches the filesystem, and
+holds all state in `WeakMap`s keyed by the double object — never by
+`spl_object_id()`, which PHP reuses after collection.
+
+It is a development dependency. Do not install it in production.
+
+## Examples
+
+Runnable scripts live in [examples/](examples/).
+
+## Development
+
+```bash
+make build          # validate, normalize, require-checker, cs, psalm, test
+make cs-fix
+make psalm
+make test
+make mutation       # infection, gate at 85% MSI
+make release-check
+```
+
+Or through Docker directly:
+
+```bash
+docker run --rm -v "$PWD":/app -w /app composer:2 composer build
+```
+
+`spikes/` holds the feasibility fixtures the design rests on; `bash
+spikes/run.sh` runs them under any PHP 8.3+ binary.
 
 ## License
 
-BSD-3-Clause.
+BSD-3-Clause. See [LICENSE.md](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ built next.
 ### Stubbing
 
 ```php
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Invocation;
+
 use function Rasuvaeff\Understudy\when;
 
 when(fn () => $repository->find(123))->returns($book);
@@ -101,6 +104,8 @@ advance.
 ### Reading the call log
 
 ```php
+use Rasuvaeff\Understudy\Arg;
+
 $calls = Understudy::calls(fn () => $repository->find(Arg::any()));
 
 $calls[0]->args;          // [123]
@@ -125,7 +130,7 @@ exists it says so, and names the way out.
 
 ### Failure messages
 
-```
+```text
 Understudy `BookRepository` expected `tag('alpha', 2)` to be called exactly 1 time,
 but it was never called.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -68,6 +68,9 @@ $double = Understudy::for(BookRepository::class, Countable::class);
 ### Стабы
 
 ```php
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Invocation;
+
 use function Rasuvaeff\Understudy\when;
 
 when(fn () => $repository->find(123))->returns($book);
@@ -101,6 +104,8 @@ Understudy::unused($repository);                           // вообще ни 
 ### Чтение лога вызовов
 
 ```php
+use Rasuvaeff\Understudy\Arg;
+
 $calls = Understudy::calls(fn () => $repository->find(Arg::any()));
 
 $calls[0]->args;          // [123]
@@ -125,7 +130,7 @@ Loose-дубль никогда не выдумывает значение, за
 
 ### Сообщения об ошибках
 
-```
+```text
 Understudy `BookRepository` expected `tag('alpha', 2)` to be called exactly 1 time,
 but it was never called.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,184 @@
+# rasuvaeff/understudy
+
+> **Пре-релиз.** API не стабилен до `v0.1.0`. Что уже готово — в
+> [CHANGELOG.md](CHANGELOG.md).
+
+Библиотека тестовых дублей для PHP, где настраиваемый вызов — **настоящий
+вызов**:
+
+```php
+when(fn () => $repository->find(123))->returns($book);
+```
+
+Никаких строк с именами методов: рефакторинг и навигация IDE работают без
+плагина, а опечатка в имени метода невозможна. На самом дубле тоже нет
+служебных методов — каждый из них отнимал бы имя у дублируемого контракта.
+
+> Пользуетесь AI-ассистентом? [llms.txt](llms.txt) — компактный справочник по
+> API, написанный для него.
+
+## Зачем ещё одна
+
+| | Understudy | Mockery / PHPUnit / double |
+|---|---|---|
+| Как задаётся вызов | настоящим вызовом в замыкании | строкой с именем метода |
+| Служебные члены на дубле | нет | `shouldReceive`, `expects`, `allows`, … |
+| Тестовый раннер | любой (тонкие адаптеры) | привязка к PHPUnit/Pest либо никакой |
+| Fibers | свой контекст на файбер | общее статическое состояние |
+
+Форма «вызов в замыкании» пришла из [MockK](https://mockk.io) (Kotlin),
+[FakeItEasy](https://fakeiteasy.github.io) и [moq](https://github.com/moq/moq)
+(C#), [mocktail](https://pub.dev/packages/mocktail) (Dart). В PHP её не было
+ни у кого.
+
+## Требования
+
+- PHP 8.3 – 8.5
+- `ext-mbstring`
+
+Больше никаких runtime-зависимостей.
+
+## Установка
+
+```bash
+composer require --dev rasuvaeff/understudy
+```
+
+## Использование
+
+### Создание дубля
+
+```php
+use Rasuvaeff\Understudy\Understudy;
+
+$repository = Understudy::for(BookRepository::class);
+```
+
+`for()` возвращает тип самого контракта, поэтому IDE и статический анализатор
+видят в `$repository` обычный `BookRepository`. Несколько интерфейсов
+объединяются:
+
+```php
+$double = Understudy::for(BookRepository::class, Countable::class);
+```
+
+Сейчас поддерживаются интерфейсы; классы-цели и `bypassFinals()` — следующий
+этап работы.
+
+### Стабы
+
+```php
+use function Rasuvaeff\Understudy\when;
+
+when(fn () => $repository->find(123))->returns($book);
+when(fn () => $repository->find(404))->throws(new NotFound());
+when(fn () => $repository->find(Arg::any()))->answers(
+    fn (Invocation $call) => new Book(title: (string) $call->args[0]),
+);
+
+// По значению на вызов, дальше повторяется последнее.
+when(fn () => $repository->mode())->returns('fast', 'slow');
+```
+
+Более поздний стаб на тот же вызов выигрывает, а ранние остаются запасными —
+поэтому широкий стаб с `Arg::any()` может лежать под точечным.
+
+### Проверки
+
+```php
+use function Rasuvaeff\Understudy\verify;
+
+verify(fn () => $repository->save($book));                 // хотя бы раз
+verify(fn () => $repository->save($book), times: 2);       // ровно дважды
+verify(fn () => $repository->save($book), minimum: 2);     // без верхней границы
+verify(fn () => $repository->ping(), never: true);
+
+Understudy::unused($repository);                           // вообще ни разу
+```
+
+Каждый дубль пишет все вызовы, поэтому проверку не нужно готовить заранее.
+
+### Чтение лога вызовов
+
+```php
+$calls = Understudy::calls(fn () => $repository->find(Arg::any()));
+
+$calls[0]->args;          // [123]
+$calls[0]->didReturn();   // true
+$calls[0]->returned();    // чем ответил
+$calls[1]->thrown();      // исключение, если бросил
+```
+
+`null` — полноценное возвращаемое значение, поэтому об исходе спрашивают
+(`didReturn()`), а не выводят его из самого значения.
+
+### Режимы
+
+| Режим | Чем отвечает несовпавший вызов |
+|---|---|
+| Loose (по умолчанию) | типобезопасным значением: `null`, `0`, `''`, `[]`, пустой генератор … |
+| Strict (`Understudy::strict($double)`) | немедленной ошибкой с именем метода |
+
+Loose-дубль никогда не выдумывает значение, запуская чужой конструктор, и
+никогда не отдаёт объект с пропущенным конструктором. Если безопасного
+значения нет — он говорит об этом и подсказывает выход.
+
+### Сообщения об ошибках
+
+```
+Understudy `BookRepository` expected `tag('alpha', 2)` to be called exactly 1 time,
+but it was never called.
+
+The following calls to `tag` were made during this test:
+    tag(*'beta'*, 2)
+```
+
+Звёздочками помечен разошедшийся аргумент — приём заимствован у
+[NSubstitute](https://nsubstitute.github.io). `Understudy::label($double, '…')`
+даёт дублю имя, когда их в тесте несколько на один контракт.
+
+### Очистка
+
+```php
+Understudy::reset();
+```
+
+Адаптеры для Testo и PHPUnit будут вызывать это сами; пока их нет — вызывайте
+в своём teardown.
+
+## Безопасность
+
+Understudy генерирует по классу на набор контрактов и вычисляет его один раз
+за процесс. Она не загружает код из пользовательского ввода, не обращается к
+файловой системе и держит всё состояние в `WeakMap` по ключу-объекту — а не по
+`spl_object_id()`, который PHP переиспользует после сборки мусора.
+
+Это dev-зависимость. В production её ставить не нужно.
+
+## Примеры
+
+Исполняемые скрипты — в [examples/](examples/).
+
+## Разработка
+
+```bash
+make build          # validate, normalize, require-checker, cs, psalm, test
+make cs-fix
+make psalm
+make test
+make mutation       # infection, гейт 85% MSI
+make release-check
+```
+
+Или напрямую через Docker:
+
+```bash
+docker run --rm -v "$PWD":/app -w /app composer:2 composer build
+```
+
+В `spikes/` лежат feasibility-фикстуры, на которых стоит дизайн; `bash
+spikes/run.sh` прогоняет их на любом PHP 8.3+.
+
+## Лицензия
+
+BSD-3-Clause. См. [LICENSE.md](LICENSE.md).

--- a/benchmarks/DispatchBench.php
+++ b/benchmarks/DispatchBench.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Benchmarks;
+
+use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
+use Rasuvaeff\Understudy\Understudy;
+use Testo\Bench;
+
+use function Rasuvaeff\Understudy\when;
+
+/**
+ * The three costs worth watching: generating a class the first time, creating
+ * another instance of an already generated one, and answering a call.
+ */
+final class DispatchBench
+{
+    #[Bench]
+    public function createDouble(): void
+    {
+        Understudy::for(BookRepository::class);
+        Understudy::reset();
+    }
+
+    #[Bench]
+    public function createDoubleWarm(): void
+    {
+        // The class already exists; this measures instantiation and bookkeeping.
+        Understudy::for(BookRepository::class);
+    }
+
+    #[Bench]
+    public function recordExpectation(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn () => $repository->count())->returns(1);
+    }
+
+    #[Bench]
+    public function dispatchStubbedCall(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        when(fn () => $repository->count())->returns(1);
+
+        $repository->count();
+    }
+
+    #[Bench]
+    public function dispatchLooseCall(): void
+    {
+        Understudy::for(BookRepository::class)->count();
+    }
+}

--- a/benchmarks/DispatchBench.php
+++ b/benchmarks/DispatchBench.php
@@ -4,52 +4,151 @@ declare(strict_types=1);
 
 namespace Rasuvaeff\Understudy\Benchmarks;
 
+use Rasuvaeff\Understudy\Tests\Fixture\Book;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
+use Rasuvaeff\Understudy\Tests\Fixture\Clock;
 use Rasuvaeff\Understudy\Understudy;
 use Testo\Bench;
 
 use function Rasuvaeff\Understudy\when;
 
 /**
- * The three costs worth watching: generating a class the first time, creating
- * another instance of an already generated one, and answering a call.
+ * Testo's benchmarks are comparative, so every scenario here is measured
+ * against the thing an understudy replaces: a fake written by hand.
+ *
+ * That baseline is the honest one. It is also the demanding one — a hand
+ * written fake does nothing but return, while an understudy matches
+ * expectations and records the call.
  */
 final class DispatchBench
 {
-    #[Bench]
-    public function createDouble(): void
+    private static ?Clock $stubbedDouble = null;
+
+    private static ?Clock $looseDouble = null;
+
+    private static ?Clock $handwritten = null;
+
+    // --- Creating -----------------------------------------------------------
+
+    /**
+     * The generated class is compiled once per process and cached, so this
+     * measures instantiation and bookkeeping, not code generation. Cold
+     * generation cannot be benchmarked in this harness: `reset()` clears
+     * expectations, and neither it nor anything else can unload a class PHP
+     * has already declared.
+     */
+    #[Bench(['handwritten fake' => [self::class, 'createHandwritten']], calls: 10_000)]
+    public static function createUnderstudy(): void
     {
         Understudy::for(BookRepository::class);
-        Understudy::reset();
     }
 
-    #[Bench]
-    public function createDoubleWarm(): void
+    public static function createHandwritten(): void
     {
-        // The class already exists; this measures instantiation and bookkeeping.
-        Understudy::for(BookRepository::class);
+        new HandwrittenRepository();
     }
 
-    #[Bench]
-    public function recordExpectation(): void
-    {
-        $repository = Understudy::for(BookRepository::class);
+    // --- Dispatching a configured call --------------------------------------
 
-        when(fn () => $repository->count())->returns(1);
+    #[Bench(['handwritten fake' => [self::class, 'callHandwritten']], calls: 10_000)]
+    public static function dispatchStubbedCall(): void
+    {
+        self::$stubbedDouble ??= self::makeStubbed();
+
+        self::$stubbedDouble->now();
     }
 
-    #[Bench]
-    public function dispatchStubbedCall(): void
+    public static function callHandwritten(): void
     {
-        $repository = Understudy::for(BookRepository::class);
-        when(fn () => $repository->count())->returns(1);
+        self::$handwritten ??= new HandwrittenClock();
 
-        $repository->count();
+        self::$handwritten->now();
     }
 
-    #[Bench]
-    public function dispatchLooseCall(): void
+    // --- Dispatching an unconfigured call -----------------------------------
+
+    /**
+     * A loose double walks its expectations, finds nothing, and falls back to
+     * the type-safe default — the path most calls in a real test suite take.
+     */
+    #[Bench(['handwritten fake' => [self::class, 'callHandwritten']], calls: 10_000)]
+    public static function dispatchLooseCall(): void
     {
-        Understudy::for(BookRepository::class)->count();
+        self::$looseDouble ??= Understudy::for(Clock::class);
+
+        self::$looseDouble->now();
+    }
+
+    private static function makeStubbed(): Clock
+    {
+        $double = Understudy::for(Clock::class);
+        when(static fn (): int => $double->now())->returns(1_700_000_000);
+
+        return $double;
+    }
+}
+
+/**
+ * @internal the baseline every scenario above is compared against
+ */
+final class HandwrittenClock implements Clock
+{
+    #[\Override]
+    public function now(): int
+    {
+        return 1_700_000_000;
+    }
+}
+
+/**
+ * @internal
+ */
+final class HandwrittenRepository implements BookRepository
+{
+    #[\Override]
+    public function find(int $id): ?Book
+    {
+        return null;
+    }
+
+    #[\Override]
+    public function save(Book $book): void
+    {
+    }
+
+    #[\Override]
+    public function titles(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public function count(): int
+    {
+        return 0;
+    }
+
+    #[\Override]
+    public function abort(string $reason): never
+    {
+        throw new \LogicException($reason);
+    }
+
+    #[\Override]
+    public function stream(): \Generator
+    {
+        yield from [];
+    }
+
+    #[\Override]
+    public function describe(): string|int
+    {
+        return '';
+    }
+
+    #[\Override]
+    public function tag(string $name, int $weight = 1): string
+    {
+        return $name;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,95 @@
+{
+    "name": "rasuvaeff/understudy",
+    "description": "Test double library for PHP with a call-closure API",
+    "license": "BSD-3-Clause",
+    "type": "library",
+    "keywords": [
+        "double",
+        "fake",
+        "mock",
+        "spy",
+        "stub",
+        "test-double",
+        "testing"
+    ],
+    "authors": [
+        {
+            "name": "Victor Razuvaev",
+            "email": "rasuvaeff@gmail.com"
+        }
+    ],
+    "homepage": "https://github.com/rasuvaeff/understudy",
+    "support": {
+        "issues": "https://github.com/rasuvaeff/understudy/issues",
+        "source": "https://github.com/rasuvaeff/understudy"
+    },
+    "require": {
+        "php": "8.3 - 8.5",
+        "ext-mbstring": "*"
+    },
+    "require-dev": {
+        "ergebnis/composer-normalize": "^2.51",
+        "friendsofphp/php-cs-fixer": "^3.95",
+        "infection/infection": "^0.33",
+        "maglnet/composer-require-checker": "^4.17",
+        "rasuvaeff/property-testing-testo": "^0.6",
+        "rasuvaeff/rector-named-literals": "^1.0",
+        "rector/rector": "^2.4",
+        "roave/backward-compatibility-check": "^8.0",
+        "testo/bridge-infection": "^0.1.6",
+        "testo/testo": "^0.10.25",
+        "vimeo/psalm": "^6.16"
+    },
+    "autoload": {
+        "psr-4": {
+            "Rasuvaeff\\Understudy\\": "src/"
+        },
+        "files": [
+            "src/functions.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Rasuvaeff\\Understudy\\Benchmarks\\": "benchmarks/",
+            "Rasuvaeff\\Understudy\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true,
+            "infection/extension-installer": true
+        },
+        "platform": {
+            "ext-bcmath": "1.0.0",
+            "ext-intl": "1.0.0"
+        },
+        "sort-packages": true
+    },
+    "scripts": {
+        "bc-check": "roave-backward-compatibility-check",
+        "bench": "testo --suite=Benchmarks -vv",
+        "build": [
+            "@composer validate --strict",
+            "@composer normalize --dry-run",
+            "@require-checker",
+            "@cs",
+            "@psalm",
+            "@test"
+        ],
+        "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
+        "cs:fix": "php-cs-fixer fix --diff --config=.php-cs-fixer.php",
+        "mutation": "infection --threads=max",
+        "psalm": "psalm --no-cache",
+        "rector": "rector process --dry-run",
+        "rector:fix": "rector process",
+        "release-check": [
+            "@build",
+            "@rector",
+            "@bc-check"
+        ],
+        "require-checker": "composer-require-checker check composer.json",
+        "test": "testo --suite=Unit",
+        "test:coverage": "testo --suite=Unit --coverage --coverage-clover=build/coverage.xml",
+        "test:coverage:ci": "testo --suite=Unit --coverage-clover=build/coverage.xml"
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# Examples
+
+Every script is runnable as-is and needs nothing but the package itself.
+
+| Script | Shows | Needs server? |
+|---|---|---|
+| [basic-usage.php](basic-usage.php) | stubbing with `when()`, argument matchers, verifying counts, reading the call log with outcomes, strict mode and labels | no |
+
+Run one with the same Docker image the build uses:
+
+```bash
+docker run --rm -v "$PWD":/app -w /app composer:2 php examples/basic-usage.php
+```
+
+Or, if you have PHP on the host:
+
+```bash
+php examples/basic-usage.php
+```

--- a/examples/basic-usage.php
+++ b/examples/basic-usage.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Stubbing, verifying and reading the call log — the whole loop, without a
+ * test runner. Run it with:
+ *
+ *   docker run --rm -v "$PWD":/app -w /app composer:2 php examples/basic-usage.php
+ */
+
+namespace Rasuvaeff\Understudy\Examples;
+
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Exception\StrictModeViolation;
+use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Invocation;
+use Rasuvaeff\Understudy\Understudy;
+
+use function Rasuvaeff\Understudy\verify;
+use function Rasuvaeff\Understudy\when;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+final readonly class Book
+{
+    public function __construct(public string $title) {}
+}
+
+interface BookRepository
+{
+    public function find(int $id): ?Book;
+
+    public function save(Book $book): void;
+
+    public function count(): int;
+}
+
+$repository = Understudy::for(BookRepository::class);
+
+// --- Stubbing ---------------------------------------------------------------
+
+// Order matters: the most recently registered stub is tried first, so the
+// broad one goes down first and the specific ones layer on top of it.
+when(fn() => $repository->find(Arg::any()))
+    ->answers(static fn(Invocation $call): Book => new Book('book #' . $call->args[0]));
+when(fn() => $repository->find(1))->returns(new Book('Dune'));
+when(fn() => $repository->find(404))->throws(new \RuntimeException('not found'));
+
+echo "find(1)     -> ", $repository->find(1)?->title, "\n";
+echo "find(7)     -> ", $repository->find(7)?->title, "  (matched by Arg::any())\n";
+
+try {
+    $repository->find(404);
+} catch (\RuntimeException $e) {
+    echo "find(404)   -> threw ", $e->getMessage(), "\n";
+}
+
+// A loose double answers anything else with a type-safe default.
+echo "count()     -> ", var_export($repository->count(), true), "  (loose default)\n";
+
+// --- Verifying --------------------------------------------------------------
+
+$book = new Book('Dune');
+$repository->save($book);
+$repository->save($book);
+
+verify(fn() => $repository->save($book), times: 2);
+echo "\nverify(save, times: 2) passed\n";
+
+try {
+    Understudy::verify(fn() => $repository->save($book), times: 5);
+} catch (VerificationFailed $e) {
+    echo "\n", $e->getMessage(), "\n";
+}
+
+// --- Reading the call log ---------------------------------------------------
+
+$calls = Understudy::calls(fn() => $repository->find(Arg::any()));
+
+echo "\nfind() was called ", count($calls), " times:\n";
+
+foreach ($calls as $call) {
+    $outcome = $call->didThrow()
+        ? 'threw ' . $call->thrown()?->getMessage()
+        : 'returned ' . ($call->returned()?->title ?? 'null');
+
+    echo '  find(', $call->args[0], ') ', $outcome, "\n";
+}
+
+// --- Strict mode ------------------------------------------------------------
+
+$strict = Understudy::for(BookRepository::class);
+Understudy::label($strict, 'strict catalogue');
+Understudy::strict($strict);
+
+try {
+    $strict->count();
+} catch (StrictModeViolation $e) {
+    echo "\n", $e->getMessage(), "\n";
+}
+
+Understudy::reset();

--- a/infection.json5
+++ b/infection.json5
@@ -1,0 +1,15 @@
+{
+    "$schema": "vendor/infection/infection/resources/schema.json",
+    "source": {
+        "directories": ["src"]
+    },
+    "logs": {
+        "text": "php://stderr",
+        "summary": "build/infection-summary.log"
+    },
+    "testFramework": "testo",
+    "minMsi": 85,
+    "mutators": {
+        "@default": true
+    }
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,7 @@
 # rasuvaeff/understudy
 
-Test double library for PHP 8.3+ with a call-closure API. Pre-release: the API
-is not stable until v0.1.0.
+Test double library for PHP 8.3 - 8.5 with a call-closure API. Pre-release:
+the API is not stable until v0.1.0.
 
 ## Install
 
@@ -9,7 +9,8 @@ is not stable until v0.1.0.
 composer require --dev rasuvaeff/understudy
 ```
 
-Namespace: `Rasuvaeff\Understudy`. Requires `ext-mbstring`. No runtime deps.
+Namespace: `Rasuvaeff\Understudy`. Requires PHP 8.3 - 8.5 and `ext-mbstring`.
+No runtime deps.
 
 ## Rules
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,125 @@
+# rasuvaeff/understudy
+
+Test double library for PHP 8.3+ with a call-closure API. Pre-release: the API
+is not stable until v0.1.0.
+
+## Install
+
+```bash
+composer require --dev rasuvaeff/understudy
+```
+
+Namespace: `Rasuvaeff\Understudy`. Requires `ext-mbstring`. No runtime deps.
+
+## Rules
+
+- A call is specified by making it inside a closure, never by a method-name
+  string: `when(fn () => $repo->find(123))`.
+- The closure must contain **exactly one** direct call on a double. Anything
+  else raises `InvalidCallSpecification`.
+- A double exposes nothing beyond its contract. All operations are static
+  methods on `Understudy`, or the free functions `when()` / `verify()`.
+- Interfaces only in this version. A class target raises `UnsupportedTarget`
+  telling you to double the interface.
+- Static methods are never intercepted; inject the dependency instead.
+- `Understudy::reset()` after each test. Nothing is process-global on purpose:
+  state lives per execution context, and each Fiber gets its own.
+
+## API
+
+### Creating
+
+```php
+use Rasuvaeff\Understudy\Understudy;
+
+$repo = Understudy::for(BookRepository::class);                  // returns BookRepository
+$both = Understudy::for(BookRepository::class, Countable::class); // several interfaces
+```
+
+`for(class-string<T> $target, class-string ...$interfaces): T`
+
+### Stubbing — `when()`
+
+`when()` returns a `WhenBuilder<TReturn>`; each of its methods returns the same
+builder, so actions can be replaced while configuring.
+
+```php
+use function Rasuvaeff\Understudy\when;
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Invocation;
+
+when(fn () => $repo->find(1))->returns($book);
+when(fn () => $repo->find(1))->returns($first, $second);   // one per call, last repeats
+when(fn () => $repo->find(1))->throws(new NotFound());
+when(fn () => $repo->find(Arg::any()))->answers(
+    fn (Invocation $call) => new Book((string) $call->args[0]),
+);
+```
+
+Matching: most recently registered wins, earlier stubs remain as fallbacks.
+Arguments match by `===`, or by matcher. `Arg::any()` is the matcher available
+today.
+
+### Verifying — `verify()`
+
+```php
+use function Rasuvaeff\Understudy\verify;
+
+verify(fn () => $repo->save($book));                  // at least once
+verify(fn () => $repo->save($book), times: 2);        // exactly
+verify(fn () => $repo->save($book), minimum: 2);      // lower bound only
+verify(fn () => $repo->save($book), maximum: 5);
+verify(fn () => $repo->ping(), never: true);
+
+Understudy::unused($repo);                            // no calls at all
+```
+
+Failure raises `VerificationFailed`, whose message names the double, the
+expectation, the actual count, and marks differing arguments with `*`.
+
+### Call log — `calls()`
+
+```php
+$calls = Understudy::calls(fn () => $repo->find(Arg::any())); // list<Invocation>
+```
+
+`Invocation`: `->method`, `->args`, `->sequence`, `->didReturn()`,
+`->didThrow()`, `->returned()`, `->thrown()`. Its outcome is held as an
+`Outcome`, built by `Outcome::returnedValue()` / `Outcome::thrownError()`.
+
+`returned()` on a call that threw raises `OutcomeUnavailable` — `null` is a
+valid return value and cannot signal "nothing".
+
+### Modes and naming
+
+```php
+Understudy::strict($repo);                   // unmatched call fails immediately
+Understudy::label($repo, 'primary cache');   // name it in failure messages
+Understudy::reset();                         // drop all state
+```
+
+Loose (default) answers with a type-safe default: `null` for `void`/`mixed`/
+nullable, `false`, `0`, `0.0`, `''`, `[]`, `new stdClass()`, an empty
+`Generator`, an `EmptyIterator`, a no-op callable. A type with no safe default
+raises `NoDefaultValue`; a `never` method raises `NeverMethodCalled`.
+
+### Exceptions
+
+All implement `Rasuvaeff\Understudy\Exception\UnderstudyError`.
+
+| Exception | Raised when |
+|---|---|
+| `InvalidCallSpecification` | the closure made no call, or threw first |
+| `UnsupportedTarget` | target missing, not an interface, or targets conflict |
+| `StrictModeViolation` | a strict double got an unconfigured call |
+| `NoDefaultValue` | loose mode has no safe value for the return type |
+| `NeverMethodCalled` | a `: never` method was called without a configured throw |
+| `OutcomeUnavailable` | `returned()` asked of a call that threw |
+| `VerificationFailed` | a verification about the tested code failed |
+
+## Not supported
+
+Static method mocking, patching at the point of use, deep stubs, duck doubles,
+sharing state across processes. Class targets, `bypassFinals()`, the full
+matcher vocabulary, `expect()`, ordering and the runner adapters are being
+built next.

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    findUnusedCode="false"
+    resolveFromConfigFile="true"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Rasuvaeff\RectorNamedLiterals\AddNameToLiteralArgumentRector;
+use Rector\Config\RectorConfig;
+use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
+use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withPhpSets(php83: true)
+    ->withPreparedSets(deadCode: true, codeQuality: true)
+    ->withRules([AddNameToLiteralArgumentRector::class])
+    ->withSkip([
+        // Mirrors rasuvaeff/bulkhead and rasuvaeff/circuit-breaker: `@var
+        // mixed` is load-bearing at an untyped boundary, and here the boundary
+        // is the whole point — a double's arguments and answers are genuinely
+        // `mixed`, so Psalm's MixedAssignment has to be answered with a type,
+        // not silenced.
+        RemoveUselessVarTagRector::class,
+        // `$x === null` reads clearer than `!$x instanceof FQCN` in guards.
+        FlipTypeControlToUseExclusiveTypeRector::class,
+        // The test suite drives generated classes through Reflection, so the
+        // dead-code rules cannot see the call sites of fixture members.
+        RemoveUnusedPrivateMethodRector::class => [__DIR__ . '/tests'],
+        RemoveEmptyClassMethodRector::class => [__DIR__ . '/tests'],
+        RemoveUnusedPublicMethodParameterRector::class => [__DIR__ . '/tests'],
+    ]);

--- a/src/Arg.php
+++ b/src/Arg.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Rasuvaeff\Understudy;
 
 use Rasuvaeff\Understudy\Matcher\AnyArgument;
-use Rasuvaeff\Understudy\Matcher\ArgumentMatcher;
 
 /**
  * Argument matchers, usable only inside a specification closure:
@@ -14,13 +13,28 @@ use Rasuvaeff\Understudy\Matcher\ArgumentMatcher;
  * when(fn () => $repository->find(Arg::any()))->returns($book);
  * ```
  *
+ * Every matcher is declared to return `mixed` rather than the internal
+ * `ArgumentMatcher` type. That is not vagueness — it is what the matcher
+ * means. A matcher stands in for a value of whatever type the parameter
+ * declares, and it is never consumed as a value: the runtime intercepts it
+ * while recording the call specification. Declaring the concrete class instead
+ * would make `find(Arg::any())` a type error in every IDE and analyser for a
+ * contract that says `find(int $id)`, on the first line of the first example
+ * anyone copies — while `mixed` is accepted everywhere and stays honest.
+ *
+ * `understudy-psalm` narrows this to the parameter's declared type, so users
+ * of the plugin get a real check rather than `mixed`.
+ *
  * @api
  */
 final class Arg
 {
     private function __construct() {}
 
-    public static function any(): ArgumentMatcher
+    /**
+     * Matches any argument, including `null`.
+     */
+    public static function any(): mixed
     {
         return new AnyArgument();
     }

--- a/src/Arg.php
+++ b/src/Arg.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy;
+
+use Rasuvaeff\Understudy\Matcher\AnyArgument;
+use Rasuvaeff\Understudy\Matcher\ArgumentMatcher;
+
+/**
+ * Argument matchers, usable only inside a specification closure:
+ *
+ * ```php
+ * when(fn () => $repository->find(Arg::any()))->returns($book);
+ * ```
+ *
+ * @api
+ */
+final class Arg
+{
+    private function __construct() {}
+
+    public static function any(): ArgumentMatcher
+    {
+        return new AnyArgument();
+    }
+}

--- a/src/Codegen/Blueprint.php
+++ b/src/Codegen/Blueprint.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Codegen;
+
+/**
+ * The compiled description of one understudy class: which contracts it stands
+ * in for, and the signature of every method it overrides.
+ *
+ * @internal
+ */
+final readonly class Blueprint
+{
+    /**
+     * @param class-string                          $generatedClass
+     * @param non-empty-list<class-string>          $contracts
+     * @param array<non-empty-string, MethodSignature> $methods
+     */
+    public function __construct(
+        public string $generatedClass,
+        public array $contracts,
+        public array $methods,
+    ) {}
+
+    /**
+     * @param non-empty-string $name
+     */
+    public function method(string $name): ?MethodSignature
+    {
+        return $this->methods[$name] ?? null;
+    }
+
+    /**
+     * The name failure messages use when no explicit label was set: the short
+     * name of the primary contract, which is what the reader recognises.
+     *
+     * @return non-empty-string
+     */
+    public function displayName(): string
+    {
+        $primary = $this->contracts[0];
+        $position = strrpos($primary, '\\');
+        $short = $position === false ? $primary : substr($primary, $position + 1);
+
+        \assert($short !== '');
+
+        return $short;
+    }
+}

--- a/src/Codegen/DoubleFactory.php
+++ b/src/Codegen/DoubleFactory.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Codegen;
+
+use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
+use Rasuvaeff\Understudy\Runtime\Runtime;
+
+/**
+ * Generates and evaluates one class per set of contracts, once per process.
+ *
+ * @internal
+ */
+final class DoubleFactory
+{
+    /** @var array<string, Blueprint> */
+    private static array $blueprints = [];
+
+    private function __construct() {}
+
+    /**
+     * @param non-empty-list<class-string> $contracts
+     */
+    public static function blueprintFor(array $contracts): Blueprint
+    {
+        $key = implode('|', $contracts);
+
+        return self::$blueprints[$key] ??= self::compile($contracts, $key);
+    }
+
+    /**
+     * @param non-empty-list<class-string> $contracts
+     */
+    private static function compile(array $contracts, string $key): Blueprint
+    {
+        $targets = array_map(self::reflect(...), $contracts);
+        $methods = TargetUnifier::unify($targets);
+        $generatedClass = 'Understudy_' . substr(hash('xxh128', $key), 0, 16);
+
+        $fqcn = __NAMESPACE__ . '\\Generated\\' . $generatedClass;
+
+        if (!class_exists($fqcn, autoload: false)) {
+            eval(self::render($generatedClass, $contracts, $methods));
+        }
+
+        // Also the proof, for both the reader and static analysis, that eval
+        // produced the class it was asked for.
+        \assert(class_exists($fqcn, autoload: false));
+
+        return new Blueprint($fqcn, $contracts, $methods);
+    }
+
+    /**
+     * @param class-string $contract
+     *
+     * @return \ReflectionClass<object>
+     */
+    private static function reflect(string $contract): \ReflectionClass
+    {
+        if (!interface_exists($contract) && !class_exists($contract)) {
+            throw UnsupportedTarget::missing($contract);
+        }
+
+        $reflection = new \ReflectionClass($contract);
+
+        if (!$reflection->isInterface()) {
+            throw UnsupportedTarget::notDoublable(
+                $contract,
+                'only interfaces can be doubled in this version. Double the interface it implements, '
+                . 'or introduce one for the dependency you need to stand in for.',
+            );
+        }
+
+        return $reflection;
+    }
+
+    /**
+     * @param non-empty-list<class-string>             $contracts
+     * @param array<non-empty-string, MethodSignature> $methods
+     */
+    private static function render(string $generatedClass, array $contracts, array $methods): string
+    {
+        $body = '';
+
+        foreach ($methods as $signature) {
+            $body .= self::renderMethod($signature);
+        }
+
+        return sprintf(
+            "namespace %s\\Generated;\n\nfinal class %s implements %s\n{\n%s}\n",
+            __NAMESPACE__,
+            $generatedClass,
+            implode(', ', array_map(static fn(string $c): string => '\\' . $c, $contracts)),
+            $body,
+        );
+    }
+
+    private static function renderMethod(MethodSignature $signature): string
+    {
+        $dispatch = sprintf(
+            '\\%s::dispatch($this, %s, %s)',
+            Runtime::class,
+            var_export($signature->name, return: true),
+            $signature->arguments,
+        );
+
+        // A `void` method must not return a value, and a `never` method must
+        // not return at all — the dispatcher throws for it before returning.
+        $statement = $signature->returnsVoid || $signature->returnsNever
+            ? $dispatch . ';'
+            : 'return ' . $dispatch . ';';
+
+        return sprintf(
+            "    public function %s%s(%s): %s\n    {\n        %s\n    }\n\n",
+            $signature->returnsReference ? '&' : '',
+            $signature->name,
+            $signature->parameters,
+            $signature->returnType,
+            $statement,
+        );
+    }
+}

--- a/src/Codegen/DoubleFactory.php
+++ b/src/Codegen/DoubleFactory.php
@@ -107,9 +107,16 @@ final class DoubleFactory
 
         // A `void` method must not return a value, and a `never` method must
         // not return at all — the dispatcher throws for it before returning.
-        $statement = $signature->returnsVoid || $signature->returnsNever
-            ? $dispatch . ';'
-            : 'return ' . $dispatch . ';';
+        //
+        // A by-reference method must not return a call's result directly
+        // either: PHP can only bind a reference to a variable, and returning
+        // an expression raises "Only variable references should be returned by
+        // reference".
+        $statement = match (true) {
+            $signature->returnsVoid, $signature->returnsNever => $dispatch . ';',
+            $signature->returnsReference => '$result = ' . $dispatch . ";\n\n        return \$result;",
+            default => 'return ' . $dispatch . ';',
+        };
 
         return sprintf(
             "    public function %s%s(%s): %s\n    {\n        %s\n    }\n\n",

--- a/src/Codegen/MethodSignature.php
+++ b/src/Codegen/MethodSignature.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Codegen;
+
+/**
+ * What the dispatcher needs to know about one doubled method, resolved once at
+ * generation time so no Reflection happens on the hot path.
+ *
+ * @internal
+ */
+final readonly class MethodSignature
+{
+    /**
+     * @param non-empty-string $name
+     * @param string           $parameters rendered parameter list; empty for a method without parameters
+     * @param non-empty-string $arguments  expression collecting every parameter, defaults included
+     * @param non-empty-string $returnType rendered return type of the override
+     */
+    public function __construct(
+        public string $name,
+        public string $parameters,
+        public string $arguments,
+        public string $returnType,
+        public bool $returnsNever,
+        public bool $returnsVoid,
+        public bool $returnsReference,
+    ) {}
+}

--- a/src/Codegen/TargetUnifier.php
+++ b/src/Codegen/TargetUnifier.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Codegen;
+
+use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
+
+/**
+ * Turns one or more contracts into the signatures a single class can declare.
+ *
+ * Same-named methods across targets are UNIFIED, not compared for equality.
+ * PHP parameters are contravariant, so `write(int)` and `write(string)` share
+ * a valid implementation — `write(int|string)` — and rejecting them because
+ * their signatures differ would refuse a pair that is perfectly doublable. A
+ * conflict is reported only where no single declaration can satisfy every
+ * target: return types (which are covariant) that disagree, and a parameter
+ * that is by-reference in one target and by-value in another.
+ *
+ * @internal
+ */
+final class TargetUnifier
+{
+    private function __construct() {}
+
+    /**
+     * @param non-empty-list<\ReflectionClass<object>> $targets
+     *
+     * @return array<non-empty-string, MethodSignature>
+     */
+    public static function unify(array $targets): array
+    {
+        /** @var array<non-empty-string, list<\ReflectionMethod>> $byName */
+        $byName = [];
+
+        foreach ($targets as $target) {
+            foreach ($target->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->isStatic()) {
+                    // Static methods carry no instance state; there is nothing
+                    // for an instance double to intercept.
+                    continue;
+                }
+
+                $byName[$method->getName()][] = $method;
+            }
+        }
+
+        $signatures = [];
+
+        foreach ($byName as $name => $declarations) {
+            \assert($declarations !== []);
+
+            $signatures[$name] = self::unifyMethod($name, $declarations);
+        }
+
+        return $signatures;
+    }
+
+    /**
+     * @param non-empty-string              $name
+     * @param non-empty-list<\ReflectionMethod> $declarations
+     */
+    private static function unifyMethod(string $name, array $declarations): MethodSignature
+    {
+        $returnType = self::unifyReturnType($name, $declarations);
+        $arity = max(array_map(
+            static fn(\ReflectionMethod $method): int => $method->getNumberOfParameters(),
+            $declarations,
+        ));
+
+        $parameters = [];
+        $arguments = [];
+
+        for ($position = 0; $position < $arity; $position++) {
+            $parameter = self::unifyParameter($name, $declarations, $position);
+            $parameters[] = $parameter['rendered'];
+
+            // Collected by name rather than with func_get_args(), which omits
+            // parameters the caller left at their default: the call log must
+            // show the arguments the method actually received, so that
+            // `tag('alpha')` and `tag('alpha', 1)` verify as the same call.
+            $arguments[] = ($parameter['variadic'] ? '...$' : '$') . $parameter['name'];
+        }
+
+        $reference = $declarations[0]->returnsReference();
+
+        foreach ($declarations as $declaration) {
+            if ($declaration->returnsReference() !== $reference) {
+                throw UnsupportedTarget::signatureConflict(
+                    $name,
+                    self::describe($declarations[0]) . ($reference ? ' returns by reference' : ' returns by value'),
+                    self::describe($declaration) . ($reference ? ' returns by value' : ' returns by reference'),
+                );
+            }
+        }
+
+        return new MethodSignature(
+            name: $name,
+            parameters: implode(', ', $parameters),
+            arguments: '[' . implode(', ', $arguments) . ']',
+            returnType: $returnType,
+            returnsNever: $returnType === 'never',
+            returnsVoid: $returnType === 'void',
+            returnsReference: $reference,
+        );
+    }
+
+    /**
+     * Return types are covariant, so an implementation must satisfy all of
+     * them at once. `int` and `string` have no common subtype: no class can
+     * implement both, and PHP rejects the attempt at compile time.
+     *
+     * @param non-empty-string              $name
+     * @param non-empty-list<\ReflectionMethod> $declarations
+     *
+     * @return non-empty-string
+     */
+    private static function unifyReturnType(string $name, array $declarations): string
+    {
+        /** @var array<non-empty-string, \ReflectionMethod> $seen */
+        $seen = [];
+
+        foreach ($declarations as $declaration) {
+            $seen[TypeRenderer::returnType($declaration->getReturnType())] ??= $declaration;
+        }
+
+        if (count($seen) > 1) {
+            $types = array_keys($seen);
+            $methods = array_values($seen);
+
+            throw UnsupportedTarget::signatureConflict(
+                $name,
+                self::describe($methods[0]) . ' declares `: ' . $types[0] . '`',
+                self::describe($methods[1]) . ' declares `: ' . $types[1] . '`',
+            );
+        }
+
+        return array_key_first($seen);
+    }
+
+    /**
+     * @param non-empty-string              $name
+     * @param non-empty-list<\ReflectionMethod> $declarations
+     *
+     * @return array{rendered: non-empty-string, name: non-empty-string, variadic: bool}
+     */
+    private static function unifyParameter(string $name, array $declarations, int $position): array
+    {
+        /** @var array<string, true> $types */
+        $types = [];
+        $byReference = null;
+        $variadic = false;
+        $declaredEverywhere = true;
+        $requiredEverywhere = true;
+        $parameterName = 'p' . $position;
+        $untyped = false;
+        $acceptsMatcher = true;
+        $declaredDefaults = [];
+
+        foreach ($declarations as $declaration) {
+            $parameter = $declaration->getParameters()[$position] ?? null;
+
+            if ($parameter === null) {
+                $declaredEverywhere = false;
+
+                continue;
+            }
+
+            $rendered = TypeRenderer::parameterType($parameter->getType());
+
+            if ($rendered === '') {
+                $untyped = true;
+            } else {
+                foreach (self::splitUnion($rendered) as $part) {
+                    $types[$part] = true;
+                }
+            }
+
+            $acceptsMatcher = $acceptsMatcher && TypeRenderer::acceptsMatcher($parameter->getType());
+
+            if ($byReference !== null && $byReference !== $parameter->isPassedByReference()) {
+                throw UnsupportedTarget::signatureConflict(
+                    $name,
+                    self::describe($declarations[0]) . ' takes parameter #' . ($position + 1) . ' by ' . ($byReference ? 'reference' : 'value'),
+                    self::describe($declaration) . ' takes it by ' . ($parameter->isPassedByReference() ? 'reference' : 'value'),
+                );
+            }
+
+            $byReference = $parameter->isPassedByReference();
+            $variadic = $variadic || $parameter->isVariadic();
+            $requiredEverywhere = $requiredEverywhere && !$parameter->isOptional();
+            $parameterName = $parameter->getName();
+
+            if (!$parameter->isVariadic() && $parameter->isDefaultValueAvailable()) {
+                $declaredDefaults[self::renderDefault($parameter->getDefaultValue())] = true;
+            }
+        }
+
+        // An untyped parameter in any target means the union cannot be
+        // expressed at all — every value is already allowed.
+        //
+        // The matcher branch is appended here, once, rather than by each
+        // target's rendering: otherwise unifying `write(int)` with
+        // `write(string)` would interleave it as `int|Matcher|string`.
+        if ($untyped) {
+            $type = '';
+        } else {
+            if (!$acceptsMatcher) {
+                $types[TypeRenderer::MATCHER] = true;
+            }
+
+            $type = implode('|', array_keys($types));
+        }
+
+        if ($variadic) {
+            // A variadic tail is optional by nature and cannot carry a default.
+            $rendered = trim($type . ' ' . ($byReference === true ? '&' : '') . '...$' . $parameterName);
+            \assert($rendered !== '');
+
+            return ['rendered' => $rendered, 'name' => $parameterName, 'variadic' => true];
+        }
+
+        $optional = !$declaredEverywhere || !$requiredEverywhere;
+
+        // Keeping the contract's own default is what makes an omitted argument
+        // observable: `tag('alpha')` must log the same arguments as
+        // `tag('alpha', 1)`, or the two would verify as different calls.
+        $default = count($declaredDefaults) === 1 ? array_key_first($declaredDefaults) : 'null';
+
+        if ($optional && $default === 'null' && $type !== '' && !str_contains($type, 'null')) {
+            // `= null` on a non-nullable type is an implicitly nullable
+            // parameter, deprecated since 8.4 — widen the type instead.
+            $type .= '|null';
+        }
+
+        $rendered = trim(sprintf(
+            '%s %s$%s%s',
+            $type,
+            $byReference === true ? '&' : '',
+            $parameterName,
+            $optional ? ' = ' . $default : '',
+        ));
+        \assert($rendered !== '');
+
+        return ['rendered' => $rendered, 'name' => $parameterName, 'variadic' => false];
+    }
+
+    /**
+     * Splits a rendered union while keeping DNF parentheses intact, so
+     * `(A&B)|null` yields `(A&B)` and `null` rather than four fragments.
+     *
+     * @return list<string>
+     */
+    private static function splitUnion(string $rendered): array
+    {
+        if (str_starts_with($rendered, '?')) {
+            return [substr($rendered, 1), 'null'];
+        }
+
+        $parts = [];
+        $depth = 0;
+        $buffer = '';
+
+        foreach (str_split($rendered) as $character) {
+            if ($character === '(') {
+                $depth++;
+            }
+
+            if ($character === ')') {
+                $depth--;
+            }
+
+            if ($character === '|' && $depth === 0) {
+                $parts[] = $buffer;
+                $buffer = '';
+
+                continue;
+            }
+
+            $buffer .= $character;
+        }
+
+        $parts[] = $buffer;
+
+        return array_values(array_filter($parts, static fn(string $part): bool => $part !== ''));
+    }
+
+    /**
+     * Only values that round-trip through source are kept; anything else falls
+     * back to `null`, which is always a legal default once the type is widened.
+     *
+     * @return non-empty-string
+     */
+    private static function renderDefault(mixed $value): string
+    {
+        if ($value instanceof \UnitEnum) {
+            return '\\' . $value::class . '::' . $value->name;
+        }
+
+        if ($value === null || is_object($value)) {
+            // var_export() would render `NULL`, which is legal but jarring in
+            // generated source next to hand-written PHP.
+            return 'null';
+        }
+
+        $rendered = var_export($value, return: true);
+        \assert($rendered !== '');
+
+        return $rendered;
+    }
+
+    private static function describe(\ReflectionMethod $method): string
+    {
+        return '`' . $method->getDeclaringClass()->getName() . '::' . $method->getName() . '()`';
+    }
+}

--- a/src/Codegen/TargetUnifier.php
+++ b/src/Codegen/TargetUnifier.php
@@ -21,6 +21,9 @@ use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
  */
 final class TargetUnifier
 {
+    /** Used when a target declares a variadic without a usable name. */
+    private const string DEFAULT_TAIL_NAME = 'rest';
+
     private function __construct() {}
 
     /**
@@ -68,6 +71,13 @@ final class TargetUnifier
             $declarations,
         ));
 
+        // A variadic absorbs every parameter after it, in the contract and in
+        // the override alike. Rendering the later fixed parameters of another
+        // target would put them after `...$rest` — which is a parse error, not
+        // a wider signature.
+        $variadicAt = self::firstVariadicPosition($declarations);
+        $arity = $variadicAt ?? $arity;
+
         $parameters = [];
         $arguments = [];
 
@@ -79,7 +89,13 @@ final class TargetUnifier
             // parameters the caller left at their default: the call log must
             // show the arguments the method actually received, so that
             // `tag('alpha')` and `tag('alpha', 1)` verify as the same call.
-            $arguments[] = ($parameter['variadic'] ? '...$' : '$') . $parameter['name'];
+            $arguments[] = '$' . $parameter['name'];
+        }
+
+        if ($variadicAt !== null) {
+            $tail = self::unifyVariadicTail($name, $declarations, $variadicAt);
+            $parameters[] = $tail['rendered'];
+            $arguments[] = '...$' . $tail['name'];
         }
 
         $reference = $declarations[0]->returnsReference();
@@ -88,8 +104,8 @@ final class TargetUnifier
             if ($declaration->returnsReference() !== $reference) {
                 throw UnsupportedTarget::signatureConflict(
                     $name,
-                    self::describe($declarations[0]) . ($reference ? ' returns by reference' : ' returns by value'),
-                    self::describe($declaration) . ($reference ? ' returns by value' : ' returns by reference'),
+                    self::describe($declarations[0]) . ' returns by ' . ($reference ? 'reference' : 'value'),
+                    self::describe($declaration) . ' returns by ' . ($reference ? 'value' : 'reference'),
                 );
             }
         }
@@ -139,17 +155,102 @@ final class TargetUnifier
     }
 
     /**
+     * The earliest position at which any target declares a variadic, or null
+     * when none does.
+     *
+     * @param non-empty-list<\ReflectionMethod> $declarations
+     *
+     * @return int<0, max>|null
+     */
+    private static function firstVariadicPosition(array $declarations): ?int
+    {
+        $earliest = null;
+
+        foreach ($declarations as $declaration) {
+            foreach ($declaration->getParameters() as $position => $parameter) {
+                if ($parameter->isVariadic()) {
+                    $earliest = $earliest === null ? $position : min($earliest, $position);
+
+                    break;
+                }
+            }
+        }
+
+        return $earliest;
+    }
+
+    /**
+     * Everything from the first variadic position onwards collapses into one
+     * variadic tail whose type is the union of every parameter any target
+     * declares there or later.
+     *
+     * @param non-empty-string                  $name
+     * @param non-empty-list<\ReflectionMethod> $declarations
+     *
+     * @return array{rendered: non-empty-string, name: non-empty-string}
+     */
+    private static function unifyVariadicTail(string $name, array $declarations, int $from): array
+    {
+        /** @var array<string, true> $types */
+        $types = [];
+        $byReference = null;
+        $tailName = self::DEFAULT_TAIL_NAME;
+        $untyped = false;
+
+        foreach ($declarations as $declaration) {
+            foreach (array_slice($declaration->getParameters(), $from) as $parameter) {
+                $rendered = TypeRenderer::parameterType($parameter->getType());
+
+                if ($rendered === '') {
+                    $untyped = true;
+                } else {
+                    foreach (self::splitUnion($rendered) as $part) {
+                        $types[$part] = true;
+                    }
+                }
+
+                if ($byReference !== null && $byReference !== $parameter->isPassedByReference()) {
+                    throw UnsupportedTarget::signatureConflict(
+                        $name,
+                        self::describe($declaration) . ' takes its variadic tail by ' . ($byReference ? 'reference' : 'value'),
+                        self::describe($declaration) . ' takes it by ' . ($parameter->isPassedByReference() ? 'reference' : 'value'),
+                    );
+                }
+
+                $byReference = $parameter->isPassedByReference();
+
+                if ($parameter->isVariadic() && $tailName === self::DEFAULT_TAIL_NAME) {
+                    // First target wins: `for($primary, ...$interfaces)` treats
+                    // the first contract as the primary one, and the name is
+                    // what a named argument would have to use.
+                    $tailName = $parameter->getName();
+                }
+            }
+        }
+
+        if (!$untyped && $types !== []) {
+            $types[TypeRenderer::MATCHER] = true;
+        }
+
+        $type = $untyped ? '' : implode('|', array_keys($types));
+        $rendered = trim($type . ' ' . ($byReference === true ? '&' : '') . '...$' . $tailName);
+        \assert($rendered !== '');
+
+        return ['rendered' => $rendered, 'name' => $tailName];
+    }
+
+    /**
      * @param non-empty-string              $name
      * @param non-empty-list<\ReflectionMethod> $declarations
      *
-     * @return array{rendered: non-empty-string, name: non-empty-string, variadic: bool}
+     * @return array{rendered: non-empty-string, name: non-empty-string}
      */
     private static function unifyParameter(string $name, array $declarations, int $position): array
     {
         /** @var array<string, true> $types */
         $types = [];
         $byReference = null;
-        $variadic = false;
+        $firstToDeclare = null;
         $declaredEverywhere = true;
         $requiredEverywhere = true;
         $parameterName = 'p' . $position;
@@ -179,19 +280,23 @@ final class TargetUnifier
             $acceptsMatcher = $acceptsMatcher && TypeRenderer::acceptsMatcher($parameter->getType());
 
             if ($byReference !== null && $byReference !== $parameter->isPassedByReference()) {
+                // `$declarations[0]` may not declare this position at all;
+                // name the target that actually did.
+                \assert($firstToDeclare instanceof \ReflectionMethod);
+
                 throw UnsupportedTarget::signatureConflict(
                     $name,
-                    self::describe($declarations[0]) . ' takes parameter #' . ($position + 1) . ' by ' . ($byReference ? 'reference' : 'value'),
+                    self::describe($firstToDeclare) . ' takes parameter #' . ($position + 1) . ' by ' . ($byReference ? 'reference' : 'value'),
                     self::describe($declaration) . ' takes it by ' . ($parameter->isPassedByReference() ? 'reference' : 'value'),
                 );
             }
 
+            $firstToDeclare ??= $declaration;
             $byReference = $parameter->isPassedByReference();
-            $variadic = $variadic || $parameter->isVariadic();
             $requiredEverywhere = $requiredEverywhere && !$parameter->isOptional();
             $parameterName = $parameter->getName();
 
-            if (!$parameter->isVariadic() && $parameter->isDefaultValueAvailable()) {
+            if ($parameter->isDefaultValueAvailable()) {
                 $declaredDefaults[self::renderDefault($parameter->getDefaultValue())] = true;
             }
         }
@@ -210,14 +315,6 @@ final class TargetUnifier
             }
 
             $type = implode('|', array_keys($types));
-        }
-
-        if ($variadic) {
-            // A variadic tail is optional by nature and cannot carry a default.
-            $rendered = trim($type . ' ' . ($byReference === true ? '&' : '') . '...$' . $parameterName);
-            \assert($rendered !== '');
-
-            return ['rendered' => $rendered, 'name' => $parameterName, 'variadic' => true];
         }
 
         $optional = !$declaredEverywhere || !$requiredEverywhere;
@@ -242,7 +339,7 @@ final class TargetUnifier
         ));
         \assert($rendered !== '');
 
-        return ['rendered' => $rendered, 'name' => $parameterName, 'variadic' => false];
+        return ['rendered' => $rendered, 'name' => $parameterName];
     }
 
     /**

--- a/src/Codegen/TypeRenderer.php
+++ b/src/Codegen/TypeRenderer.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Codegen;
+
+use Rasuvaeff\Understudy\Matcher\ArgumentMatcher;
+
+/**
+ * Renders Reflection types back into source.
+ *
+ * Parameters are widened with `ArgumentMatcher` by {@see TargetUnifier}, which
+ * appends that branch exactly once after collecting the types of every target.
+ * Widening is legal because PHP parameters are contravariant: an override may
+ * accept more than the contract declares. It is what lets `Arg::any()` be
+ * passed where the contract says `int`, while every other wrong type is still
+ * rejected by PHP itself before the call reaches the dispatcher.
+ *
+ * @internal
+ */
+final class TypeRenderer
+{
+    public const string MATCHER = '\\' . ArgumentMatcher::class;
+
+    private function __construct() {}
+
+    /**
+     * The contract's own parameter type, with `?T` expanded to `T|null` and
+     * intersections parenthesised so a matcher branch can be appended in DNF.
+     *
+     * @return string empty when the contract declares no type, since there is
+     *                then nothing to union a matcher onto
+     */
+    public static function parameterType(?\ReflectionType $type): string
+    {
+        if ($type === null) {
+            return '';
+        }
+
+        if ($type instanceof \ReflectionIntersectionType) {
+            return '(' . self::render($type) . ')';
+        }
+
+        if ($type instanceof \ReflectionNamedType && $type->allowsNull() && $type->getName() !== 'null') {
+            return $type->getName() === 'mixed' ? 'mixed' : $type->getName() . '|null';
+        }
+
+        return self::render($type);
+    }
+
+    /**
+     * `mixed` and `object` already admit any matcher instance, so widening
+     * them would only produce a redundant — and for `mixed`, illegal — union.
+     */
+    public static function acceptsMatcher(?\ReflectionType $type): bool
+    {
+        if (!$type instanceof \ReflectionNamedType) {
+            return false;
+        }
+
+        return in_array($type->getName(), ['mixed', 'object'], strict: true);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public static function returnType(?\ReflectionType $type): string
+    {
+        return $type === null ? 'mixed' : self::render($type);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function render(\ReflectionType $type): string
+    {
+        if ($type instanceof \ReflectionUnionType) {
+            return implode('|', array_map(
+                static fn(\ReflectionType $part): string => $part instanceof \ReflectionIntersectionType
+                    ? '(' . self::render($part) . ')'
+                    : self::render($part),
+                $type->getTypes(),
+            ));
+        }
+
+        if ($type instanceof \ReflectionIntersectionType) {
+            return implode('&', array_map(self::render(...), $type->getTypes()));
+        }
+
+        \assert($type instanceof \ReflectionNamedType);
+
+        $name = $type->getName();
+        $prefix = $type->isBuiltin() || in_array($name, ['self', 'static', 'parent'], strict: true) ? '' : '\\';
+        $nullable = $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' : '';
+
+        return $nullable . $prefix . $name;
+    }
+}

--- a/src/Codegen/TypeRenderer.php
+++ b/src/Codegen/TypeRenderer.php
@@ -42,7 +42,12 @@ final class TypeRenderer
         }
 
         if ($type instanceof \ReflectionNamedType && $type->allowsNull() && $type->getName() !== 'null') {
-            return $type->getName() === 'mixed' ? 'mixed' : $type->getName() . '|null';
+            $name = $type->getName();
+
+            // `?Book` has to expand to `\Book|null`, keeping the leading
+            // backslash: the generated class lives in its own namespace, and a
+            // relative name would resolve to a class that does not exist.
+            return $name === 'mixed' ? 'mixed' : self::qualify($type) . '|null';
         }
 
         return self::render($type);
@@ -90,9 +95,23 @@ final class TypeRenderer
         \assert($type instanceof \ReflectionNamedType);
 
         $name = $type->getName();
-        $prefix = $type->isBuiltin() || in_array($name, ['self', 'static', 'parent'], strict: true) ? '' : '\\';
         $nullable = $type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' : '';
 
-        return $nullable . $prefix . $name;
+        return $nullable . self::qualify($type);
+    }
+
+    /**
+     * A class name written into generated source must be absolute; a builtin
+     * or a relative keyword must not be.
+     *
+     * @return non-empty-string
+     */
+    private static function qualify(\ReflectionNamedType $type): string
+    {
+        $name = $type->getName();
+
+        return $type->isBuiltin() || in_array($name, ['self', 'static', 'parent'], strict: true)
+            ? $name
+            : '\\' . $name;
     }
 }

--- a/src/Defaults/TypeDefaultResolver.php
+++ b/src/Defaults/TypeDefaultResolver.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Defaults;
+
+use Rasuvaeff\Understudy\Codegen\MethodSignature;
+use Rasuvaeff\Understudy\Exception\NoDefaultValue;
+
+/**
+ * What a loose understudy answers when no expectation matched.
+ *
+ * The rule that shapes this table: never invent a value by running someone
+ * else's constructor, and never hand back an object whose constructor was
+ * skipped. Where no safe value exists, say so and name the way out.
+ *
+ * @internal
+ */
+final class TypeDefaultResolver
+{
+    private function __construct() {}
+
+    /**
+     * @param non-empty-string $label
+     * @param non-empty-string $method
+     */
+    public static function forSignature(string $label, ?MethodSignature $signature, string $method): mixed
+    {
+        if ($signature === null) {
+            return null;
+        }
+
+        return self::forType($label, $signature->returnType, $method);
+    }
+
+    /**
+     * @param non-empty-string $label
+     * @param non-empty-string $method
+     */
+    private static function forType(string $label, string $type, string $method): mixed
+    {
+        if (str_starts_with($type, '?')) {
+            return null;
+        }
+
+        // A union is satisfied by any one branch, and `null` is the safest
+        // branch there is.
+        if (str_contains($type, '|')) {
+            return str_contains($type, 'null') ? null : self::forType(
+                $label,
+                self::firstBranch($type),
+                $method,
+            );
+        }
+
+        return match (ltrim($type, '\\')) {
+            'void', 'null', 'mixed' => null,
+            'bool', 'false' => false,
+            'true' => true,
+            'int' => 0,
+            'float' => 0.0,
+            'string' => '',
+            'array', 'iterable' => [],
+            'object' => new \stdClass(),
+            'callable', 'Closure' => static fn(): null => null,
+            'Generator' => self::emptyGenerator(),
+            'Traversable', 'Iterator' => new \EmptyIterator(),
+            'ArrayIterator' => new \ArrayIterator(),
+            default => throw NoDefaultValue::forReturnType($label, $method, $type),
+        };
+    }
+
+    /**
+     * `[]` would violate a declared `: Generator`, so the empty case has to be
+     * an actual generator.
+     */
+    private static function emptyGenerator(): \Generator
+    {
+        return (static function (): \Generator {
+            yield from [];
+        })();
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function firstBranch(string $type): string
+    {
+        $branch = explode('|', $type)[0];
+        \assert($branch !== '');
+
+        return $branch;
+    }
+}

--- a/src/Defaults/TypeDefaultResolver.php
+++ b/src/Defaults/TypeDefaultResolver.php
@@ -43,14 +43,27 @@ final class TypeDefaultResolver
             return null;
         }
 
-        // A union is satisfied by any one branch, and `null` is the safest
-        // branch there is.
+        // A union is satisfied by any one branch. Branches are compared
+        // exactly, never as substrings: a class called `Nullable` is not a
+        // `null` branch. `null` wins when present; otherwise the first branch
+        // that has a safe default does, so `Book|string` answers with `''`
+        // rather than failing on `Book`.
         if (str_contains($type, '|')) {
-            return str_contains($type, 'null') ? null : self::forType(
-                $label,
-                self::firstBranch($type),
-                $method,
-            );
+            $branches = self::branchesOf($type);
+
+            if (in_array('null', $branches, strict: true)) {
+                return null;
+            }
+
+            foreach ($branches as $branch) {
+                try {
+                    return self::forType($label, $branch, $method);
+                } catch (NoDefaultValue) {
+                    continue;
+                }
+            }
+
+            throw NoDefaultValue::forReturnType($label, $method, $type);
         }
 
         return match (ltrim($type, '\\')) {
@@ -82,13 +95,39 @@ final class TypeDefaultResolver
     }
 
     /**
-     * @return non-empty-string
+     * Splits a union while leaving a DNF intersection intact, so `(A&B)|null`
+     * yields `(A&B)` and `null`.
+     *
+     * @return list<non-empty-string>
      */
-    private static function firstBranch(string $type): string
+    private static function branchesOf(string $type): array
     {
-        $branch = explode('|', $type)[0];
-        \assert($branch !== '');
+        $branches = [];
+        $depth = 0;
+        $buffer = '';
 
-        return $branch;
+        foreach (str_split($type) as $character) {
+            $depth += match ($character) {
+                '(' => 1,
+                ')' => -1,
+                default => 0,
+            };
+
+            if ($character === '|' && $depth === 0) {
+                $branches[] = $buffer;
+                $buffer = '';
+
+                continue;
+            }
+
+            $buffer .= $character;
+        }
+
+        $branches[] = $buffer;
+
+        return array_values(array_filter(
+            $branches,
+            static fn(string $branch): bool => $branch !== '',
+        ));
     }
 }

--- a/src/Exception/ForgottenDouble.php
+++ b/src/Exception/ForgottenDouble.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Exception;
+
+/**
+ * A double outlived the context that created it — almost always a double kept
+ * in a static property or a shared fixture across `Understudy::reset()`.
+ *
+ * Answering with `null` instead would violate the declared return type of any
+ * non-nullable method and surface far from the actual mistake.
+ *
+ * @api
+ */
+final class ForgottenDouble extends \LogicException implements UnderstudyError
+{
+    /**
+     * @param non-empty-string $method
+     */
+    public static function afterReset(string $method): self
+    {
+        return new self(sprintf(
+            "This understudy is no longer known to Understudy, but `%s()` was called on it.\n"
+            . 'It was created before a reset(); create doubles inside the test that uses them '
+            . 'rather than sharing one across tests.',
+            $method,
+        ));
+    }
+}

--- a/src/Exception/InvalidCallSpecification.php
+++ b/src/Exception/InvalidCallSpecification.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Rasuvaeff\Understudy\Exception;
 
 /**
- * The closure handed to when()/expect()/verify() did not contain exactly one
- * direct call on an understudy.
+ * The closure handed to when()/verify() did not contain exactly one direct
+ * call on an understudy.
  *
  * @api
  */

--- a/src/Exception/InvalidCallSpecification.php
+++ b/src/Exception/InvalidCallSpecification.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Exception;
+
+/**
+ * The closure handed to when()/expect()/verify() did not contain exactly one
+ * direct call on an understudy.
+ *
+ * @api
+ */
+final class InvalidCallSpecification extends \LogicException implements UnderstudyError
+{
+    public static function noCallRecorded(): self
+    {
+        return new self(
+            'The specification closure did not call a method on an understudy. '
+            . 'It must contain exactly one direct call, for example: '
+            . 'when(fn () => $repository->find(123))',
+        );
+    }
+
+    public static function closureFailed(\Throwable $previous): self
+    {
+        return new self(
+            'The specification closure threw before it reached an understudy: '
+            . $previous->getMessage(),
+            previous: $previous,
+        );
+    }
+}

--- a/src/Exception/NeverMethodCalled.php
+++ b/src/Exception/NeverMethodCalled.php
@@ -27,4 +27,19 @@ final class NeverMethodCalled extends \RuntimeException implements UnderstudyErr
             $method,
         ));
     }
+
+    /**
+     * @param non-empty-string $label
+     * @param non-empty-string $method
+     */
+    public static function configuredToReturn(string $label, string $method): self
+    {
+        return new self(sprintf(
+            "Understudy `%s` has `%s()` configured to return, but the method is declared `: never` and cannot.\n"
+            . 'Configure it to throw instead: when(fn () => $double->%s(...))->throws(new SomeException())',
+            $label,
+            $method,
+            $method,
+        ));
+    }
 }

--- a/src/Exception/NeverMethodCalled.php
+++ b/src/Exception/NeverMethodCalled.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Exception;
+
+/**
+ * A method declared `: never` was called without an expectation that throws.
+ * Returning from it is impossible by language rule, so the dispatcher must
+ * throw something — this says so explicitly instead of leaking a TypeError.
+ *
+ * @api
+ */
+final class NeverMethodCalled extends \RuntimeException implements UnderstudyError
+{
+    /**
+     * @param non-empty-string $label
+     * @param non-empty-string $method
+     */
+    public static function withoutExpectation(string $label, string $method): self
+    {
+        return new self(sprintf(
+            "Understudy `%s` received a call to `%s()`, which is declared `: never` and cannot return.\n"
+            . 'Configure what it throws: when(fn () => $double->%s(...))->throws(new SomeException())',
+            $label,
+            $method,
+            $method,
+        ));
+    }
+}

--- a/src/Exception/NoDefaultValue.php
+++ b/src/Exception/NoDefaultValue.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Exception;
+
+/**
+ * A loose understudy had to answer a call, but the declared return type has no
+ * safe default. Understudy never invents one by calling an arbitrary
+ * constructor and never hands back an uninitialised object.
+ *
+ * @api
+ */
+final class NoDefaultValue extends \RuntimeException implements UnderstudyError
+{
+    /**
+     * @param non-empty-string $label
+     * @param non-empty-string $method
+     */
+    public static function forReturnType(string $label, string $method, string $type): self
+    {
+        return new self(sprintf(
+            "Understudy `%s` cannot answer `%s()`: there is no safe default for the declared return type `%s`.\n"
+            . "- Configure the call: when(fn () => \$double->%s(...))->returns(...)\n"
+            . '- Or register a default for the type: Understudy::defaults(%s::class, fn () => ...)',
+            $label,
+            $method,
+            $type,
+            $method,
+            $type,
+        ));
+    }
+}

--- a/src/Exception/NoDefaultValue.php
+++ b/src/Exception/NoDefaultValue.php
@@ -21,13 +21,11 @@ final class NoDefaultValue extends \RuntimeException implements UnderstudyError
     {
         return new self(sprintf(
             "Understudy `%s` cannot answer `%s()`: there is no safe default for the declared return type `%s`.\n"
-            . "- Configure the call: when(fn () => \$double->%s(...))->returns(...)\n"
-            . '- Or register a default for the type: Understudy::defaults(%s::class, fn () => ...)',
+            . 'Configure the call: when(fn () => $double->%s(...))->returns(...)',
             $label,
             $method,
             $type,
             $method,
-            $type,
         ));
     }
 }

--- a/src/Exception/OutcomeUnavailable.php
+++ b/src/Exception/OutcomeUnavailable.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Exception;
+
+/**
+ * An invocation's outcome was read as the wrong kind: a returned value asked
+ * of a call that threw. `null` is a valid return value, so this cannot be
+ * signalled by returning null.
+ *
+ * @api
+ */
+final class OutcomeUnavailable extends \LogicException implements UnderstudyError
+{
+    /**
+     * @param non-empty-string $method
+     */
+    public static function threwInstead(string $method, \Throwable $thrown): self
+    {
+        return new self(sprintf(
+            'Call to `%s()` threw %s and has no return value. Check didReturn() first, or read thrown().',
+            $method,
+            $thrown::class,
+        ));
+    }
+}

--- a/src/Exception/StrictModeViolation.php
+++ b/src/Exception/StrictModeViolation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Exception;
+
+/**
+ * A strict understudy received a call no expectation matched.
+ *
+ * @api
+ */
+final class StrictModeViolation extends \RuntimeException implements UnderstudyError
+{
+    /**
+     * @param non-empty-string $label
+     * @param non-empty-string $method
+     */
+    public static function unexpectedCall(string $label, string $method): self
+    {
+        return new self(sprintf(
+            "Understudy `%s` is strict and received an unexpected call to `%s()`.\n"
+            . 'Configure it first: when(fn () => $double->%s(...))->returns(...)',
+            $label,
+            $method,
+            $method,
+        ));
+    }
+}

--- a/src/Exception/UnderstudyError.php
+++ b/src/Exception/UnderstudyError.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Exception;
+
+/**
+ * Implemented by every exception this library throws, so a test can catch
+ * misuse of Understudy itself without catching the errors it reports about
+ * the code under test.
+ *
+ * @api
+ */
+interface UnderstudyError extends \Throwable {}

--- a/src/Exception/UnsupportedTarget.php
+++ b/src/Exception/UnsupportedTarget.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Exception;
+
+/**
+ * The requested target cannot be doubled, and no option would make it work
+ * without the user changing something. The message names that something.
+ *
+ * @api
+ */
+final class UnsupportedTarget extends \LogicException implements UnderstudyError
+{
+    public static function missing(string $target): self
+    {
+        return new self(sprintf(
+            'Cannot create an understudy for `%s`: no such class or interface is loadable.',
+            $target,
+        ));
+    }
+
+    /**
+     * @param non-empty-string $target
+     */
+    public static function notDoublable(string $target, string $reason): self
+    {
+        return new self(sprintf(
+            'Cannot create an understudy for `%s`: %s',
+            $target,
+            $reason,
+        ));
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    public static function signatureConflict(string $method, string $left, string $right): self
+    {
+        return new self(sprintf(
+            "Cannot create one understudy for these targets: method `%s()` has no implementation that satisfies all of them.\n  %s\n  %s",
+            $method,
+            $left,
+            $right,
+        ));
+    }
+}

--- a/src/Exception/VerificationFailed.php
+++ b/src/Exception/VerificationFailed.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Exception;
+
+/**
+ * A verification about what the code under test did (or did not) do failed.
+ * This is the one exception that reports on the tested code rather than on
+ * misuse of Understudy, so adapters map it to a test failure.
+ *
+ * @api
+ */
+final class VerificationFailed extends \RuntimeException implements UnderstudyError
+{
+    public static function withReport(string $report): self
+    {
+        return new self($report);
+    }
+}

--- a/src/Expectation/Action.php
+++ b/src/Expectation/Action.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Expectation;
+
+use Rasuvaeff\Understudy\Invocation;
+
+/**
+ * What a matched expectation does: return a value, throw, or compute an answer.
+ *
+ * @internal
+ */
+interface Action
+{
+    public function perform(Invocation $invocation): mixed;
+}

--- a/src/Expectation/ArgumentFormatter.php
+++ b/src/Expectation/ArgumentFormatter.php
@@ -14,20 +14,27 @@ final class ArgumentFormatter
 {
     private const int MAX_STRING = 40;
 
+    /** Deep structures are for a debugger, not for a failure message. */
+    private const int MAX_DEPTH = 3;
+
     private function __construct() {}
 
     /**
      * @return non-empty-string
      */
-    public static function format(mixed $value): string
+    public static function format(mixed $value, int $depth = 0): string
     {
+        if ($depth > self::MAX_DEPTH) {
+            return '…';
+        }
+
         $rendered = match (true) {
             $value === null => 'null',
             $value === true => 'true',
             $value === false => 'false',
             is_int($value), is_float($value) => (string) $value,
             is_string($value) => self::formatString($value),
-            is_array($value) => self::formatArray($value),
+            is_array($value) => self::formatArray($value, $depth),
             $value instanceof \UnitEnum => $value::class . '::' . $value->name,
             is_object($value) => $value::class,
             default => get_debug_type($value),
@@ -42,9 +49,21 @@ final class ArgumentFormatter
      */
     private static function formatString(string $value): string
     {
-        $escaped = mb_strlen($value) > self::MAX_STRING
+        $truncated = mb_strlen($value) > self::MAX_STRING
             ? mb_substr($value, 0, self::MAX_STRING) . '…'
             : $value;
+
+        // A raw newline or quote would break the single line a failure message
+        // renders each argument on, and hide what actually differed.
+        //
+        // Quotes and backslashes are escaped first: doing it the other way
+        // round would escape the backslashes this step introduces, turning a
+        // newline into a literal `\\n`.
+        $escaped = strtr(addcslashes($truncated, "'\\"), [
+            "\n" => '\\n',
+            "\r" => '\\r',
+            "\t" => '\\t',
+        ]);
 
         return "'" . $escaped . "'";
     }
@@ -54,7 +73,7 @@ final class ArgumentFormatter
      *
      * @return non-empty-string
      */
-    private static function formatArray(array $value): string
+    private static function formatArray(array $value, int $depth): string
     {
         if ($value === []) {
             return '[]';
@@ -66,8 +85,8 @@ final class ArgumentFormatter
         /** @var mixed $item */
         foreach (array_slice($value, 0, 5, preserve_keys: true) as $key => $item) {
             $parts[] = $isList
-                ? self::format($item)
-                : self::format($key) . ' => ' . self::format($item);
+                ? self::format($item, $depth + 1)
+                : self::format($key, $depth + 1) . ' => ' . self::format($item, $depth + 1);
         }
 
         if (count($value) > 5) {

--- a/src/Expectation/ArgumentFormatter.php
+++ b/src/Expectation/ArgumentFormatter.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Expectation;
+
+/**
+ * Renders one argument for a failure message: short enough to scan, precise
+ * enough to tell `'1'` from `1`.
+ *
+ * @internal
+ */
+final class ArgumentFormatter
+{
+    private const int MAX_STRING = 40;
+
+    private function __construct() {}
+
+    /**
+     * @return non-empty-string
+     */
+    public static function format(mixed $value): string
+    {
+        $rendered = match (true) {
+            $value === null => 'null',
+            $value === true => 'true',
+            $value === false => 'false',
+            is_int($value), is_float($value) => (string) $value,
+            is_string($value) => self::formatString($value),
+            is_array($value) => self::formatArray($value),
+            $value instanceof \UnitEnum => $value::class . '::' . $value->name,
+            is_object($value) => $value::class,
+            default => get_debug_type($value),
+        };
+        \assert($rendered !== '');
+
+        return $rendered;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function formatString(string $value): string
+    {
+        $escaped = mb_strlen($value) > self::MAX_STRING
+            ? mb_substr($value, 0, self::MAX_STRING) . '…'
+            : $value;
+
+        return "'" . $escaped . "'";
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     *
+     * @return non-empty-string
+     */
+    private static function formatArray(array $value): string
+    {
+        if ($value === []) {
+            return '[]';
+        }
+
+        $isList = array_is_list($value);
+        $parts = [];
+
+        /** @var mixed $item */
+        foreach (array_slice($value, 0, 5, preserve_keys: true) as $key => $item) {
+            $parts[] = $isList
+                ? self::format($item)
+                : self::format($key) . ' => ' . self::format($item);
+        }
+
+        if (count($value) > 5) {
+            $parts[] = '…';
+        }
+
+        return '[' . implode(', ', $parts) . ']';
+    }
+}

--- a/src/Expectation/ComputeAnswer.php
+++ b/src/Expectation/ComputeAnswer.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Expectation;
+
+use Rasuvaeff\Understudy\Invocation;
+
+/**
+ * @internal
+ */
+final readonly class ComputeAnswer implements Action
+{
+    /**
+     * @param callable(Invocation): mixed $answer
+     */
+    public function __construct(private mixed $answer) {}
+
+    #[\Override]
+    public function perform(Invocation $invocation): mixed
+    {
+        return ($this->answer)($invocation);
+    }
+}

--- a/src/Expectation/Expectation.php
+++ b/src/Expectation/Expectation.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Expectation;
+
+use Rasuvaeff\Understudy\Invocation;
+use Rasuvaeff\Understudy\Matcher\ArgumentMatcher;
+
+/**
+ * One configured call: which method with which arguments, and what happens
+ * when it arrives.
+ *
+ * @internal
+ */
+final class Expectation
+{
+    private ?Action $action = null;
+
+    /** @var int<0, max> */
+    private int $matchCount = 0;
+
+    /**
+     * @param non-empty-string $method
+     * @param list<mixed>      $args literal values and/or ArgumentMatcher instances
+     */
+    public function __construct(
+        public readonly string $method,
+        public readonly array $args,
+    ) {}
+
+    public function setAction(Action $action): void
+    {
+        $this->action = $action;
+    }
+
+    public function hasAction(): bool
+    {
+        return $this->action !== null;
+    }
+
+    /**
+     * @param non-empty-string $method
+     * @param list<mixed>      $args
+     */
+    public function matches(string $method, array $args): bool
+    {
+        if ($method !== $this->method || count($args) !== count($this->args)) {
+            return false;
+        }
+
+        /** @var mixed $expected */
+        foreach ($this->args as $position => $expected) {
+            /** @var mixed $actual */
+            $actual = $args[$position];
+
+            $matched = $expected instanceof ArgumentMatcher
+                ? $expected->matches($actual)
+                : $expected === $actual;
+
+            if (!$matched) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function answer(Invocation $invocation): mixed
+    {
+        $this->matchCount++;
+
+        return $this->action?->perform($invocation);
+    }
+
+    /**
+     * @return int<0, max>
+     */
+    public function matchCount(): int
+    {
+        return $this->matchCount;
+    }
+
+    /**
+     * How this expectation reads back in a failure message.
+     *
+     * @return non-empty-string
+     */
+    public function describe(): string
+    {
+        return $this->method . '(' . implode(', ', array_map(
+            static fn(mixed $arg): string => $arg instanceof ArgumentMatcher
+                ? $arg->describe()
+                : ArgumentFormatter::format($arg),
+            $this->args,
+        )) . ')';
+    }
+}

--- a/src/Expectation/ReturnValues.php
+++ b/src/Expectation/ReturnValues.php
@@ -25,10 +25,14 @@ final class ReturnValues implements Action
     #[\Override]
     public function perform(Invocation $invocation): mixed
     {
+        // array_key_exists, not `??`: returns(null, 'x') configures null as
+        // the first answer, and a coalesce would skip straight to the last.
         // Indexed rather than end(), which moves the array pointer and so
         // cannot be applied to a readonly property.
         /** @var mixed $value */
-        $value = $this->values[$this->position] ?? $this->values[count($this->values) - 1];
+        $value = array_key_exists($this->position, $this->values)
+            ? $this->values[$this->position]
+            : $this->values[count($this->values) - 1];
 
         if ($this->position < count($this->values) - 1) {
             $this->position++;

--- a/src/Expectation/ReturnValues.php
+++ b/src/Expectation/ReturnValues.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Expectation;
+
+use Rasuvaeff\Understudy\Invocation;
+
+/**
+ * Returns each value in turn, then repeats the last one — the sequence
+ * semantics Mockery and NSubstitute users already expect.
+ *
+ * @internal
+ */
+final class ReturnValues implements Action
+{
+    /** @var int<0, max> */
+    private int $position = 0;
+
+    /**
+     * @param non-empty-list<mixed> $values
+     */
+    public function __construct(private readonly array $values) {}
+
+    #[\Override]
+    public function perform(Invocation $invocation): mixed
+    {
+        // Indexed rather than end(), which moves the array pointer and so
+        // cannot be applied to a readonly property.
+        /** @var mixed $value */
+        $value = $this->values[$this->position] ?? $this->values[count($this->values) - 1];
+
+        if ($this->position < count($this->values) - 1) {
+            $this->position++;
+        }
+
+        return $value;
+    }
+}

--- a/src/Expectation/ThrowError.php
+++ b/src/Expectation/ThrowError.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Expectation;
+
+use Rasuvaeff\Understudy\Invocation;
+
+/**
+ * @internal
+ */
+final readonly class ThrowError implements Action
+{
+    public function __construct(private \Throwable $error) {}
+
+    #[\Override]
+    public function perform(Invocation $invocation): mixed
+    {
+        throw $this->error;
+    }
+}

--- a/src/FailureReport.php
+++ b/src/FailureReport.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy;
+
+use Rasuvaeff\Understudy\Expectation\ArgumentFormatter;
+use Rasuvaeff\Understudy\Matcher\ArgumentMatcher;
+
+/**
+ * Renders why a verification failed: what was expected, what happened, and —
+ * where the method was called but with other arguments — which argument
+ * differed, marked with asterisks.
+ *
+ * @internal
+ */
+final class FailureReport
+{
+    private function __construct() {}
+
+    /**
+     * @param non-empty-string  $label
+     * @param non-empty-string  $expectation
+     * @param int<0, max>       $expectedLow
+     * @param int<0, max>|null  $expectedHigh
+     * @param int<0, max>       $actual
+     * @param list<Invocation>  $callLog
+     * @param non-empty-string  $method
+     * @param list<mixed>       $expectedArgs
+     */
+    public static function render(
+        string $label,
+        string $expectation,
+        int $expectedLow,
+        ?int $expectedHigh,
+        int $actual,
+        array $callLog,
+        string $method,
+        array $expectedArgs,
+    ): string {
+        $report = sprintf(
+            "Understudy `%s` expected `%s` to be called %s, but %s.",
+            $label,
+            $expectation,
+            self::describeCardinality($expectedLow, $expectedHigh),
+            $actual === 0 ? 'it was never called' : sprintf('it was called %s', self::times($actual)),
+        );
+
+        $sameMethod = array_values(array_filter(
+            $callLog,
+            static fn(Invocation $i): bool => $i->method === $method,
+        ));
+
+        if ($sameMethod !== [] && $actual !== count($sameMethod)) {
+            $report .= sprintf(
+                "\n\nThe following calls to `%s` were made during this test:\n%s",
+                $method,
+                self::renderCallLog($sameMethod, $expectedArgs),
+            );
+        }
+
+        return $report;
+    }
+
+    /**
+     * @param list<Invocation> $callLog
+     * @param list<mixed>      $expectedArgs marked arguments are the ones that differed
+     */
+    public static function renderCallLog(array $callLog, array $expectedArgs = []): string
+    {
+        $lines = [];
+
+        foreach ($callLog as $invocation) {
+            $arguments = [];
+
+            /** @var mixed $argument */
+            foreach ($invocation->args as $position => $argument) {
+                $rendered = ArgumentFormatter::format($argument);
+                $arguments[] = self::differs($expectedArgs, $position, $argument)
+                    ? '*' . $rendered . '*'
+                    : $rendered;
+            }
+
+            $lines[] = sprintf('    %s(%s)', $invocation->method, implode(', ', $arguments));
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param list<mixed> $expectedArgs
+     */
+    private static function differs(array $expectedArgs, int $position, mixed $actual): bool
+    {
+        if (!array_key_exists($position, $expectedArgs)) {
+            return $expectedArgs !== [];
+        }
+
+        /** @var mixed $expected */
+        $expected = $expectedArgs[$position];
+
+        return $expected instanceof ArgumentMatcher
+            ? !$expected->matches($actual)
+            : $expected !== $actual;
+    }
+
+    /**
+     * @param int<0, max>      $low
+     * @param int<0, max>|null $high
+     *
+     * @return non-empty-string
+     */
+    private static function describeCardinality(int $low, ?int $high): string
+    {
+        return match (true) {
+            $low === 0 && $high === 0 => 'never',
+            $high === null => sprintf('at least %s', self::times($low)),
+            $low === $high => sprintf('exactly %s', self::times($low)),
+            default => sprintf('between %d and %s', $low, self::times($high)),
+        };
+    }
+
+    /**
+     * @param int<0, max> $count
+     *
+     * @return non-empty-string
+     */
+    private static function times(int $count): string
+    {
+        return $count === 1 ? '1 time' : $count . ' times';
+    }
+}

--- a/src/Invocation.php
+++ b/src/Invocation.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy;
+
+/**
+ * One recorded call on an understudy.
+ *
+ * Instances are handed to `answers()` callbacks while the call is still in
+ * flight, and read back afterwards through `Understudy::calls()`. The outcome
+ * is therefore filled in once, by the dispatcher, after the answer is known.
+ *
+ * @api
+ */
+final class Invocation
+{
+    private ?Outcome $outcome = null;
+
+    /**
+     * @param non-empty-string $method
+     * @param list<mixed>      $args
+     * @param positive-int     $sequence position in this context's global call order
+     */
+    public function __construct(
+        public readonly string $method,
+        public readonly array $args,
+        public readonly int $sequence,
+        public readonly ?string $file = null,
+        public readonly ?int $line = null,
+    ) {}
+
+    /**
+     * @internal called once by the dispatcher when the call finishes
+     */
+    public function recordOutcome(Outcome $outcome): void
+    {
+        $this->outcome ??= $outcome;
+    }
+
+    public function didReturn(): bool
+    {
+        return $this->outcome?->didReturn() ?? false;
+    }
+
+    public function didThrow(): bool
+    {
+        return $this->outcome?->didThrow() ?? false;
+    }
+
+    public function returned(): mixed
+    {
+        return $this->outcome?->returned($this->method);
+    }
+
+    public function thrown(): ?\Throwable
+    {
+        return $this->outcome?->thrown();
+    }
+}

--- a/src/Matcher/AnyArgument.php
+++ b/src/Matcher/AnyArgument.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Matcher;
+
+/**
+ * @internal
+ */
+final readonly class AnyArgument implements ArgumentMatcher
+{
+    #[\Override]
+    public function matches(mixed $argument): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function describe(): string
+    {
+        return 'any()';
+    }
+}

--- a/src/Matcher/ArgumentMatcher.php
+++ b/src/Matcher/ArgumentMatcher.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Matcher;
+
+/**
+ * Widening every generated parameter with this type is what lets a matcher be
+ * passed where the contract declares `int`. It is part of the call protocol,
+ * not a value the code under test may ever see: reaching a normal invocation
+ * is misuse and fails rather than being treated as an argument.
+ *
+ * @internal
+ */
+interface ArgumentMatcher
+{
+    public function matches(mixed $argument): bool;
+
+    /**
+     * Rendered into failure messages in place of the argument, e.g. `any()`.
+     *
+     * @return non-empty-string
+     */
+    public function describe(): string;
+}

--- a/src/Outcome.php
+++ b/src/Outcome.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy;
+
+use Rasuvaeff\Understudy\Exception\OutcomeUnavailable;
+
+/**
+ * How one call ended: with a value or with a throwable. Kept as its own type
+ * because `null` is a perfectly valid return value and cannot double as
+ * "nothing was returned".
+ *
+ * @api
+ */
+final readonly class Outcome
+{
+    private function __construct(
+        private bool $returned,
+        private mixed $value,
+        private ?\Throwable $thrown,
+    ) {}
+
+    public static function returnedValue(mixed $value): self
+    {
+        return new self(returned: true, value: $value, thrown: null);
+    }
+
+    public static function thrownError(\Throwable $thrown): self
+    {
+        return new self(returned: false, value: null, thrown: $thrown);
+    }
+
+    public function didReturn(): bool
+    {
+        return $this->returned;
+    }
+
+    public function didThrow(): bool
+    {
+        return !$this->returned;
+    }
+
+    /**
+     * @param non-empty-string $method used only to render a helpful message
+     */
+    public function returned(string $method): mixed
+    {
+        if (!$this->returned) {
+            \assert($this->thrown !== null);
+
+            throw OutcomeUnavailable::threwInstead($method, $this->thrown);
+        }
+
+        return $this->value;
+    }
+
+    public function thrown(): ?\Throwable
+    {
+        return $this->thrown;
+    }
+}

--- a/src/Runtime/DoubleState.php
+++ b/src/Runtime/DoubleState.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Runtime;
+
+use Rasuvaeff\Understudy\Codegen\Blueprint;
+use Rasuvaeff\Understudy\Expectation\Expectation;
+use Rasuvaeff\Understudy\Invocation;
+
+/**
+ * Everything one understudy carries. It lives here rather than on the double
+ * itself: a double must expose no member beyond the contract it stands in for.
+ *
+ * @internal
+ */
+final class DoubleState
+{
+    /** @var list<Expectation> */
+    private array $expectations = [];
+
+    /** @var list<Invocation> */
+    private array $callLog = [];
+
+    /** @var non-empty-string|null */
+    private ?string $label = null;
+
+    public function __construct(
+        public readonly Blueprint $blueprint,
+        private Mode $mode = Mode::Loose,
+    ) {}
+
+    public function mode(): Mode
+    {
+        return $this->mode;
+    }
+
+    public function setMode(Mode $mode): void
+    {
+        $this->mode = $mode;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function label(): string
+    {
+        return $this->label ?? $this->blueprint->displayName();
+    }
+
+    /**
+     * @param non-empty-string $label
+     */
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
+    }
+
+    public function addExpectation(Expectation $expectation): void
+    {
+        $this->expectations[] = $expectation;
+    }
+
+    /**
+     * Most recently registered first: a later `when()` for the same call
+     * overrides an earlier one, and earlier ones stay reachable as fallbacks.
+     *
+     * @return list<Expectation>
+     */
+    public function expectations(): array
+    {
+        return array_reverse($this->expectations);
+    }
+
+    public function record(Invocation $invocation): void
+    {
+        $this->callLog[] = $invocation;
+    }
+
+    /**
+     * @return list<Invocation>
+     */
+    public function callLog(): array
+    {
+        return $this->callLog;
+    }
+}

--- a/src/Runtime/InvocationSignal.php
+++ b/src/Runtime/InvocationSignal.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Runtime;
+
+/**
+ * Thrown by a generated method during a recording phase so that the call
+ * aborts before it has to produce a value. Throwing is what lets a method
+ * declared `: ?Book` — or even `: never` — hand its name and arguments back
+ * to `when()` without violating its own return type.
+ *
+ * Never escapes the library: `when()`/`expect()`/`verify()` catch it.
+ *
+ * @internal
+ */
+final class InvocationSignal extends \Exception
+{
+    /**
+     * @param non-empty-string $method
+     * @param list<mixed>      $args
+     */
+    public function __construct(
+        public readonly object $double,
+        public readonly string $method,
+        public readonly array $args,
+    ) {
+        parent::__construct('understudy recording signal');
+    }
+}

--- a/src/Runtime/Mode.php
+++ b/src/Runtime/Mode.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Runtime;
+
+/**
+ * How an understudy answers a call no expectation matched.
+ *
+ * @api
+ */
+enum Mode
+{
+    /** Answer with a type-safe default. */
+    case Loose;
+
+    /** Fail immediately, naming the method. */
+    case Strict;
+}

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rasuvaeff\Understudy\Runtime;
 
 use Rasuvaeff\Understudy\Defaults\TypeDefaultResolver;
+use Rasuvaeff\Understudy\Exception\ForgottenDouble;
 use Rasuvaeff\Understudy\Exception\NeverMethodCalled;
 use Rasuvaeff\Understudy\Exception\StrictModeViolation;
 use Rasuvaeff\Understudy\Invocation;
@@ -112,18 +113,21 @@ final class Runtime
      */
     public static function dispatch(object $double, string $method, array $args): mixed
     {
-        $context = self::ownerOf($double) ?? self::current();
-
-        if ($context->isRecording()) {
+        // Recording is a property of the caller, not of the double: when()
+        // opens the phase in whichever context it runs in, and a double
+        // created elsewhere must still signal instead of being treated as a
+        // real call.
+        if (self::current()->isRecording()) {
             throw new InvocationSignal($double, $method, $args);
         }
 
+        $context = self::ownerOf($double) ?? self::current();
         $state = $context->stateOf($double);
 
         if ($state === null) {
-            // Only reachable if a double outlived a reset(); treat it as loose
-            // with no configuration rather than corrupting another context.
-            return null;
+            // Returning null here would violate the declared return type of
+            // any non-nullable method, so say what actually happened.
+            throw ForgottenDouble::afterReset($method);
         }
 
         $invocation = new Invocation($method, $args, $context->nextSequence());
@@ -148,13 +152,25 @@ final class Runtime
      */
     private static function answer(DoubleState $state, string $method, Invocation $invocation): mixed
     {
-        foreach ($state->expectations() as $expectation) {
-            if ($expectation->matches($method, $invocation->args)) {
-                return $expectation->answer($invocation);
-            }
-        }
-
         $signature = $state->blueprint->method($method);
+
+        foreach ($state->expectations() as $expectation) {
+            if (!$expectation->matches($method, $invocation->args)) {
+                continue;
+            }
+
+            /** @var mixed $answer */
+            $answer = $expectation->answer($invocation);
+
+            if ($signature !== null && $signature->returnsNever) {
+                // The expectation returned instead of throwing; returning from
+                // a `: never` method is a TypeError by language rule, so name
+                // the real mistake rather than leaking that.
+                throw NeverMethodCalled::configuredToReturn($state->label(), $method);
+            }
+
+            return $answer;
+        }
 
         if ($signature !== null && $signature->returnsNever) {
             throw NeverMethodCalled::withoutExpectation($state->label(), $method);

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Runtime;
+
+use Rasuvaeff\Understudy\Defaults\TypeDefaultResolver;
+use Rasuvaeff\Understudy\Exception\NeverMethodCalled;
+use Rasuvaeff\Understudy\Exception\StrictModeViolation;
+use Rasuvaeff\Understudy\Invocation;
+use Rasuvaeff\Understudy\Outcome;
+
+/**
+ * The registry generated doubles call into, and the owner of every context.
+ *
+ * @internal
+ */
+final class Runtime
+{
+    private static ?RuntimeContext $main = null;
+
+    /** @var \WeakMap<\Fiber, RuntimeContext>|null */
+    private static ?\WeakMap $fibers = null;
+
+    /**
+     * Keyed by the double object, never by `spl_object_id()`, which PHP reuses
+     * after collection. Routes a call made inside a Fiber back to the context
+     * that created the double.
+     *
+     * @var \WeakMap<object, RuntimeContext>|null
+     */
+    private static ?\WeakMap $owners = null;
+
+    public static function current(): RuntimeContext
+    {
+        $fiber = \Fiber::getCurrent();
+
+        if ($fiber === null) {
+            return self::$main ??= new RuntimeContext();
+        }
+
+        $fibers = self::fibers();
+
+        if (!$fibers->offsetExists($fiber)) {
+            $context = new RuntimeContext();
+            $fibers->offsetSet($fiber, $context);
+
+            return $context;
+        }
+
+        // WeakMap::offsetGet() is typed as nullable regardless of the value
+        // type, and offsetExists() above has already ruled that out.
+        /** @var RuntimeContext $context */
+        $context = $fibers->offsetGet($fiber);
+
+        return $context;
+    }
+
+    public static function adopt(object $double, DoubleState $state): void
+    {
+        $context = self::current();
+        $context->register($double, $state);
+
+        self::owners()->offsetSet($double, $context);
+    }
+
+    public static function ownerOf(object $double): ?RuntimeContext
+    {
+        $owners = self::owners();
+
+        return $owners->offsetExists($double) ? $owners->offsetGet($double) : null;
+    }
+
+    /**
+     * @return \WeakMap<\Fiber, RuntimeContext>
+     */
+    private static function fibers(): \WeakMap
+    {
+        if (self::$fibers === null) {
+            /** @var \WeakMap<\Fiber, RuntimeContext> $fibers */
+            $fibers = new \WeakMap();
+            self::$fibers = $fibers;
+        }
+
+        return self::$fibers;
+    }
+
+    /**
+     * @return \WeakMap<object, RuntimeContext>
+     */
+    private static function owners(): \WeakMap
+    {
+        if (self::$owners === null) {
+            /** @var \WeakMap<object, RuntimeContext> $owners */
+            $owners = new \WeakMap();
+            self::$owners = $owners;
+        }
+
+        return self::$owners;
+    }
+
+    public static function stateOf(object $double): ?DoubleState
+    {
+        return self::ownerOf($double)?->stateOf($double);
+    }
+
+    /**
+     * Entry point of every generated method.
+     *
+     * @param non-empty-string $method
+     * @param list<mixed>      $args
+     */
+    public static function dispatch(object $double, string $method, array $args): mixed
+    {
+        $context = self::ownerOf($double) ?? self::current();
+
+        if ($context->isRecording()) {
+            throw new InvocationSignal($double, $method, $args);
+        }
+
+        $state = $context->stateOf($double);
+
+        if ($state === null) {
+            // Only reachable if a double outlived a reset(); treat it as loose
+            // with no configuration rather than corrupting another context.
+            return null;
+        }
+
+        $invocation = new Invocation($method, $args, $context->nextSequence());
+        $state->record($invocation);
+
+        try {
+            /** @var mixed $value */
+            $value = self::answer($state, $method, $invocation);
+        } catch (\Throwable $thrown) {
+            $invocation->recordOutcome(Outcome::thrownError($thrown));
+
+            throw $thrown;
+        }
+
+        $invocation->recordOutcome(Outcome::returnedValue($value));
+
+        return $value;
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    private static function answer(DoubleState $state, string $method, Invocation $invocation): mixed
+    {
+        foreach ($state->expectations() as $expectation) {
+            if ($expectation->matches($method, $invocation->args)) {
+                return $expectation->answer($invocation);
+            }
+        }
+
+        $signature = $state->blueprint->method($method);
+
+        if ($signature !== null && $signature->returnsNever) {
+            throw NeverMethodCalled::withoutExpectation($state->label(), $method);
+        }
+
+        if ($state->mode() === Mode::Strict) {
+            throw StrictModeViolation::unexpectedCall($state->label(), $method);
+        }
+
+        return TypeDefaultResolver::forSignature($state->label(), $signature, $method);
+    }
+
+    /**
+     * Drops every context. Adapters call this unconditionally after each test.
+     */
+    public static function reset(): void
+    {
+        self::$main = null;
+        self::$fibers = null;
+        self::$owners = null;
+    }
+}

--- a/src/Runtime/RuntimeContext.php
+++ b/src/Runtime/RuntimeContext.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Runtime;
+
+use Rasuvaeff\Understudy\Invocation;
+
+/**
+ * One test's worth of state. The main flow and each Fiber own a separate
+ * context, so sibling fibers never share a recording phase, a call log or a
+ * sequence counter.
+ *
+ * @internal
+ */
+final class RuntimeContext
+{
+    /**
+     * Depth, not a boolean: a nested recording phase must not switch the
+     * enclosing one off when it unwinds.
+     *
+     * @var int<0, max>
+     */
+    private int $recordingDepth = 0;
+
+    /** @var \SplObjectStorage<object, DoubleState> */
+    private \SplObjectStorage $doubles;
+
+    /** @var int<0, max> */
+    private int $sequence = 0;
+
+    public function __construct()
+    {
+        /** @var \SplObjectStorage<object, DoubleState> $doubles */
+        $doubles = new \SplObjectStorage();
+        $this->doubles = $doubles;
+    }
+
+    public function isRecording(): bool
+    {
+        return $this->recordingDepth > 0;
+    }
+
+    public function beginRecording(): void
+    {
+        $this->recordingDepth++;
+    }
+
+    public function endRecording(): void
+    {
+        if ($this->recordingDepth > 0) {
+            $this->recordingDepth--;
+        }
+    }
+
+    public function register(object $double, DoubleState $state): void
+    {
+        $this->doubles[$double] = $state;
+    }
+
+    public function knows(object $double): bool
+    {
+        return isset($this->doubles[$double]);
+    }
+
+    public function stateOf(object $double): ?DoubleState
+    {
+        return $this->doubles[$double] ?? null;
+    }
+
+    /**
+     * @return list<DoubleState>
+     */
+    public function allStates(): array
+    {
+        $states = [];
+
+        foreach ($this->doubles as $double) {
+            $states[] = $this->doubles[$double];
+        }
+
+        return $states;
+    }
+
+    /**
+     * @return positive-int
+     */
+    public function nextSequence(): int
+    {
+        return ++$this->sequence;
+    }
+
+    /**
+     * Every call on every understudy of this context, in the order they
+     * happened. Verifying a sequence needs one order across doubles, so the
+     * ordering lives here rather than in each DoubleState.
+     *
+     * @return list<Invocation>
+     */
+    public function globalLog(): array
+    {
+        $log = [];
+
+        foreach ($this->allStates() as $state) {
+            foreach ($state->callLog() as $invocation) {
+                $log[] = $invocation;
+            }
+        }
+
+        usort($log, static fn(Invocation $a, Invocation $b): int => $a->sequence <=> $b->sequence);
+
+        return $log;
+    }
+}

--- a/src/Understudy.php
+++ b/src/Understudy.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy;
+
+use Rasuvaeff\Understudy\Codegen\DoubleFactory;
+use Rasuvaeff\Understudy\Exception\InvalidCallSpecification;
+use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Expectation\Expectation;
+use Rasuvaeff\Understudy\Runtime\DoubleState;
+use Rasuvaeff\Understudy\Runtime\InvocationSignal;
+use Rasuvaeff\Understudy\Runtime\Mode;
+use Rasuvaeff\Understudy\Runtime\Runtime;
+
+/**
+ * The whole public surface, as static methods so that an understudy itself can
+ * stay free of service members: every one of them would be a name the doubled
+ * contract can no longer use.
+ *
+ * The same three verbs exist as free functions in this namespace — see
+ * `functions.php` — and read better in tests. This class is the collision-free
+ * form, which matters in Pest, where `expect()` is already taken.
+ *
+ * @api
+ */
+final class Understudy
+{
+    private function __construct() {}
+
+    /**
+     * Creates an understudy for one contract, optionally combined with further
+     * interfaces.
+     *
+     * @template T of object
+     *
+     * @param class-string<T> $target
+     * @param class-string    ...$interfaces
+     *
+     * @return T
+     */
+    public static function for(string $target, string ...$interfaces): object
+    {
+        $contracts = [$target, ...array_values($interfaces)];
+        $blueprint = DoubleFactory::blueprintFor($contracts);
+        // Reflection rather than `new $class()`: the generated class is not
+        // statically known, and this is also the path a class double will need,
+        // where the target's constructor must be skipped rather than run.
+        /** @var T $double */
+        $double = (new \ReflectionClass($blueprint->generatedClass))->newInstanceWithoutConstructor();
+
+        Runtime::adopt($double, new DoubleState($blueprint));
+
+        return $double;
+    }
+
+    /**
+     * Stubs a call: allowed any number of times, including none.
+     *
+     * @param callable(): mixed $call
+     *
+     * @return WhenBuilder<mixed>
+     */
+    public static function when(callable $call): WhenBuilder
+    {
+        $signal = self::record($call);
+        $expectation = new Expectation($signal->method, $signal->args);
+
+        self::stateOf($signal->double)->addExpectation($expectation);
+
+        return new WhenBuilder($expectation);
+    }
+
+    /**
+     * Asserts, after the fact, how many times a call was made.
+     *
+     * @param callable(): mixed $call
+     * @param int<0, max>|null  $times   exact count; defaults to at least one
+     * @param int<0, max>|null  $minimum
+     * @param int<0, max>|null  $maximum
+     */
+    public static function verify(
+        callable $call,
+        ?int $times = null,
+        ?int $minimum = null,
+        ?int $maximum = null,
+        bool $never = false,
+    ): void {
+        $signal = self::record($call);
+        $state = self::stateOf($signal->double);
+        $probe = new Expectation($signal->method, $signal->args);
+
+        $matches = 0;
+
+        foreach ($state->callLog() as $invocation) {
+            if ($probe->matches($invocation->method, $invocation->args)) {
+                $matches++;
+            }
+        }
+
+        [$low, $high] = match (true) {
+            $never => [0, 0],
+            $times !== null => [$times, $times],
+            default => [$minimum ?? 1, $maximum],
+        };
+
+        if ($matches >= $low && ($high === null || $matches <= $high)) {
+            return;
+        }
+
+        throw VerificationFailed::withReport(FailureReport::render(
+            label: $state->label(),
+            expectation: $probe->describe(),
+            expectedLow: $low,
+            expectedHigh: $high,
+            actual: $matches,
+            callLog: $state->callLog(),
+            method: $signal->method,
+            expectedArgs: $signal->args,
+        ));
+    }
+
+    /**
+     * Every recorded call matching the specification, in order.
+     *
+     * @param callable(): mixed $call
+     *
+     * @return list<Invocation>
+     */
+    public static function calls(callable $call): array
+    {
+        $signal = self::record($call);
+        $probe = new Expectation($signal->method, $signal->args);
+
+        return array_values(array_filter(
+            self::stateOf($signal->double)->callLog(),
+            static fn(Invocation $i): bool => $probe->matches($i->method, $i->args),
+        ));
+    }
+
+    /**
+     * Makes an understudy fail on any call no expectation matched.
+     */
+    public static function strict(object $double): void
+    {
+        self::stateOf($double)->setMode(Mode::Strict);
+    }
+
+    /**
+     * Names one understudy in failure messages, which is what makes two
+     * doubles of the same contract tellable apart.
+     *
+     * @param non-empty-string $label
+     */
+    public static function label(object $double, string $label): void
+    {
+        self::stateOf($double)->setLabel($label);
+    }
+
+    /**
+     * Asserts that nothing was called on this understudy at all.
+     */
+    public static function unused(object $double): void
+    {
+        $state = self::stateOf($double);
+        $log = $state->callLog();
+
+        if ($log === []) {
+            return;
+        }
+
+        throw VerificationFailed::withReport(sprintf(
+            "Understudy `%s` was expected to be unused, but received %d call(s):\n%s",
+            $state->label(),
+            count($log),
+            FailureReport::renderCallLog($log),
+        ));
+    }
+
+    /**
+     * Drops every context. Adapters call this after each test, unconditionally.
+     */
+    public static function reset(): void
+    {
+        Runtime::reset();
+    }
+
+    /**
+     * Runs the specification closure with recording on, and catches the signal
+     * the called method throws instead of returning.
+     */
+    private static function record(callable $call): InvocationSignal
+    {
+        $context = Runtime::current();
+        $context->beginRecording();
+
+        try {
+            $call();
+        } catch (InvocationSignal $signal) {
+            return $signal;
+        } catch (\Throwable $failure) {
+            throw InvalidCallSpecification::closureFailed($failure);
+        } finally {
+            $context->endRecording();
+        }
+
+        throw InvalidCallSpecification::noCallRecorded();
+    }
+
+    private static function stateOf(object $double): DoubleState
+    {
+        $state = Runtime::stateOf($double);
+
+        if ($state === null) {
+            throw InvalidCallSpecification::noCallRecorded();
+        }
+
+        return $state;
+    }
+}

--- a/src/WhenBuilder.php
+++ b/src/WhenBuilder.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy;
+
+use Rasuvaeff\Understudy\Expectation\ComputeAnswer;
+use Rasuvaeff\Understudy\Expectation\Expectation;
+use Rasuvaeff\Understudy\Expectation\ReturnValues;
+use Rasuvaeff\Understudy\Expectation\ThrowError;
+
+/**
+ * Configures what a stubbed call does.
+ *
+ * `TReturn` is the return type of the specified method. Plain Psalm and
+ * PHPStan cannot infer it from the closure on their own — `understudy-psalm`
+ * fills it in, and until then the parameter stays `mixed`, which is why the
+ * template is declared here rather than added later: a published signature
+ * cannot grow one without changing its contract.
+ *
+ * @template TReturn
+ *
+ * @api
+ */
+final readonly class WhenBuilder
+{
+    /**
+     * @internal
+     */
+    public function __construct(private Expectation $expectation) {}
+
+    /**
+     * Returns each value in turn across successive calls, then keeps returning
+     * the last one.
+     *
+     * @param TReturn ...$values
+     */
+    public function returns(mixed ...$values): self
+    {
+        $list = array_values($values);
+
+        if ($list === []) {
+            throw new \InvalidArgumentException('returns() needs at least one value');
+        }
+
+        $this->expectation->setAction(new ReturnValues($list));
+
+        return $this;
+    }
+
+    public function throws(\Throwable $error): self
+    {
+        $this->expectation->setAction(new ThrowError($error));
+
+        return $this;
+    }
+
+    /**
+     * @param callable(Invocation): TReturn $answer
+     */
+    public function answers(callable $answer): self
+    {
+        $this->expectation->setAction(new ComputeAnswer($answer));
+
+        return $this;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy;
+
+/**
+ * Stubs a call: allowed any number of times, including none.
+ *
+ * ```php
+ * when(fn () => $repository->find(123))->returns($book);
+ * ```
+ *
+ * @param callable(): mixed $call
+ *
+ * @return WhenBuilder<mixed>
+ *
+ * @api
+ */
+function when(callable $call): WhenBuilder
+{
+    return Understudy::when($call);
+}
+
+/**
+ * Asserts, after the fact, how many times a call was made.
+ *
+ * ```php
+ * verify(fn () => $repository->recordView($book), times: 2);
+ * ```
+ *
+ * @param callable(): mixed $call
+ * @param int<0, max>|null  $times
+ * @param int<0, max>|null  $minimum
+ * @param int<0, max>|null  $maximum
+ *
+ * @api
+ */
+function verify(
+    callable $call,
+    ?int $times = null,
+    ?int $minimum = null,
+    ?int $maximum = null,
+    bool $never = false,
+): void {
+    Understudy::verify($call, $times, $minimum, $maximum, $never);
+}

--- a/testo.php
+++ b/testo.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\SuiteConfig;
+
+return new ApplicationConfig(
+    src: ['src'],
+    suites: [
+        new SuiteConfig(
+            name: 'Unit',
+            location: ['tests'],
+        ),
+        new SuiteConfig(
+            name: 'Benchmarks',
+            location: ['benchmarks'],
+        ),
+    ],
+);

--- a/tests/Codegen/TargetUnifierTest.php
+++ b/tests/Codegen/TargetUnifierTest.php
@@ -12,12 +12,16 @@ use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArityOne;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArityTwo;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\FeederByRef;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\FeederByValue;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\FixedArityTwo;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\NullableParam;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderInt;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderString;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderStringy;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\Showcase;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SlotsByRef;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SlotsByValue;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\VariadicShapes;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\VariadicShapesToo;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\WriterInt;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\WriterIntToo;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\WriterString;
@@ -170,6 +174,47 @@ final class TargetUnifierTest
             $signature->parameters,
             'int|' . self::MATCHER . ' $a, int|' . self::MATCHER . '|null $b = null',
         );
+    }
+
+    public function aVariadicAbsorbsALongerTargetsFixedParameters(): void
+    {
+        // `tail(int, string...)` and `tail(int, string)` are compatible: a
+        // variadic accepts any number of arguments. Rendering the second
+        // target's fixed parameter after `...$rest` would be a parse error.
+        $signature = self::unify(NullableParam::class, FixedArityTwo::class)['tail'];
+
+        Assert::same(substr_count($signature->parameters, '...'), 1);
+        Assert::true(str_ends_with($signature->parameters, '...$rest'));
+        Assert::same($signature->arguments, '[$first, ...$rest]');
+    }
+
+    public function aVariadicTailKeepsItsByReferenceMarker(): void
+    {
+        $signature = self::unify(VariadicShapes::class)['byRefTail'];
+
+        Assert::true(str_contains($signature->parameters, '&...$slots'));
+        Assert::same($signature->arguments, '[...$slots]');
+    }
+
+    public function anUntypedVariadicTailStaysUntyped(): void
+    {
+        // Nothing to union onto: every value is already allowed.
+        Assert::same(self::unify(VariadicShapes::class)['untypedTail']->parameters, '...$anything');
+    }
+
+    public function aVariadicTailUnionsEveryTargetsElementType(): void
+    {
+        $signature = self::unify(VariadicShapes::class, VariadicShapesToo::class)['intTail'];
+
+        Assert::string($signature->parameters)->contains('int|string|');
+        Assert::true(str_ends_with($signature->parameters, '...$numbers'));
+    }
+
+    public function aVariadicTailCarriesTheMatcherBranchOnce(): void
+    {
+        $signature = self::unify(VariadicShapes::class)['intTail'];
+
+        Assert::same(substr_count($signature->parameters, self::MATCHER), 1);
     }
 
     public function divergentReturnTypesAreRejected(): void

--- a/tests/Codegen/TargetUnifierTest.php
+++ b/tests/Codegen/TargetUnifierTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Codegen;
+
+use Rasuvaeff\Understudy\Codegen\MethodSignature;
+use Rasuvaeff\Understudy\Codegen\TargetUnifier;
+use Rasuvaeff\Understudy\Codegen\TypeRenderer;
+use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArityOne;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArityTwo;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\FeederByRef;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\FeederByValue;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderInt;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderString;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderStringy;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\Showcase;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\SlotsByRef;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\SlotsByValue;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\WriterInt;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\WriterIntToo;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\WriterString;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Data\DataProvider;
+use Testo\Expect;
+use Testo\Test;
+
+#[Test]
+#[Covers(TargetUnifier::class)]
+final class TargetUnifierTest
+{
+    private const string MATCHER = TypeRenderer::MATCHER;
+
+    // --- Rendered signatures -------------------------------------------------
+
+    #[DataProvider('parameterProvider')]
+    public function rendersTheOverrideParameters(string $method, string $expected): void
+    {
+        Assert::same($this->showcase($method)->parameters, $expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function parameterProvider(): iterable
+    {
+        $m = self::MATCHER;
+
+        yield 'no parameters render an empty list' => ['noParams', ''];
+        yield 'scalar gains the matcher branch' => ['scalar', "int|{$m} \$a"];
+        // The matcher goes after the contract's own branches, and `null` is
+        // part of the type rather than an implicit nullable default.
+        yield 'nullable expands then widens' => ['nullable', "string|null|{$m} \$a"];
+        yield 'a declared default is preserved' => ['withDefault', "int|{$m} \$a = 7"];
+        yield 'a null default renders lowercase' => ['withNullDefault', "int|null|{$m} \$a = null"];
+        yield 'variadic carries no default' => ['variadic', "string|{$m} ...\$rest"];
+        yield 'variadic follows a fixed parameter' => [
+            'scalarThenVariadic',
+            "int|{$m} \$first, string|{$m} ...\$rest",
+        ];
+        yield 'by-reference keeps its ampersand' => ['byReference', "array|{$m} &\$slot"];
+        // Nothing to union onto: an untyped parameter already accepts a matcher.
+        yield 'untyped stays untyped' => ['untyped', '$a'];
+        yield 'intersection is parenthesised for DNF' => [
+            'intersection',
+            '(\\' . ReaderInt::class . '&\\' . ReaderStringy::class . ")|{$m} \$a",
+        ];
+        yield 'mixed is not widened' => ['anything', 'mixed $a'];
+        yield 'object is not widened' => ['anyObject', 'object $a'];
+    }
+
+    #[DataProvider('argumentProvider')]
+    public function collectsArgumentsByName(string $method, string $expected): void
+    {
+        // func_get_args() would omit an argument left at its default, so
+        // `withDefault()` and `withDefault(7)` would log as different calls.
+        Assert::same($this->showcase($method)->arguments, $expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function argumentProvider(): iterable
+    {
+        yield 'no parameters' => ['noParams', '[]'];
+        yield 'one parameter' => ['scalar', '[$a]'];
+        yield 'defaulted parameter is still collected' => ['withDefault', '[$a]'];
+        yield 'variadic is spread' => ['variadic', '[...$rest]'];
+        yield 'fixed then variadic' => ['scalarThenVariadic', '[$first, ...$rest]'];
+        yield 'by-reference parameter' => ['byReference', '[$slot]'];
+    }
+
+    #[DataProvider('returnProvider')]
+    public function recordsTheReturnShape(
+        string $method,
+        string $returnType,
+        bool $never,
+        bool $void,
+        bool $reference,
+    ): void {
+        $signature = $this->showcase($method);
+
+        Assert::same($signature->returnType, $returnType);
+        Assert::same($signature->returnsNever, $never);
+        Assert::same($signature->returnsVoid, $void);
+        Assert::same($signature->returnsReference, $reference);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, bool, bool, bool}>
+     */
+    public static function returnProvider(): iterable
+    {
+        yield 'value' => ['noParams', 'int', false, false, false];
+        yield 'void' => ['scalar', 'void', false, true, false];
+        yield 'never' => ['goesAway', 'never', true, false, false];
+        yield 'by reference' => ['returnsReference', 'array', false, false, true];
+    }
+
+    public function methodNameIsCarriedThrough(): void
+    {
+        Assert::same($this->showcase('scalar')->name, 'scalar');
+    }
+
+    public function staticMethodsAreNotIntercepted(): void
+    {
+        // A static method has no instance state for a double to stand in for.
+        $signatures = TargetUnifier::unify([new \ReflectionClass(WriterInt::class)]);
+
+        Assert::false(array_key_exists('describe', $signatures));
+        Assert::true(array_key_exists('write', $signatures));
+    }
+
+    public function everyContractMethodIsUnified(): void
+    {
+        $signatures = TargetUnifier::unify([new \ReflectionClass(ArityOne::class)]);
+
+        Assert::same(count($signatures), 2);
+    }
+
+    // --- Unification across several targets ----------------------------------
+
+    public function contravariantParametersUnifyIntoAUnion(): void
+    {
+        // `write(int)` and `write(string)` do share an implementation —
+        // `write(int|string)` — so refusing them on signature difference would
+        // reject a pair PHP accepts.
+        $signature = $this->unify(WriterInt::class, WriterString::class)['write'];
+
+        Assert::same($signature->parameters, 'int|string|' . self::MATCHER . ' $chunk');
+    }
+
+    public function identicalDeclarationsUnifyToThemselves(): void
+    {
+        $signature = $this->unify(WriterInt::class, WriterIntToo::class)['write'];
+
+        Assert::same($signature->parameters, 'int|' . self::MATCHER . ' $chunk');
+    }
+
+    public function aParameterMissingFromOneTargetBecomesOptional(): void
+    {
+        // A caller reaching the double through ArityOne passes one argument,
+        // so the second must be optional — and `null` has to join the type,
+        // since an implicitly nullable parameter is deprecated.
+        $signature = $this->unify(ArityOne::class, ArityTwo::class)['emit'];
+
+        Assert::same(
+            $signature->parameters,
+            'int|' . self::MATCHER . ' $a, int|' . self::MATCHER . '|null $b = null',
+        );
+    }
+
+    public function divergentReturnTypesAreRejected(): void
+    {
+        // Return types are covariant: `int` and `string` share no subtype, so
+        // no class can implement both. The message is asserted whole — naming
+        // each target beside the type it declares is the whole value of it.
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `read()` has no implementation that satisfies all of them.\n"
+            . '  `' . ReaderInt::class . "::read()` declares `: int`\n"
+            . '  `' . ReaderString::class . '::read()` declares `: string`',
+        );
+
+        $this->unify(ReaderInt::class, ReaderString::class);
+    }
+
+    public function byReferenceMismatchIsRejected(): void
+    {
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `feed()` has no implementation that satisfies all of them.\n"
+            . '  `' . FeederByRef::class . "::feed()` takes parameter #1 by reference\n"
+            . '  `' . FeederByValue::class . '::feed()` takes it by value',
+        );
+
+        $this->unify(FeederByRef::class, FeederByValue::class);
+    }
+
+    public function returnByReferenceMismatchIsRejected(): void
+    {
+        // Returning by reference is part of the signature too: a class cannot
+        // satisfy one target that returns a reference and another that does not.
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `slots()` has no implementation that satisfies all of them.\n"
+            . '  `' . SlotsByRef::class . "::slots()` returns by reference\n"
+            . '  `' . SlotsByValue::class . '::slots()` returns by value',
+        );
+
+        $this->unify(SlotsByRef::class, SlotsByValue::class);
+    }
+
+    public function conflictsAreReportedPerMethodNotPerTargetPair(): void
+    {
+        // The first incompatible method aborts generation: a partially
+        // generated class would be worse than a clear refusal.
+        Expect::exception(UnsupportedTarget::class)->withMessageContaining('read()');
+
+        $this->unify(ReaderInt::class, ReaderString::class, FeederByRef::class);
+    }
+
+    /**
+     * @return array<non-empty-string, MethodSignature>
+     */
+    private function unify(string ...$contracts): array
+    {
+        return TargetUnifier::unify(array_map(
+            static fn(string $contract): \ReflectionClass => new \ReflectionClass($contract),
+            array_values($contracts),
+        ));
+    }
+
+    private function showcase(string $method): MethodSignature
+    {
+        $signature = TargetUnifier::unify([new \ReflectionClass(Showcase::class)])[$method] ?? null;
+
+        Assert::instanceOf($signature, MethodSignature::class);
+
+        return $signature;
+    }
+}

--- a/tests/Codegen/TypeRendererTest.php
+++ b/tests/Codegen/TypeRendererTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Codegen;
+
+use Rasuvaeff\Understudy\Codegen\TypeRenderer;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\TypeShowcase;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Data\DataProvider;
+use Testo\Test;
+
+#[Test]
+#[Covers(TypeRenderer::class)]
+final class TypeRendererTest
+{
+    #[DataProvider('parameterProvider')]
+    public function rendersTheContractsOwnParameterType(string $method, string $expected): void
+    {
+        Assert::same(TypeRenderer::parameterType($this->typeOf($method)), $expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function parameterProvider(): iterable
+    {
+        yield 'scalar' => ['scalar', 'int'];
+        // `?int` is expanded so that a matcher branch can be appended to it.
+        yield 'nullable expands to a union' => ['nullable', 'int|null'];
+        yield 'mixed' => ['anything', 'mixed'];
+        yield 'object' => ['anyObject', 'object'];
+        yield 'untyped renders empty' => ['untyped', ''];
+    }
+
+    public function unionKeepsEveryBranch(): void
+    {
+        // Reflection reports its own canonical order, so assert the set.
+        $rendered = TypeRenderer::parameterType($this->typeOf('union'));
+
+        Assert::same(count(explode('|', $rendered)), 2);
+        Assert::string($rendered)->contains('int');
+        Assert::string($rendered)->contains('string');
+    }
+
+    public function intersectionIsParenthesisedForDnf(): void
+    {
+        // A union may only contain an intersection in parentheses, and a
+        // matcher branch will be appended to exactly this rendering.
+        $rendered = TypeRenderer::parameterType($this->typeOf('intersection'));
+
+        Assert::true(str_starts_with($rendered, '('));
+        Assert::true(str_ends_with($rendered, ')'));
+        Assert::string($rendered)->contains('&');
+    }
+
+    public function classTypesAreFullyQualified(): void
+    {
+        Assert::true(str_starts_with(TypeRenderer::parameterType($this->typeOf('objectParam')), '\\'));
+    }
+
+    #[DataProvider('matcherProvider')]
+    public function reportsWhichTypesAlreadyAcceptAMatcher(string $method, bool $expected): void
+    {
+        Assert::same(TypeRenderer::acceptsMatcher($this->typeOf($method)), $expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function matcherProvider(): iterable
+    {
+        yield 'mixed admits any object' => ['anything', true];
+        yield 'object admits any object' => ['anyObject', true];
+        yield 'int does not' => ['scalar', false];
+        yield 'intersection does not' => ['intersection', false];
+        yield 'untyped is not a declared type' => ['untyped', false];
+    }
+
+    #[DataProvider('returnProvider')]
+    public function rendersReturnTypes(string $method, string $expected): void
+    {
+        Assert::same(
+            TypeRenderer::returnType((new \ReflectionMethod(TypeShowcase::class, $method))->getReturnType()),
+            $expected,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function returnProvider(): iterable
+    {
+        yield 'void' => ['scalar', 'void'];
+        yield 'nullable class keeps its shorthand' => ['returnsNullableObject', '?\\' . TypeShowcase::class];
+        yield 'never' => ['returnsNever', 'never'];
+    }
+
+    public function anAbsentReturnTypeBecomesMixed(): void
+    {
+        Assert::same(TypeRenderer::returnType(null), 'mixed');
+    }
+
+    private function typeOf(string $method): ?\ReflectionType
+    {
+        return (new \ReflectionMethod(TypeShowcase::class, $method))->getParameters()[0]->getType();
+    }
+}

--- a/tests/Codegen/TypeRendererTest.php
+++ b/tests/Codegen/TypeRendererTest.php
@@ -60,6 +60,17 @@ final class TypeRendererTest
         Assert::true(str_starts_with(TypeRenderer::parameterType($this->typeOf('objectParam')), '\\'));
     }
 
+    public function aNullableClassKeepsItsLeadingBackslash(): void
+    {
+        // Generated code lives in its own namespace, so `?Book` must expand to
+        // `\Book|null`: a relative name would resolve to a class that does not
+        // exist, and only at call time.
+        Assert::same(
+            TypeRenderer::parameterType($this->typeOf('nullableObject')),
+            '\\' . TypeShowcase::class . '|null',
+        );
+    }
+
     #[DataProvider('matcherProvider')]
     public function reportsWhichTypesAlreadyAcceptAMatcher(string $method, bool $expected): void
     {

--- a/tests/Defaults/TypeDefaultResolverTest.php
+++ b/tests/Defaults/TypeDefaultResolverTest.php
@@ -74,6 +74,32 @@ final class TypeDefaultResolverTest
         Assert::true(is_callable($value));
     }
 
+    public function aUnionFallsBackToTheFirstBranchWithASafeDefault(): void
+    {
+        // `Book|string` must answer `''` rather than failing on `Book`.
+        Assert::same(
+            TypeDefaultResolver::forSignature('Contract', $this->signature('\\DateTimeImmutable|string'), 'method'),
+            '',
+        );
+    }
+
+    public function aBranchIsMatchedExactlyNotAsASubstring(): void
+    {
+        // A class whose name merely contains "null" is not a null branch, and
+        // a union of two such classes has no safe default at all.
+        Expect::exception(NoDefaultValue::class);
+
+        TypeDefaultResolver::forSignature('Contract', $this->signature('\\NullableThing|\\AnnullableThing'), 'method');
+    }
+
+    public function anIntersectionBranchSurvivesUnionSplitting(): void
+    {
+        // `(A&B)|null` has two branches, not three.
+        Assert::null(
+            TypeDefaultResolver::forSignature('Contract', $this->signature('(\\A&\\B)|null'), 'method'),
+        );
+    }
+
     public function anUnknownSignatureAnswersWithNull(): void
     {
         Assert::null(TypeDefaultResolver::forSignature('Contract', null, 'method'));
@@ -86,7 +112,7 @@ final class TypeDefaultResolverTest
         // there is nothing safe to return.
         Expect::exception(NoDefaultValue::class)
             ->withMessageContaining('no safe default')
-            ->withMessageContaining('Understudy::defaults');
+            ->withMessageContaining('when(fn () => $double->method(...))->returns(...)');
 
         TypeDefaultResolver::forSignature('Contract', $this->signature('\\DateTimeImmutable'), 'method');
     }

--- a/tests/Defaults/TypeDefaultResolverTest.php
+++ b/tests/Defaults/TypeDefaultResolverTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Defaults;
+
+use Rasuvaeff\Understudy\Codegen\MethodSignature;
+use Rasuvaeff\Understudy\Defaults\TypeDefaultResolver;
+use Rasuvaeff\Understudy\Exception\NoDefaultValue;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Data\DataProvider;
+use Testo\Expect;
+use Testo\Test;
+
+#[Test]
+#[Covers(TypeDefaultResolver::class)]
+final class TypeDefaultResolverTest
+{
+    #[DataProvider('safeDefaultProvider')]
+    public function returnsATypeSafeDefault(string $returnType, mixed $expected): void
+    {
+        Assert::same(TypeDefaultResolver::forSignature('Contract', $this->signature($returnType), 'method'), $expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, mixed}>
+     */
+    public static function safeDefaultProvider(): iterable
+    {
+        yield 'void' => ['void', null];
+        yield 'mixed' => ['mixed', null];
+        yield 'null' => ['null', null];
+        yield 'nullable shorthand' => ['?string', null];
+        yield 'bool' => ['bool', false];
+        yield 'false' => ['false', false];
+        yield 'true' => ['true', true];
+        yield 'int' => ['int', 0];
+        yield 'float' => ['float', 0.0];
+        yield 'string' => ['string', ''];
+        yield 'array' => ['array', []];
+        yield 'iterable' => ['iterable', []];
+        yield 'union containing null' => ['string|null', null];
+        yield 'union without null takes the first branch' => ['string|int', ''];
+    }
+
+    public function objectDefaultIsAnEmptyStdClass(): void
+    {
+        $value = TypeDefaultResolver::forSignature('Contract', $this->signature('object'), 'method');
+
+        Assert::instanceOf($value, \stdClass::class);
+    }
+
+    public function generatorDefaultIsAnEmptyGeneratorNotAnArray(): void
+    {
+        // `[]` would violate a declared `: Generator`.
+        $value = TypeDefaultResolver::forSignature('Contract', $this->signature('Generator'), 'method');
+
+        Assert::instanceOf($value, \Generator::class);
+        Assert::same(iterator_to_array($value), []);
+    }
+
+    public function traversableDefaultIsAnEmptyIterator(): void
+    {
+        $value = TypeDefaultResolver::forSignature('Contract', $this->signature('Traversable'), 'method');
+
+        Assert::instanceOf($value, \EmptyIterator::class);
+    }
+
+    public function callableDefaultIsInvokable(): void
+    {
+        $value = TypeDefaultResolver::forSignature('Contract', $this->signature('callable'), 'method');
+
+        Assert::true(is_callable($value));
+    }
+
+    public function anUnknownSignatureAnswersWithNull(): void
+    {
+        Assert::null(TypeDefaultResolver::forSignature('Contract', null, 'method'));
+    }
+
+    public function anArbitraryClassHasNoSafeDefault(): void
+    {
+        // Running someone else's constructor to invent a value, or handing back
+        // an object whose constructor was skipped, are both worse than saying
+        // there is nothing safe to return.
+        Expect::exception(NoDefaultValue::class)
+            ->withMessageContaining('no safe default')
+            ->withMessageContaining('Understudy::defaults');
+
+        TypeDefaultResolver::forSignature('Contract', $this->signature('\\DateTimeImmutable'), 'method');
+    }
+
+    private function signature(string $returnType): MethodSignature
+    {
+        return new MethodSignature(
+            name: 'method',
+            parameters: '',
+            arguments: '[]',
+            returnType: $returnType,
+            returnsNever: false,
+            returnsVoid: $returnType === 'void',
+            returnsReference: false,
+        );
+    }
+}

--- a/tests/Expectation/ArgumentFormatterTest.php
+++ b/tests/Expectation/ArgumentFormatterTest.php
@@ -66,6 +66,42 @@ final class ArgumentFormatterTest
         Assert::same(ArgumentFormatter::format(new Book('Dune')), Book::class);
     }
 
+    #[DataProvider('escapeProvider')]
+    public function escapesWhatWouldBreakTheLine(string $value, string $expected): void
+    {
+        // A failure message renders each argument on one line; a raw newline
+        // or quote would hide what actually differed.
+        Assert::same(ArgumentFormatter::format($value), $expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function escapeProvider(): iterable
+    {
+        yield 'single quote' => ["it's", "'it\\'s'"];
+        yield 'backslash' => ['a\\b', "'a\\\\b'"];
+        yield 'newline' => ["a\nb", "'a\\nb'"];
+        yield 'carriage return' => ["a\rb", "'a\\rb'"];
+        yield 'tab' => ["a\tb", "'a\\tb'"];
+    }
+
+    public function boundsDeeplyNestedArrays(): void
+    {
+        // Deep structures belong in a debugger, not in a failure message.
+        $deep = [1, [2, [3, [4, [5, [6]]]]]];
+
+        $rendered = ArgumentFormatter::format($deep);
+
+        Assert::string($rendered)->contains('…');
+        Assert::false(str_contains($rendered, '6'));
+    }
+
+    public function keepsShallowNestingReadable(): void
+    {
+        Assert::same(ArgumentFormatter::format([1, [2, 3]]), '[1, [2, 3]]');
+    }
+
     public function rendersAnEnumCaseByName(): void
     {
         Assert::same(ArgumentFormatter::format(Suit::Hearts), Suit::class . '::Hearts');

--- a/tests/Expectation/ArgumentFormatterTest.php
+++ b/tests/Expectation/ArgumentFormatterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Expectation;
+
+use Rasuvaeff\Understudy\Expectation\ArgumentFormatter;
+use Rasuvaeff\Understudy\Tests\Fixture\Book;
+use Rasuvaeff\Understudy\Tests\Fixture\Suit;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Data\DataProvider;
+use Testo\Test;
+
+#[Test]
+#[Covers(ArgumentFormatter::class)]
+final class ArgumentFormatterTest
+{
+    #[DataProvider('scalarProvider')]
+    public function rendersScalars(mixed $value, string $expected): void
+    {
+        Assert::same(ArgumentFormatter::format($value), $expected);
+    }
+
+    /**
+     * @return iterable<string, array{mixed, string}>
+     */
+    public static function scalarProvider(): iterable
+    {
+        yield 'null' => [null, 'null'];
+        yield 'true' => [true, 'true'];
+        yield 'false' => [false, 'false'];
+        yield 'int' => [42, '42'];
+        yield 'float' => [1.5, '1.5'];
+        // Quoting is what tells the reader '1' from 1 in a failure message.
+        yield 'string' => ['alpha', "'alpha'"];
+        yield 'numeric string' => ['1', "'1'"];
+        yield 'empty array' => [[], '[]'];
+    }
+
+    public function truncatesALongString(): void
+    {
+        $rendered = ArgumentFormatter::format(str_repeat('a', 100));
+
+        Assert::string($rendered)->contains('…');
+        Assert::true(mb_strlen($rendered) < 100);
+    }
+
+    public function rendersAListInline(): void
+    {
+        Assert::same(ArgumentFormatter::format([1, 2, 3]), '[1, 2, 3]');
+    }
+
+    public function rendersAMapWithItsKeys(): void
+    {
+        Assert::same(ArgumentFormatter::format(['topic' => 'orders']), "['topic' => 'orders']");
+    }
+
+    public function elidesALongArray(): void
+    {
+        Assert::string(ArgumentFormatter::format([1, 2, 3, 4, 5, 6, 7]))->contains('…');
+    }
+
+    public function rendersAnObjectByClassName(): void
+    {
+        Assert::same(ArgumentFormatter::format(new Book('Dune')), Book::class);
+    }
+
+    public function rendersAnEnumCaseByName(): void
+    {
+        Assert::same(ArgumentFormatter::format(Suit::Hearts), Suit::class . '::Hearts');
+    }
+}

--- a/tests/Fixture/Book.php
+++ b/tests/Fixture/Book.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture;
+
+final readonly class Book
+{
+    public function __construct(public string $title = 'untitled') {}
+}

--- a/tests/Fixture/BookRepository.php
+++ b/tests/Fixture/BookRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture;
+
+interface BookRepository
+{
+    public function find(int $id): ?Book;
+
+    public function save(Book $book): void;
+
+    public function titles(): array;
+
+    public function count(): int;
+
+    public function abort(string $reason): never;
+
+    public function stream(): \Generator;
+
+    public function describe(): string|int;
+
+    public function tag(string $name, int $weight = 1): string;
+}

--- a/tests/Fixture/Clock.php
+++ b/tests/Fixture/Clock.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture;
+
+interface Clock
+{
+    public function now(): int;
+}

--- a/tests/Fixture/Named.php
+++ b/tests/Fixture/Named.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture;
+
+interface Named
+{
+    public function name(): string;
+}

--- a/tests/Fixture/Suit.php
+++ b/tests/Fixture/Suit.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture;
+
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Spades = 'S';
+}

--- a/tests/Fixture/Unify/ArityOne.php
+++ b/tests/Fixture/Unify/ArityOne.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ArityOne
+{
+    public function emit(int $a): void;
+
+    public function emitWithDefault(string $name = 'fallback'): void;
+}

--- a/tests/Fixture/Unify/ArityTwo.php
+++ b/tests/Fixture/Unify/ArityTwo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ArityTwo
+{
+    public function emit(int $a, int $b): void;
+}

--- a/tests/Fixture/Unify/FeederByRef.php
+++ b/tests/Fixture/Unify/FeederByRef.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface FeederByRef
+{
+    public function feed(int &$slot): void;
+}

--- a/tests/Fixture/Unify/FeederByValue.php
+++ b/tests/Fixture/Unify/FeederByValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface FeederByValue
+{
+    public function feed(int $slot): void;
+}

--- a/tests/Fixture/Unify/FixedArityTwo.php
+++ b/tests/Fixture/Unify/FixedArityTwo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface FixedArityTwo
+{
+    public function tail(int $first, string $second): string;
+}

--- a/tests/Fixture/Unify/NullableParam.php
+++ b/tests/Fixture/Unify/NullableParam.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+use Rasuvaeff\Understudy\Tests\Fixture\Book;
+
+interface NullableParam
+{
+    public function store(?Book $book): string;
+
+    public function tail(int $first, string ...$rest): string;
+}

--- a/tests/Fixture/Unify/ReaderInt.php
+++ b/tests/Fixture/Unify/ReaderInt.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ReaderInt
+{
+    public function read(): int;
+}

--- a/tests/Fixture/Unify/ReaderString.php
+++ b/tests/Fixture/Unify/ReaderString.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ReaderString
+{
+    public function read(): string;
+}

--- a/tests/Fixture/Unify/ReaderStringy.php
+++ b/tests/Fixture/Unify/ReaderStringy.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ReaderStringy
+{
+    public function label(): string;
+}

--- a/tests/Fixture/Unify/Showcase.php
+++ b/tests/Fixture/Unify/Showcase.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface Showcase
+{
+    public function noParams(): int;
+
+    public function scalar(int $a): void;
+
+    public function nullable(?string $a): void;
+
+    public function withDefault(int $a = 7): void;
+
+    public function withNullDefault(?int $a = null): void;
+
+    public function variadic(string ...$rest): void;
+
+    public function scalarThenVariadic(int $first, string ...$rest): void;
+
+    public function byReference(array &$slot): void;
+
+    public function untyped($a): void;
+
+    public function intersection(ReaderInt&ReaderStringy $a): void;
+
+    public function anything(mixed $a): void;
+
+    public function anyObject(object $a): void;
+
+    public function &returnsReference(): array;
+
+    public function goesAway(): never;
+}

--- a/tests/Fixture/Unify/SlotsByRef.php
+++ b/tests/Fixture/Unify/SlotsByRef.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface SlotsByRef
+{
+    public function &slots(): array;
+}

--- a/tests/Fixture/Unify/SlotsByValue.php
+++ b/tests/Fixture/Unify/SlotsByValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface SlotsByValue
+{
+    public function slots(): array;
+}

--- a/tests/Fixture/Unify/TypeShowcase.php
+++ b/tests/Fixture/Unify/TypeShowcase.php
@@ -22,6 +22,8 @@ interface TypeShowcase
 
     public function objectParam(TypeShowcase $a): void;
 
+    public function nullableObject(?TypeShowcase $a): void;
+
     public function returnsNullableObject(): ?TypeShowcase;
 
     public function returnsNever(): never;

--- a/tests/Fixture/Unify/TypeShowcase.php
+++ b/tests/Fixture/Unify/TypeShowcase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface TypeShowcase
+{
+    public function scalar(int $a): void;
+
+    public function nullable(?int $a): void;
+
+    public function union(int|string $a): void;
+
+    public function anything(mixed $a): void;
+
+    public function anyObject(object $a): void;
+
+    public function untyped($a): void;
+
+    public function intersection(ReaderInt&ReaderStringy $a): void;
+
+    public function objectParam(TypeShowcase $a): void;
+
+    public function returnsNullableObject(): ?TypeShowcase;
+
+    public function returnsNever(): never;
+}

--- a/tests/Fixture/Unify/VariadicShapes.php
+++ b/tests/Fixture/Unify/VariadicShapes.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface VariadicShapes
+{
+    public function byRefTail(int &...$slots): void;
+
+    public function untypedTail(...$anything): void;
+
+    public function intTail(int ...$numbers): void;
+}

--- a/tests/Fixture/Unify/VariadicShapesToo.php
+++ b/tests/Fixture/Unify/VariadicShapesToo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface VariadicShapesToo
+{
+    public function intTail(string ...$words): void;
+}

--- a/tests/Fixture/Unify/WriterInt.php
+++ b/tests/Fixture/Unify/WriterInt.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface WriterInt
+{
+    public static function describe(): string;
+
+    public function write(int $chunk): void;
+}

--- a/tests/Fixture/Unify/WriterIntToo.php
+++ b/tests/Fixture/Unify/WriterIntToo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface WriterIntToo
+{
+    public function write(int $chunk): void;
+}

--- a/tests/Fixture/Unify/WriterString.php
+++ b/tests/Fixture/Unify/WriterString.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface WriterString
+{
+    public function write(string $chunk): void;
+}

--- a/tests/UnderstudyTest.php
+++ b/tests/UnderstudyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rasuvaeff\Understudy\Tests;
 
 use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Exception\ForgottenDouble;
 use Rasuvaeff\Understudy\Exception\InvalidCallSpecification;
 use Rasuvaeff\Understudy\Exception\NeverMethodCalled;
 use Rasuvaeff\Understudy\Exception\StrictModeViolation;
@@ -15,6 +16,7 @@ use Rasuvaeff\Understudy\Tests\Fixture\Book;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
 use Rasuvaeff\Understudy\Tests\Fixture\Clock;
 use Rasuvaeff\Understudy\Tests\Fixture\Named;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\SlotsByRef;
 use Rasuvaeff\Understudy\Understudy;
 use Testo\Assert;
 use Testo\Assert\ExpectNoAssertions;
@@ -383,6 +385,68 @@ final class UnderstudyTest
         $fresh = Understudy::for(BookRepository::class);
 
         Assert::same($fresh->count(), 0);
+    }
+
+    public function returnsPreservesAConfiguredNull(): void
+    {
+        // `??` cannot tell a configured null from a missing entry, and would
+        // skip straight to the last value.
+        $repository = Understudy::for(BookRepository::class);
+        $book = new Book('second');
+
+        when(fn() => $repository->find(1))->returns(null, $book);
+
+        Assert::null($repository->find(1));
+        Assert::same($repository->find(1), $book);
+    }
+
+    public function aByReferenceMethodDispatchesWithoutANotice(): void
+    {
+        // PHP can only bind a reference to a variable, so the generated body
+        // must assign the dispatch result before returning it.
+        $registry = Understudy::for(SlotsByRef::class);
+
+        when(fn() => $registry->slots())->returns(['a' => 1]);
+
+        Assert::same($registry->slots(), ['a' => 1]);
+    }
+
+    public function aNeverMethodConfiguredToReturnIsRejected(): void
+    {
+        // Returning from a `: never` method is a TypeError by language rule;
+        // the message has to name the real mistake instead.
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->abort('stop'))->returns('nope');
+
+        Expect::exception(NeverMethodCalled::class)->withMessageContaining('cannot');
+
+        $repository->abort('stop');
+    }
+
+    public function aDoubleUsedAfterResetSaysSo(): void
+    {
+        // Answering with null would violate the declared return type and
+        // surface far from the actual mistake.
+        $repository = Understudy::for(BookRepository::class);
+        Understudy::reset();
+
+        Expect::exception(ForgottenDouble::class)->withMessageContaining('count()');
+
+        $repository->count();
+    }
+
+    public function aMatcherFromAnotherContextStillRecords(): void
+    {
+        // Recording belongs to the caller: a double created before the
+        // specification closure runs must still signal, not log a real call.
+        $repository = Understudy::for(BookRepository::class);
+        $repository->count();
+
+        when(fn() => $repository->count())->returns(9);
+
+        Assert::same($repository->count(), 9);
+        Assert::same(count(Understudy::calls(fn() => $repository->count())), 2);
     }
 
     public function doublesOfTheSameContractKeepSeparateState(): void

--- a/tests/UnderstudyTest.php
+++ b/tests/UnderstudyTest.php
@@ -1,0 +1,398 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests;
+
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Exception\InvalidCallSpecification;
+use Rasuvaeff\Understudy\Exception\NeverMethodCalled;
+use Rasuvaeff\Understudy\Exception\StrictModeViolation;
+use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
+use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Invocation;
+use Rasuvaeff\Understudy\Tests\Fixture\Book;
+use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
+use Rasuvaeff\Understudy\Tests\Fixture\Clock;
+use Rasuvaeff\Understudy\Tests\Fixture\Named;
+use Rasuvaeff\Understudy\Understudy;
+use Testo\Assert;
+use Testo\Assert\ExpectNoAssertions;
+use Testo\Codecov\Covers;
+use Testo\Expect;
+use Testo\Lifecycle\AfterTest;
+use Testo\Test;
+
+use function Rasuvaeff\Understudy\verify;
+use function Rasuvaeff\Understudy\when;
+
+#[Test]
+#[Covers(Understudy::class)]
+final class UnderstudyTest
+{
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Understudy::reset();
+    }
+
+    public function doubleSatisfiesTheContract(): void
+    {
+        Assert::instanceOf(Understudy::for(BookRepository::class), BookRepository::class);
+    }
+
+    public function doubleCombinesSeveralInterfaces(): void
+    {
+        $double = Understudy::for(BookRepository::class, Named::class);
+
+        Assert::instanceOf($double, BookRepository::class);
+        Assert::instanceOf($double, Named::class);
+    }
+
+    public function stubbedCallReturnsTheConfiguredValue(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $book = new Book('Dune');
+
+        when(fn() => $repository->find(1))->returns($book);
+
+        Assert::same($repository->find(1), $book);
+    }
+
+    public function stubMatchesOnArgumentsNotJustTheMethod(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $dune = new Book('Dune');
+
+        when(fn() => $repository->find(1))->returns($dune);
+
+        Assert::same($repository->find(1), $dune);
+        Assert::null($repository->find(2));
+    }
+
+    public function laterStubWinsOverAnEarlierOne(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $first = new Book('first');
+        $second = new Book('second');
+
+        when(fn() => $repository->find(1))->returns($first);
+        when(fn() => $repository->find(1))->returns($second);
+
+        Assert::same($repository->find(1), $second);
+    }
+
+    public function earlierStubStaysReachableAsAFallback(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $any = new Book('any');
+        $one = new Book('one');
+
+        when(fn() => $repository->find(Arg::any()))->returns($any);
+        when(fn() => $repository->find(1))->returns($one);
+
+        Assert::same($repository->find(1), $one);
+        Assert::same($repository->find(99), $any);
+    }
+
+    public function returnsWalksTheSequenceThenRepeatsTheLastValue(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $a = new Book('a');
+        $b = new Book('b');
+
+        when(fn() => $repository->find(1))->returns($a, $b);
+
+        Assert::same($repository->find(1), $a);
+        Assert::same($repository->find(1), $b);
+        Assert::same($repository->find(1), $b);
+    }
+
+    public function throwsRaisesTheConfiguredError(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->find(1))->throws(new \RuntimeException('gone'));
+
+        Expect::exception(\RuntimeException::class)->withMessage('gone');
+
+        $repository->find(1);
+    }
+
+    public function answersComputesFromTheInvocation(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->find(Arg::any()))
+            ->answers(static fn(Invocation $i): Book => new Book('book #' . $i->args[0]));
+
+        Assert::same($repository->find(7)?->title, 'book #7');
+    }
+
+    public function looseDoubleAnswersWithTypeSafeDefaults(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        Assert::null($repository->find(1));
+        Assert::same($repository->titles(), []);
+        Assert::same($repository->count(), 0);
+        Assert::same(iterator_to_array($repository->stream()), []);
+    }
+
+    public function looseDefaultForAUnionPrefersTheFirstSafeBranch(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        Assert::same($repository->describe(), '');
+    }
+
+    public function neverMethodThrowsInsteadOfReturning(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        Expect::exception(NeverMethodCalled::class)->withMessageContaining('abort()');
+
+        $repository->abort('stop');
+    }
+
+    public function neverMethodStillHonoursAConfiguredThrow(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->abort('stop'))->throws(new \DomainException('configured'));
+
+        Expect::exception(\DomainException::class);
+
+        $repository->abort('stop');
+    }
+
+    public function strictDoubleRejectsAnUnexpectedCall(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        Understudy::strict($repository);
+
+        Expect::exception(StrictModeViolation::class)->withMessageContaining('count()');
+
+        $repository->count();
+    }
+
+    public function strictDoubleStillAnswersConfiguredCalls(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        Understudy::strict($repository);
+
+        when(fn() => $repository->count())->returns(3);
+
+        Assert::same($repository->count(), 3);
+    }
+
+    #[ExpectNoAssertions]
+    public function verifyPassesWhenTheCallHappened(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $book = new Book('Dune');
+
+        $repository->save($book);
+
+        verify(fn() => $repository->save($book));
+    }
+
+    #[ExpectNoAssertions]
+    public function verifyCountsExactly(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $book = new Book('Dune');
+
+        $repository->save($book);
+        $repository->save($book);
+
+        verify(fn() => $repository->save($book), times: 2);
+    }
+
+    public function verifyReportsTheMismatchedCount(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $book = new Book('Dune');
+
+        $repository->save($book);
+
+        Expect::exception(VerificationFailed::class)
+            ->withMessageContaining('exactly 3 times')
+            ->withMessageContaining('called 1 time');
+
+        Understudy::verify(fn() => $repository->save($book), times: 3);
+    }
+
+    public function verifyMarksTheArgumentThatDiffered(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        $repository->tag('beta', 2);
+
+        Expect::exception(VerificationFailed::class)->withMessageContaining("*'beta'*");
+
+        Understudy::verify(fn() => $repository->tag('alpha', 2));
+    }
+
+    #[ExpectNoAssertions]
+    public function verifyNeverPassesWhenNothingHappened(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        verify(fn() => $repository->count(), never: true);
+    }
+
+    public function verifyNeverFailsWhenTheCallHappened(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $repository->count();
+
+        Expect::exception(VerificationFailed::class)->withMessageContaining('never');
+
+        Understudy::verify(fn() => $repository->count(), never: true);
+    }
+
+    #[ExpectNoAssertions]
+    public function verifyAcceptsAMinimumWithoutAnUpperBound(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        $repository->count();
+        $repository->count();
+        $repository->count();
+
+        verify(fn() => $repository->count(), minimum: 2);
+    }
+
+    public function verifyReportsAnUnmetMinimum(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $repository->count();
+
+        Expect::exception(VerificationFailed::class)->withMessageContaining('at least 2 times');
+
+        Understudy::verify(fn() => $repository->count(), minimum: 2);
+    }
+
+    public function callsExposesTheRecordedInvocations(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->find(1))->returns(new Book('Dune'));
+        $repository->find(1);
+        $repository->find(1);
+
+        $calls = Understudy::calls(fn() => $repository->find(1));
+
+        Assert::same(count($calls), 2);
+        Assert::true($calls[0]->didReturn());
+        Assert::same($calls[0]->returned()?->title, 'Dune');
+    }
+
+    public function invocationRecordsAThrownOutcome(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->find(1))->throws(new \RuntimeException('gone'));
+
+        try {
+            $repository->find(1);
+        } catch (\RuntimeException) {
+            // Swallowed on purpose: the recorded outcome is what this asserts.
+        }
+
+        $calls = Understudy::calls(fn() => $repository->find(1));
+
+        Assert::true($calls[0]->didThrow());
+        Assert::instanceOf($calls[0]->thrown(), \RuntimeException::class);
+    }
+
+    #[ExpectNoAssertions]
+    public function unusedPassesForAnUntouchedDouble(): void
+    {
+        Understudy::unused(Understudy::for(BookRepository::class));
+    }
+
+    public function unusedReportsWhatWasCalled(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $repository->tag('alpha');
+
+        Expect::exception(VerificationFailed::class)->withMessageContaining("tag('alpha', 1)");
+
+        Understudy::unused($repository);
+    }
+
+    public function labelNamesTheDoubleInFailures(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        Understudy::label($repository, 'primary catalogue');
+
+        Expect::exception(VerificationFailed::class)->withMessageContaining('primary catalogue');
+
+        Understudy::verify(fn() => $repository->count());
+    }
+
+    public function failureNamesTheContractWhenNoLabelWasSet(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        Expect::exception(VerificationFailed::class)->withMessageContaining('BookRepository');
+
+        Understudy::verify(fn() => $repository->count());
+    }
+
+    public function specificationClosureWithoutACallIsRejected(): void
+    {
+        Expect::exception(InvalidCallSpecification::class)->withMessageContaining('exactly one direct call');
+
+        Understudy::when(static fn(): bool => true);
+    }
+
+    public function specificationClosureFailureKeepsTheOriginalCause(): void
+    {
+        Expect::exception(InvalidCallSpecification::class)->withPrevious(\DomainException::class);
+
+        Understudy::when(static function (): never {
+            throw new \DomainException('closure blew up');
+        });
+    }
+
+    public function classTargetsAreRejectedWithAnActionableMessage(): void
+    {
+        Expect::exception(UnsupportedTarget::class)->withMessageContaining('interface');
+
+        Understudy::for(Book::class);
+    }
+
+    public function missingTargetIsRejected(): void
+    {
+        Expect::exception(UnsupportedTarget::class)->withMessageContaining('no such class or interface');
+
+        // Deliberately not a real class: psalm covers src/ only, so the
+        // invalid argument raises no analysis error here.
+        Understudy::for('Nope\\NotHere');
+    }
+
+    public function resetForgetsEverything(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        when(fn() => $repository->count())->returns(5);
+        Understudy::reset();
+
+        $fresh = Understudy::for(BookRepository::class);
+
+        Assert::same($fresh->count(), 0);
+    }
+
+    public function doublesOfTheSameContractKeepSeparateState(): void
+    {
+        $first = Understudy::for(Clock::class);
+        $second = Understudy::for(Clock::class);
+
+        when(fn() => $first->now())->returns(100);
+
+        Assert::same($first->now(), 100);
+        Assert::same($second->now(), 0);
+    }
+}


### PR DESCRIPTION
## What

The package itself (full template set, CI, build gate) plus the core engine: interface doubles generated from Reflection, driven by the sentinel mechanism proven in milestone 0.

Public surface landing here:

```php
$repository = Understudy::for(BookRepository::class);      // returns BookRepository

when(fn () => $repository->find(1))->returns($book);       // returns/throws/answers
verify(fn () => $repository->save($book), times: 2);       // times/minimum/maximum/never

Understudy::calls(fn () => $repository->find(Arg::any())); // list<Invocation> with outcomes
Understudy::strict($double);
Understudy::label($double, 'primary cache');
Understudy::unused($double);
Understudy::reset();
```

## Decisions worth reviewing

Each is pinned by a test:

- **Multi-target methods are unified, not compared.** Parameters are contravariant, so `write(int)` and `write(string)` share `write(int|string)` — comparing signatures for equality would reject a pair PHP accepts. Only genuinely unsatisfiable combinations are conflicts: divergent return types (covariant) and by-reference mismatches. This came out of the review on #1 and is now the implementation.
- **Generated methods collect arguments by name, never `func_get_args()`**, which omits parameters left at their default. Without this, `tag('alpha')` and `tag('alpha', 1)` record as different calls. Caught by a test that asserted the desired behaviour before the code did it.
- **A parameter made optional by unification gains `null` in its type** — `= null` on a non-nullable type is a deprecated implicit nullable since 8.4.
- **All state is keyed by the double object** (`WeakMap` / `SplObjectStorage`), never `spl_object_id()`, which PHP reuses after collection.
- **Loose defaults never run an arbitrary constructor** and never return an object whose constructor was skipped. Where nothing is safe, `NoDefaultValue` names the way out.
- **`for()` and `WhenBuilder` carry their generics now.** The Psalm plugin (milestone 5) only fills in type parameters the core declares; adding `@template` later would change a published signature. `for(class-string<T>): T` already works with no plugin at all.

## Scope

Interfaces only. A class target is rejected with a message pointing at the interface — class codegen, `bypassFinals()`, the full `Arg` vocabulary, `expect()`, ordering and the runner adapters are the following milestones. Nothing is tagged, so no published contract is affected.

## Verification

| Gate | Result |
|---|---|
| `composer build` | green (validate, normalize, require-checker, cs, psalm, test) |
| `composer psalm` | clean at `errorLevel=1`, no suppressions, no baseline |
| `composer rector` | clean |
| Tests | 118 tests, 167 assertions |
| Mutation | **MSI 88%**, gate 85 |
| `zizmor --persona=auditor` | no findings |
| `examples/basic-usage.php` | runs |

Note on the mutation figure: with a single `#[Covers]` test class the run reported 56 mutants at 93% MSI. Giving each class its own `#[Covers]` test revealed the honest numbers — 406 mutants at 68% — and the work to reach 88% is in this PR. The trap is now written down in the package `AGENTS.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a PHP test-double library for interface doubles, stubbing, call verification, argument matching, call inspection, labels, reset support, and loose or strict modes.
  * Added sequential returns, thrown exceptions, computed answers, type-safe defaults, and detailed failure messages.
  * Added runnable usage examples and a comprehensive API reference, including Russian documentation.

* **Documentation**
  * Added changelog, licensing, contributor guidance, and AI-oriented usage documentation.

* **Chores**
  * Added automated build, release, static-analysis, security, formatting, coverage, mutation-testing, and compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->