### PR TITLE
Mutation-harden the engine: honest #[Covers], 96% MSI, gate at 95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Multi-target unification: a variadic tail declared by reference in one target
+  and by value in another now names both targets in the rejection instead of
+  reporting the same one twice.
 - Initial engine: interface doubles generated from Reflection, the sentinel
   recording mechanism behind the call-closure API, `when()` with
   `returns()`/`throws()`/`answers()`, `verify()` with count bounds,

--- a/infection.json5
+++ b/infection.json5
@@ -8,7 +8,7 @@
         "summary": "build/infection-summary.log"
     },
     "testFramework": "testo",
-    "minMsi": 85,
+    "minMsi": 95,
     "mutators": {
         "@default": true
     }

--- a/src/Codegen/TargetUnifier.php
+++ b/src/Codegen/TargetUnifier.php
@@ -574,6 +574,7 @@ final class TargetUnifier
         /** @var array<string, true> $types */
         $types = [];
         $byReference = null;
+        $byReferenceSource = null;
         $tailName = self::DEFAULT_TAIL_NAME;
         $untyped = false;
         $acceptsMatcher = false;
@@ -593,14 +594,19 @@ final class TargetUnifier
                 $acceptsMatcher = $acceptsMatcher || TypeRenderer::acceptsMatcher($parameter->getType());
 
                 if ($byReference !== null && $byReference !== $parameter->isPassedByReference()) {
+                    // Naming `$declaration` on both lines would report the same
+                    // target twice; the other side is whoever set the mode.
+                    \assert($byReferenceSource !== null);
+
                     throw UnsupportedTarget::signatureConflict(
                         $name,
-                        self::describe($declaration) . ' takes its variadic tail by ' . ($byReference ? 'reference' : 'value'),
+                        self::describe($byReferenceSource) . ' takes its variadic tail by ' . ($byReference ? 'reference' : 'value'),
                         self::describe($declaration) . ' takes it by ' . ($parameter->isPassedByReference() ? 'reference' : 'value'),
                     );
                 }
 
                 $byReference = $parameter->isPassedByReference();
+                $byReferenceSource = $declaration;
 
                 if ($parameter->isVariadic() && $tailName === self::DEFAULT_TAIL_NAME) {
                     // First target wins: `for($primary, ...$interfaces)` treats

--- a/tests/CardinalityTest.php
+++ b/tests/CardinalityTest.php
@@ -71,14 +71,16 @@ final class CardinalityTest
 
     public function aNegativeMinimumIsRejected(): void
     {
-        Expect::exception(\InvalidArgumentException::class)->withMessageContaining('cannot be negative');
+        Expect::exception(\InvalidArgumentException::class)->withMessage('A call count cannot be negative, got -1');
 
         Cardinality::exactly(-1);
     }
 
     public function aMaximumBelowTheMinimumIsRejected(): void
     {
-        Expect::exception(\InvalidArgumentException::class)->withMessageContaining('below the minimum');
+        Expect::exception(\InvalidArgumentException::class)->withMessage(
+            'A maximum call count cannot be below the minimum, got minimum 3 and maximum 1',
+        );
 
         Cardinality::between(3, 1);
     }

--- a/tests/Codegen/TargetUnifierTest.php
+++ b/tests/Codegen/TargetUnifierTest.php
@@ -8,29 +8,72 @@ use Rasuvaeff\Understudy\Codegen\MethodSignature;
 use Rasuvaeff\Understudy\Codegen\TargetUnifier;
 use Rasuvaeff\Understudy\Codegen\TypeRenderer;
 use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\AggregateUnion;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArityOne;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArityTwo;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArrayAll;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArrayObjectValue;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\BetaOnly;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\BoolFlag;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\BothIterableCountable;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\CallableFactory;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ClassUnionFirst;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ClosureFactory;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\CountableValue;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\DnfParam;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\DnfParamToo;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\FeederByRef;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\FeederByValue;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\FixedArityTwo;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\GeneratorAll;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\InstanceDescribe;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\InterfaceUnionSecond;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\InterfaceValue;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntersectedInt;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntersectedPair;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntersectionAlpha;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntersectionBeta;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntReturn;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntTailPlain;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\IterableAll;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\MixedTail;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\MixedValue;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\MixedWriter;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\NarrowPartsUnion;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\NarrowReturn;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\NeverValue;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\NullableParam;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\NullableString;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ObjectTail;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ObjectValueToo;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\PrimaryNamed;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderInt;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderString;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderStringy;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SecondaryNamed;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SelfReturn;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\SelfValue;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\Showcase;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SlotsByRef;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SlotsByValue;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticReturn;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticValue;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StdClassAll;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StdClassFactory;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StringFlag;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StringyOnly;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\TraversableAlphaUnion;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\TripleUnion;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\TrueFlag;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\TypedUntypedTail;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\UnionAlphaBeta;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\UnionAlphaStringy;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\UnionReaderInt;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\UnionReaderString;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\VariadicByValueTail;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\VariadicShapes;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\VariadicShapesToo;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\WidePartsUnion;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\WideReturn;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\WriterInt;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\WriterIntToo;
@@ -43,6 +86,8 @@ use Testo\Test;
 
 #[Test]
 #[Covers(TargetUnifier::class)]
+#[Covers(MethodSignature::class)]
+#[Covers(UnsupportedTarget::class)]
 final class TargetUnifierTest
 {
     private const string MATCHER = TypeRenderer::MATCHER;
@@ -334,6 +379,325 @@ final class TargetUnifierTest
         Expect::exception(UnsupportedTarget::class)->withMessageContaining('read()');
 
         $this->unify(ReaderInt::class, ReaderString::class, FeederByRef::class);
+    }
+
+    // --- Return-type compatibility rules -------------------------------------
+
+    public function aNullableReturnKeepsTheShorthandReflectionReports(): void
+    {
+        // The compatible-candidate path renders the declaration as it stands;
+        // falling through to the intersection fallback would spell the same
+        // type `string|null`, which is legal but not what the contract says.
+        Assert::same($this->unify(NullableString::class)['fetch']->returnType, '?string');
+    }
+
+    public function aNeverReturnSatisfiesEveryOtherTarget(): void
+    {
+        // `never` is a subtype of everything: a method that cannot return
+        // satisfies any declared return type.
+        $signature = $this->unify(NeverValue::class, IntReturn::class)['value'];
+
+        Assert::same($signature->returnType, 'never');
+        Assert::true($signature->returnsNever);
+    }
+
+    public function mixedIsSatisfiedByAnyNarrowerReturn(): void
+    {
+        Assert::same($this->unify(IntReturn::class, MixedValue::class)['value']->returnType, 'int');
+    }
+
+    public function objectIsSatisfiedByAnInterfaceReturn(): void
+    {
+        Assert::same(
+            $this->unify(WideReturn::class, InterfaceValue::class)['value']->returnType,
+            '\\' . ReaderInt::class,
+        );
+    }
+
+    public function objectIsSatisfiedByASelfReturn(): void
+    {
+        // Either rendering satisfies both contracts, and which one Reflection
+        // reports is a PHP-version difference: 8.3/8.4 keep `self`, 8.5
+        // resolves it to the declaring interface.
+        Assert::true(in_array(
+            $this->unify(WideReturn::class, SelfValue::class)['value']->returnType,
+            ['self', '\\' . SelfValue::class],
+            strict: true,
+        ));
+    }
+
+    public function objectIsSatisfiedByAStaticReturn(): void
+    {
+        Assert::same($this->unify(WideReturn::class, StaticValue::class)['value']->returnType, 'static');
+    }
+
+    public function twoObjectReturnsStayObject(): void
+    {
+        Assert::same($this->unify(WideReturn::class, ObjectValueToo::class)['value']->returnType, 'object');
+    }
+
+    public function boolIsSatisfiedByTheTrueLiteral(): void
+    {
+        Assert::same($this->unify(BoolFlag::class, TrueFlag::class)['flag']->returnType, 'true');
+    }
+
+    public function iterableIsSatisfiedByArray(): void
+    {
+        Assert::same($this->unify(IterableAll::class, ArrayAll::class)['all']->returnType, 'array');
+    }
+
+    public function iterableIsSatisfiedByATraversableClass(): void
+    {
+        Assert::same($this->unify(IterableAll::class, GeneratorAll::class)['all']->returnType, '\\Generator');
+    }
+
+    public function callableIsSatisfiedByClosure(): void
+    {
+        Assert::same($this->unify(CallableFactory::class, ClosureFactory::class)['factory']->returnType, '\\Closure');
+    }
+
+    public function aClassReturnSatisfiesAnInterfaceItImplements(): void
+    {
+        // The class-to-class rule is the last one tried, and it is the only
+        // one that has to strip the leading backslash before asking is_a().
+        Assert::same(
+            $this->unify(CountableValue::class, ArrayObjectValue::class)['value']->returnType,
+            '\\ArrayObject',
+        );
+    }
+
+    public function aBuiltinReturnNeverSatisfiesAClassReturn(): void
+    {
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `value()` has no implementation that satisfies all of them.\n"
+            . '  `' . CountableValue::class . "::value()` declares `: \\Countable`\n"
+            . '  `' . IntReturn::class . '::value()` declares `: int`',
+        );
+
+        $this->unify(CountableValue::class, IntReturn::class);
+    }
+
+    public function unionReturnsCollapseToTheBranchTheyShare(): void
+    {
+        // Neither union satisfies the other, but they overlap in one branch —
+        // that overlap is the only return type a class could declare.
+        Assert::same(
+            $this->unify(UnionReaderInt::class, UnionReaderString::class)['value']->returnType,
+            '\\' . ReaderInt::class,
+        );
+    }
+
+    public function aStaticAndAnInstanceMethodOfTheSameNameCannotBeUnified(): void
+    {
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `describe()` has no implementation that satisfies all of them.\n"
+            . '  `' . WriterInt::class . "::describe()` is static\n"
+            . '  `' . InstanceDescribe::class . '::describe()` is an instance method',
+        );
+
+        $this->unify(WriterInt::class, InstanceDescribe::class);
+    }
+
+    // --- Parameter rendering -------------------------------------------------
+
+    public function anObjectVariadicTailIsNotWidened(): void
+    {
+        // `object` already accepts a matcher instance, so a matcher branch
+        // would only make the rendered type redundant.
+        Assert::same($this->unify(ObjectTail::class)['sink']->parameters, 'object ...$items');
+    }
+
+    public function anObjectTailStaysUnwidenedWhenAnotherTargetIsTyped(): void
+    {
+        Assert::same(
+            $this->unify(ObjectTail::class, IntTailPlain::class)['sink']->parameters,
+            'object|int ...$items',
+        );
+    }
+
+    public function aDnfParameterSplitsOnTheTopLevelUnionOnly(): void
+    {
+        // `(A&B)|null` is two branches, not four fragments: splitting inside
+        // the parentheses would emit `(A` and `B)` as separate types.
+        $signature = $this->unify(DnfParam::class, DnfParamToo::class)['store'];
+
+        Assert::same(
+            $signature->parameters,
+            '(\\' . ReaderInt::class . '&\\' . ReaderStringy::class . ')|null|' . self::MATCHER . ' $slot',
+        );
+    }
+
+    public function aVariadicTailByReferenceInOneTargetOnlyIsRejected(): void
+    {
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `byRefTail()` has no implementation that satisfies all of them.\n"
+            . '  `' . VariadicShapes::class . "::byRefTail()` takes its variadic tail by reference\n"
+            . '  `' . VariadicByValueTail::class . '::byRefTail()` takes it by value',
+        );
+
+        $this->unify(VariadicShapes::class, VariadicByValueTail::class);
+    }
+
+    public function theTrueLiteralDoesNotSatisfyAnUnrelatedReturn(): void
+    {
+        // `true` is a subtype of `bool` only: naming it alone would let any
+        // scalar contract through.
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `flag()` has no implementation that satisfies all of them.\n"
+            . '  `' . TrueFlag::class . "::flag()` declares `: true`\n"
+            . '  `' . StringFlag::class . '::flag()` declares `: string`',
+        );
+
+        $this->unify(TrueFlag::class, StringFlag::class);
+    }
+
+    public function iterableIsNotSatisfiedByANonTraversableClass(): void
+    {
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `all()` has no implementation that satisfies all of them.\n"
+            . '  `' . IterableAll::class . "::all()` declares `: iterable`\n"
+            . '  `' . StdClassAll::class . '::all()` declares `: \stdClass`',
+        );
+
+        $this->unify(IterableAll::class, StdClassAll::class);
+    }
+
+    public function callableIsNotSatisfiedByAnArbitraryObject(): void
+    {
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `factory()` has no implementation that satisfies all of them.\n"
+            . '  `' . CallableFactory::class . "::factory()` declares `: callable`\n"
+            . '  `' . StdClassFactory::class . '::factory()` declares `: \stdClass`',
+        );
+
+        $this->unify(CallableFactory::class, StdClassFactory::class);
+    }
+
+    public function unionsThatOverlapPartiallyRenderAsDnf(): void
+    {
+        // (A|B) and (A|S) share A outright, and their remaining branches can
+        // only be satisfied together — `A|(B&S)` is exactly that.
+        $signature = $this->unify(UnionAlphaBeta::class, UnionAlphaStringy::class)['pick'];
+
+        Assert::same(
+            $signature->returnType,
+            '\\' . IntersectionAlpha::class
+            . '|(\\' . IntersectionBeta::class . '&\\' . ReaderStringy::class . ')',
+        );
+    }
+
+    public function aUnionBranchNarrowerThanTheOtherTargetsWins(): void
+    {
+        // `\ArrayObject` implements `\Countable`, so it is the only branch a
+        // class could declare for both targets.
+        $signatures = $this->unify(ClassUnionFirst::class, InterfaceUnionSecond::class);
+
+        Assert::same($signatures['narrow']->returnType, '\ArrayObject');
+        Assert::same($signatures['wide']->returnType, '\ArrayObject');
+    }
+
+    public function aThreeBranchUnionKeepsTheBranchTheOtherTargetNeeds(): void
+    {
+        $signature = $this->unify(TripleUnion::class, StringyOnly::class)['pick'];
+
+        Assert::same($signature->returnType, '\\' . ReaderStringy::class);
+    }
+
+    public function theReportedConflictSkipsPairsThatDoIntersect(): void
+    {
+        // Alpha and Beta unify into `Alpha&Beta`; the pair worth naming is the
+        // one that no class could satisfy at all.
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `intersected()` has no implementation that satisfies all of them.\n"
+            . '  `' . IntersectionAlpha::class . "::intersected()` declares `: \\" . IntersectionAlpha::class . "`\n"
+            . '  `' . IntersectedInt::class . '::intersected()` declares `: int`',
+        );
+
+        $this->unify(IntersectionAlpha::class, IntersectionBeta::class, IntersectedInt::class);
+    }
+
+    public function anUntypedTailStaysUntypedEvenWhenAnotherTargetTypesIt(): void
+    {
+        // One untyped target means the union cannot be expressed: rendering
+        // the other target's `int` would reject calls the contract allows.
+        $signature = $this->unify(VariadicShapes::class, TypedUntypedTail::class)['untypedTail'];
+
+        Assert::same($signature->parameters, '...$anything');
+    }
+
+    public function aMixedTailAbsorbsEveryOtherTargetsType(): void
+    {
+        Assert::same($this->unify(MixedTail::class, IntTailPlain::class)['sink']->parameters, 'mixed ...$items');
+    }
+
+    public function theReportedConflictIsNotSimplyTheFirstAndLastTarget(): void
+    {
+        // Alpha and Beta do intersect; the pair that cannot be satisfied sits
+        // in the middle of the list, and naming the outer two would mislead.
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            "Cannot create one understudy for these targets: method `intersected()` has no implementation that satisfies all of them.\n"
+            . '  `' . IntersectionAlpha::class . "::intersected()` declares `: \\" . IntersectionAlpha::class . "`\n"
+            . '  `' . IntersectedInt::class . '::intersected()` declares `: int`',
+        );
+
+        $this->unify(IntersectionAlpha::class, IntersectedInt::class, IntersectionBeta::class);
+    }
+
+    public function anIntersectionReturnKeepsEveryAtomWhenItIsNarrowedFurther(): void
+    {
+        $signature = $this->unify(IntersectedPair::class, StringyOnly::class)['pick'];
+
+        Assert::same(
+            $signature->returnType,
+            '\\' . IntersectionAlpha::class
+            . '&\\' . IntersectionBeta::class
+            . '&\\' . ReaderStringy::class,
+        );
+    }
+
+    public function anIntersectionDropsTheAtomAnotherAtomAlreadyImplies(): void
+    {
+        // `\IteratorAggregate` already is a `\Traversable`: keeping both would
+        // render an intersection PHP rejects as redundant.
+        $signature = $this->unify(TraversableAlphaUnion::class, AggregateUnion::class)['pick'];
+
+        Assert::same(
+            $signature->returnType,
+            '\\' . IntersectionAlpha::class . '&\IteratorAggregate',
+        );
+    }
+
+    public function aMiddleUnionBranchIsKeptLikeAnyOther(): void
+    {
+        $signature = $this->unify(TripleUnion::class, BetaOnly::class)['pick'];
+
+        Assert::same($signature->returnType, '\\' . IntersectionBeta::class);
+    }
+
+    public function anIntersectionKeepsEveryAtomWhenTheNarrowingSideComesSecond(): void
+    {
+        // Same pair as above with the targets swapped: the atoms of the second
+        // target must survive too, not just its first one.
+        $signature = $this->unify(StringyOnly::class, IntersectedPair::class)['pick'];
+
+        Assert::same(
+            $signature->returnType,
+            '\\' . ReaderStringy::class
+            . '&\\' . IntersectionAlpha::class
+            . '&\\' . IntersectionBeta::class,
+        );
+    }
+
+    public function oneAtomCanSupersedeSeveralAlreadyCollected(): void
+    {
+        // `BothIterableCountable` implies `\Traversable` *and* `\Countable`;
+        // stopping after the first of them would leave a redundant atom.
+        $signature = $this->unify(WidePartsUnion::class, NarrowPartsUnion::class)['pick'];
+
+        Assert::same(
+            $signature->returnType,
+            '\Stringable&\\' . BothIterableCountable::class . '&\JsonSerializable',
+        );
     }
 
     /**

--- a/tests/Codegen/TypeRendererTest.php
+++ b/tests/Codegen/TypeRendererTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Rasuvaeff\Understudy\Tests\Codegen;
 
 use Rasuvaeff\Understudy\Codegen\TypeRenderer;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderInt;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderStringy;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\TypeShowcase;
 use Testo\Assert;
 use Testo\Codecov\Covers;
@@ -113,8 +115,40 @@ final class TypeRendererTest
         Assert::same(TypeRenderer::returnType(null), 'mixed');
     }
 
+
+    public function aDnfParameterKeepsItsParenthesesInsideTheUnion(): void
+    {
+        // Only the intersection is parenthesised, and every branch is
+        // rendered — a union of one branch would be a different type.
+        Assert::same(
+            TypeRenderer::parameterType($this->typeOf('dnf')),
+            '(\\' . ReaderInt::class . '&\\' . ReaderStringy::class . ')|null',
+        );
+    }
+
+    public function aDnfReturnTypeIsRenderedTheSameWay(): void
+    {
+        Assert::same(
+            TypeRenderer::returnType($this->returnTypeOf('returnsDnf')),
+            '(\\' . ReaderInt::class . '&\\' . ReaderStringy::class . ')|null',
+        );
+    }
+
+    public function anIntersectionRendersEveryAtom(): void
+    {
+        Assert::same(
+            TypeRenderer::parameterType($this->typeOf('intersection')),
+            '(\\' . ReaderInt::class . '&\\' . ReaderStringy::class . ')',
+        );
+    }
+
     private function typeOf(string $method): ?\ReflectionType
     {
         return (new \ReflectionMethod(TypeShowcase::class, $method))->getParameters()[0]->getType();
+    }
+
+    private function returnTypeOf(string $method): ?\ReflectionType
+    {
+        return (new \ReflectionMethod(TypeShowcase::class, $method))->getReturnType();
     }
 }

--- a/tests/Defaults/TypeDefaultPropertyTest.php
+++ b/tests/Defaults/TypeDefaultPropertyTest.php
@@ -25,6 +25,7 @@ use Testo\Test;
  */
 #[Test]
 #[Covers(TypeDefaultResolver::class)]
+#[Covers(NoDefaultValue::class)]
 final class TypeDefaultPropertyTest
 {
     /**

--- a/tests/Defaults/TypeDefaultResolverTest.php
+++ b/tests/Defaults/TypeDefaultResolverTest.php
@@ -15,6 +15,8 @@ use Testo\Test;
 
 #[Test]
 #[Covers(TypeDefaultResolver::class)]
+#[Covers(MethodSignature::class)]
+#[Covers(NoDefaultValue::class)]
 final class TypeDefaultResolverTest
 {
     #[DataProvider('safeDefaultProvider')]
@@ -115,6 +117,55 @@ final class TypeDefaultResolverTest
             ->withMessageContaining('when(fn () => $double->method(...))->returns(...)');
 
         TypeDefaultResolver::forSignature('Contract', $this->signature('\\DateTimeImmutable'), 'method');
+    }
+
+
+    public function aQualifiedClassNameResolvesLikeItsShortName(): void
+    {
+        // Signatures render class types with a leading backslash, so the
+        // resolver has to strip it before matching.
+        Assert::instanceOf($this->resolve('\Generator'), \Generator::class);
+        Assert::instanceOf($this->resolve('\Traversable'), \EmptyIterator::class);
+        Assert::instanceOf($this->resolve('\Iterator'), \EmptyIterator::class);
+        Assert::instanceOf($this->resolve('\ArrayIterator'), \ArrayIterator::class);
+        Assert::instanceOf($this->resolve('\Closure'), \Closure::class);
+    }
+
+    public function anIteratorDefaultIsAnEmptyIterator(): void
+    {
+        Assert::instanceOf($this->resolve('Iterator'), \EmptyIterator::class);
+    }
+
+    public function anArrayIteratorDefaultIsItsOwnEmptyInstance(): void
+    {
+        // `\EmptyIterator` is not an `\ArrayIterator`, so the narrower type
+        // needs its own default.
+        $value = $this->resolve('ArrayIterator');
+
+        Assert::instanceOf($value, \ArrayIterator::class);
+        Assert::same(iterator_to_array($value), []);
+    }
+
+    public function aClosureDefaultIsAClosure(): void
+    {
+        Assert::instanceOf($this->resolve('Closure'), \Closure::class);
+    }
+
+    public function aDnfUnionSplitsOnTheTopLevelOnly(): void
+    {
+        // `(A&B)|null` is two branches: splitting inside the parentheses
+        // would leave `(A` and `B)` as types nobody can default.
+        Assert::null($this->resolve('(\ArrayObject&\Countable)|null'));
+    }
+
+    public function aDnfUnionWithoutNullFallsBackToTheBranchThatHasADefault(): void
+    {
+        Assert::same($this->resolve('(\ArrayObject&\Countable)|string'), '');
+    }
+
+    private function resolve(string $returnType): mixed
+    {
+        return TypeDefaultResolver::forSignature('Contract', $this->signature($returnType), 'method');
     }
 
     private function signature(string $returnType): MethodSignature

--- a/tests/EnginePropertyTest.php
+++ b/tests/EnginePropertyTest.php
@@ -12,7 +12,12 @@ use Rasuvaeff\Understudy\Arg;
 use Rasuvaeff\Understudy\Cardinality;
 use Rasuvaeff\Understudy\Exception\StrictModeViolation;
 use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Expectation\Expectation;
+use Rasuvaeff\Understudy\FailureReport;
 use Rasuvaeff\Understudy\Invocation;
+use Rasuvaeff\Understudy\Outcome;
+use Rasuvaeff\Understudy\Runtime\DoubleState;
+use Rasuvaeff\Understudy\Runtime\Runtime;
 use Rasuvaeff\Understudy\Tests\Fixture\Book;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
 use Rasuvaeff\Understudy\Tests\Support\EngineGenerators;
@@ -38,6 +43,14 @@ use function Rasuvaeff\Understudy\when;
 #[Test]
 #[Covers(Understudy::class)]
 #[Covers(Cardinality::class)]
+#[Covers(Runtime::class)]
+#[Covers(DoubleState::class)]
+#[Covers(Expectation::class)]
+#[Covers(Invocation::class)]
+#[Covers(Outcome::class)]
+#[Covers(FailureReport::class)]
+#[Covers(StrictModeViolation::class)]
+#[Covers(VerificationFailed::class)]
 final class EnginePropertyTest
 {
     #[AfterTest]

--- a/tests/Expectation/ArgumentFormatterTest.php
+++ b/tests/Expectation/ArgumentFormatterTest.php
@@ -102,6 +102,76 @@ final class ArgumentFormatterTest
         Assert::same(ArgumentFormatter::format([1, [2, 3]]), '[1, [2, 3]]');
     }
 
+    public function aStringOfExactlyTheLimitIsNotTruncated(): void
+    {
+        $value = str_repeat('a', 40);
+
+        Assert::same(ArgumentFormatter::format($value), "'" . $value . "'");
+    }
+
+    public function aLongerStringIsCutToTheLimitAndMarked(): void
+    {
+        Assert::same(ArgumentFormatter::format(str_repeat('a', 41)), "'" . str_repeat('a', 40) . "…'");
+    }
+
+    public function truncationCountsCharactersNotBytes(): void
+    {
+        // Cutting bytes would split a multibyte character and render mojibake
+        // in the middle of a failure message.
+        Assert::same(ArgumentFormatter::format(str_repeat('и', 41)), "'" . str_repeat('и', 40) . "…'");
+    }
+
+    public function aMultibyteStringUnderTheLimitSurvivesWhole(): void
+    {
+        // 21 characters, 42 bytes: measuring bytes would truncate a string
+        // that fits.
+        $value = str_repeat('и', 21);
+
+        Assert::same(ArgumentFormatter::format($value), "'" . $value . "'");
+    }
+
+    public function truncationKeepsTheStringsOwnBeginning(): void
+    {
+        // Every character differs, so cutting from the wrong offset shows.
+        $value = substr(str_repeat('abcdefghij', 5), 0, 41);
+
+        Assert::same(ArgumentFormatter::format($value), "'" . substr($value, 0, 40) . "…'");
+    }
+
+    public function anArrayOfExactlyFiveIsRenderedWhole(): void
+    {
+        Assert::same(ArgumentFormatter::format([1, 2, 3, 4, 5]), '[1, 2, 3, 4, 5]');
+    }
+
+    public function aLongerArrayKeepsTheFirstFiveEntries(): void
+    {
+        Assert::same(ArgumentFormatter::format([1, 2, 3, 4, 5, 6, 7]), '[1, 2, 3, 4, 5, …]');
+    }
+
+    public function nestingIsRenderedUpToTheLimitAndNoFurther(): void
+    {
+        Assert::same(ArgumentFormatter::format([[['x']]]), "[[['x']]]");
+        Assert::same(ArgumentFormatter::format([[[['x']]]]), '[[[[…]]]]');
+    }
+
+    public function mapKeysAndValuesShareTheDepthBudget(): void
+    {
+        Assert::same(ArgumentFormatter::format([['k' => [1, [2]]]]), "[['k' => [1, […]]]]");
+        Assert::same(ArgumentFormatter::format([[['k' => 1]]]), "[[['k' => 1]]]");
+        Assert::same(ArgumentFormatter::format([[[['k' => 1]]]]), '[[[[… => …]]]]');
+    }
+
+    public function anUnprintableValueFallsBackToItsDebugType(): void
+    {
+        $handle = fopen('php://memory', 'rb');
+
+        Assert::same(ArgumentFormatter::format($handle), 'resource (stream)');
+
+        if (is_resource($handle)) {
+            fclose($handle);
+        }
+    }
+
     public function rendersAnEnumCaseByName(): void
     {
         Assert::same(ArgumentFormatter::format(Suit::Hearts), Suit::class . '::Hearts');

--- a/tests/ExpectationsTest.php
+++ b/tests/ExpectationsTest.php
@@ -7,7 +7,15 @@ namespace Rasuvaeff\Understudy\Tests;
 use Rasuvaeff\Understudy\Arg;
 use Rasuvaeff\Understudy\Exception\NeverMethodCalled;
 use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Expectation\ComputeAnswer;
+use Rasuvaeff\Understudy\Expectation\Expectation;
+use Rasuvaeff\Understudy\Expectation\ReturnValue;
+use Rasuvaeff\Understudy\Expectation\ThrowError;
 use Rasuvaeff\Understudy\ExpectBuilder;
+use Rasuvaeff\Understudy\FailureReport;
+use Rasuvaeff\Understudy\Invocation;
+use Rasuvaeff\Understudy\Runtime\DoubleState;
+use Rasuvaeff\Understudy\Runtime\Runtime;
 use Rasuvaeff\Understudy\Tests\Fixture\Book;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
 use Rasuvaeff\Understudy\Understudy;
@@ -25,6 +33,16 @@ use function Rasuvaeff\Understudy\when;
 #[Test]
 #[Covers(ExpectBuilder::class)]
 #[Covers(WhenBuilder::class)]
+#[Covers(Runtime::class)]
+#[Covers(DoubleState::class)]
+#[Covers(Expectation::class)]
+#[Covers(ReturnValue::class)]
+#[Covers(ThrowError::class)]
+#[Covers(ComputeAnswer::class)]
+#[Covers(Invocation::class)]
+#[Covers(FailureReport::class)]
+#[Covers(NeverMethodCalled::class)]
+#[Covers(VerificationFailed::class)]
 final class ExpectationsTest
 {
     #[AfterTest]
@@ -102,7 +120,10 @@ final class ExpectationsTest
 
         expect(fn() => $repository->abort('stop'));
 
-        Expect::exception(NeverMethodCalled::class)->withMessageContaining('an expectation alone cannot answer it');
+        Expect::exception(NeverMethodCalled::class)->withMessage(
+            "Understudy `BookRepository` expects `abort()`, but the method is declared `: never` and an expectation alone cannot answer it.\n"
+            . 'Say what it throws: expect(fn () => $double->abort(...))->throws(new SomeException())',
+        );
 
         $repository->abort('stop');
     }
@@ -329,5 +350,23 @@ final class ExpectationsTest
         Understudy::for(BookRepository::class);
 
         Understudy::verifyAll();
+    }
+
+    public function chainedReturnsAnswerInOrder(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->count())->returns(1, 2)->then()->returns(3, 4)->then()->returns(5);
+
+        Assert::same(
+            [
+                $repository->count(),
+                $repository->count(),
+                $repository->count(),
+                $repository->count(),
+                $repository->count(),
+            ],
+            [1, 2, 3, 4, 5],
+        );
     }
 }

--- a/tests/Fixture/HashedContract.php
+++ b/tests/Fixture/HashedContract.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture;
+
+/**
+ * Doubled by exactly one test, so that test really runs the codegen path
+ * rather than hitting the blueprint cache another test already filled.
+ */
+interface HashedContract
+{
+    public function ping(): string;
+}

--- a/tests/Fixture/HashedContractToo.php
+++ b/tests/Fixture/HashedContractToo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture;
+
+interface HashedContractToo
+{
+    public function pong(): string;
+}

--- a/tests/Fixture/Unify/AggregateUnion.php
+++ b/tests/Fixture/Unify/AggregateUnion.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface AggregateUnion
+{
+    public function pick(): \IteratorAggregate|string;
+}

--- a/tests/Fixture/Unify/ArrayAll.php
+++ b/tests/Fixture/Unify/ArrayAll.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ArrayAll
+{
+    public function all(): array;
+}

--- a/tests/Fixture/Unify/ArrayObjectValue.php
+++ b/tests/Fixture/Unify/ArrayObjectValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ArrayObjectValue
+{
+    public function value(): \ArrayObject;
+}

--- a/tests/Fixture/Unify/BetaOnly.php
+++ b/tests/Fixture/Unify/BetaOnly.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface BetaOnly
+{
+    public function pick(): IntersectionBeta;
+}

--- a/tests/Fixture/Unify/BoolFlag.php
+++ b/tests/Fixture/Unify/BoolFlag.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface BoolFlag
+{
+    public function flag(): bool;
+}

--- a/tests/Fixture/Unify/BothIterableCountable.php
+++ b/tests/Fixture/Unify/BothIterableCountable.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface BothIterableCountable extends \IteratorAggregate, \Countable {}

--- a/tests/Fixture/Unify/CallableFactory.php
+++ b/tests/Fixture/Unify/CallableFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface CallableFactory
+{
+    public function factory(): callable;
+}

--- a/tests/Fixture/Unify/ClassUnionFirst.php
+++ b/tests/Fixture/Unify/ClassUnionFirst.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ClassUnionFirst
+{
+    public function narrow(): \ArrayObject|int;
+
+    public function wide(): \Countable|int;
+}

--- a/tests/Fixture/Unify/ClosureFactory.php
+++ b/tests/Fixture/Unify/ClosureFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ClosureFactory
+{
+    public function factory(): \Closure;
+}

--- a/tests/Fixture/Unify/CountableValue.php
+++ b/tests/Fixture/Unify/CountableValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface CountableValue
+{
+    public function value(): \Countable;
+}

--- a/tests/Fixture/Unify/DnfParam.php
+++ b/tests/Fixture/Unify/DnfParam.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface DnfParam
+{
+    public function store((ReaderInt&ReaderStringy)|null $slot): void;
+}

--- a/tests/Fixture/Unify/DnfParamToo.php
+++ b/tests/Fixture/Unify/DnfParamToo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface DnfParamToo
+{
+    public function store(ReaderInt&ReaderStringy $slot): void;
+}

--- a/tests/Fixture/Unify/GeneratorAll.php
+++ b/tests/Fixture/Unify/GeneratorAll.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface GeneratorAll
+{
+    public function all(): \Generator;
+}

--- a/tests/Fixture/Unify/InstanceDescribe.php
+++ b/tests/Fixture/Unify/InstanceDescribe.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface InstanceDescribe
+{
+    public function describe(): string;
+}

--- a/tests/Fixture/Unify/IntTailPlain.php
+++ b/tests/Fixture/Unify/IntTailPlain.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface IntTailPlain
+{
+    public function sink(int ...$items): void;
+}

--- a/tests/Fixture/Unify/InterfaceUnionSecond.php
+++ b/tests/Fixture/Unify/InterfaceUnionSecond.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface InterfaceUnionSecond
+{
+    public function narrow(): \Countable|string;
+
+    public function wide(): \ArrayObject|string;
+}

--- a/tests/Fixture/Unify/InterfaceValue.php
+++ b/tests/Fixture/Unify/InterfaceValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface InterfaceValue
+{
+    public function value(): ReaderInt;
+}

--- a/tests/Fixture/Unify/IntersectedInt.php
+++ b/tests/Fixture/Unify/IntersectedInt.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface IntersectedInt
+{
+    public function intersected(): int;
+}

--- a/tests/Fixture/Unify/IntersectedPair.php
+++ b/tests/Fixture/Unify/IntersectedPair.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface IntersectedPair
+{
+    public function pick(): IntersectionAlpha&IntersectionBeta;
+}

--- a/tests/Fixture/Unify/IterableAll.php
+++ b/tests/Fixture/Unify/IterableAll.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface IterableAll
+{
+    public function all(): iterable;
+}

--- a/tests/Fixture/Unify/MixedTail.php
+++ b/tests/Fixture/Unify/MixedTail.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface MixedTail
+{
+    public function sink(mixed ...$items): void;
+}

--- a/tests/Fixture/Unify/MixedValue.php
+++ b/tests/Fixture/Unify/MixedValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface MixedValue
+{
+    public function value(): mixed;
+}

--- a/tests/Fixture/Unify/NarrowPartsUnion.php
+++ b/tests/Fixture/Unify/NarrowPartsUnion.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface NarrowPartsUnion
+{
+    public function pick(): (BothIterableCountable&\JsonSerializable)|string;
+}

--- a/tests/Fixture/Unify/NeverValue.php
+++ b/tests/Fixture/Unify/NeverValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface NeverValue
+{
+    public function value(): never;
+}

--- a/tests/Fixture/Unify/NullableString.php
+++ b/tests/Fixture/Unify/NullableString.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface NullableString
+{
+    public function fetch(): ?string;
+}

--- a/tests/Fixture/Unify/ObjectTail.php
+++ b/tests/Fixture/Unify/ObjectTail.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ObjectTail
+{
+    public function sink(object ...$items): void;
+}

--- a/tests/Fixture/Unify/ObjectValueToo.php
+++ b/tests/Fixture/Unify/ObjectValueToo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ObjectValueToo
+{
+    public function value(): object;
+}

--- a/tests/Fixture/Unify/SelfValue.php
+++ b/tests/Fixture/Unify/SelfValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface SelfValue
+{
+    public function value(): self;
+}

--- a/tests/Fixture/Unify/StaticValue.php
+++ b/tests/Fixture/Unify/StaticValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface StaticValue
+{
+    public function value(): static;
+}

--- a/tests/Fixture/Unify/StdClassAll.php
+++ b/tests/Fixture/Unify/StdClassAll.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface StdClassAll
+{
+    public function all(): \stdClass;
+}

--- a/tests/Fixture/Unify/StdClassFactory.php
+++ b/tests/Fixture/Unify/StdClassFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface StdClassFactory
+{
+    public function factory(): \stdClass;
+}

--- a/tests/Fixture/Unify/StringFlag.php
+++ b/tests/Fixture/Unify/StringFlag.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface StringFlag
+{
+    public function flag(): string;
+}

--- a/tests/Fixture/Unify/StringyOnly.php
+++ b/tests/Fixture/Unify/StringyOnly.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface StringyOnly
+{
+    public function pick(): ReaderStringy;
+}

--- a/tests/Fixture/Unify/TraversableAlphaUnion.php
+++ b/tests/Fixture/Unify/TraversableAlphaUnion.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface TraversableAlphaUnion
+{
+    public function pick(): (IntersectionAlpha&\Traversable)|int;
+}

--- a/tests/Fixture/Unify/TripleUnion.php
+++ b/tests/Fixture/Unify/TripleUnion.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface TripleUnion
+{
+    public function pick(): IntersectionAlpha|IntersectionBeta|ReaderStringy;
+}

--- a/tests/Fixture/Unify/TrueFlag.php
+++ b/tests/Fixture/Unify/TrueFlag.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface TrueFlag
+{
+    public function flag(): true;
+}

--- a/tests/Fixture/Unify/TypeShowcase.php
+++ b/tests/Fixture/Unify/TypeShowcase.php
@@ -26,5 +26,9 @@ interface TypeShowcase
 
     public function returnsNullableObject(): ?TypeShowcase;
 
+    public function dnf((ReaderInt&ReaderStringy)|null $a): void;
+
+    public function returnsDnf(): (ReaderInt&ReaderStringy)|null;
+
     public function returnsNever(): never;
 }

--- a/tests/Fixture/Unify/TypedUntypedTail.php
+++ b/tests/Fixture/Unify/TypedUntypedTail.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface TypedUntypedTail
+{
+    public function untypedTail(int ...$anything): void;
+}

--- a/tests/Fixture/Unify/UnionAlphaBeta.php
+++ b/tests/Fixture/Unify/UnionAlphaBeta.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface UnionAlphaBeta
+{
+    public function pick(): IntersectionAlpha|IntersectionBeta;
+}

--- a/tests/Fixture/Unify/UnionAlphaStringy.php
+++ b/tests/Fixture/Unify/UnionAlphaStringy.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface UnionAlphaStringy
+{
+    public function pick(): IntersectionAlpha|ReaderStringy;
+}

--- a/tests/Fixture/Unify/UnionReaderInt.php
+++ b/tests/Fixture/Unify/UnionReaderInt.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface UnionReaderInt
+{
+    public function value(): ReaderInt|int;
+}

--- a/tests/Fixture/Unify/UnionReaderString.php
+++ b/tests/Fixture/Unify/UnionReaderString.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface UnionReaderString
+{
+    public function value(): ReaderInt|string;
+}

--- a/tests/Fixture/Unify/VariadicByValueTail.php
+++ b/tests/Fixture/Unify/VariadicByValueTail.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface VariadicByValueTail
+{
+    public function byRefTail(int ...$slots): void;
+}

--- a/tests/Fixture/Unify/WidePartsUnion.php
+++ b/tests/Fixture/Unify/WidePartsUnion.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface WidePartsUnion
+{
+    public function pick(): (\Traversable&\Countable&\Stringable)|int;
+}

--- a/tests/LedgerTest.php
+++ b/tests/LedgerTest.php
@@ -8,6 +8,13 @@ use Rasuvaeff\Understudy\Arg;
 use Rasuvaeff\Understudy\Exception\ContextOwnershipViolation;
 use Rasuvaeff\Understudy\Exception\ForgottenDouble;
 use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Expectation\Expectation;
+use Rasuvaeff\Understudy\FailureReport;
+use Rasuvaeff\Understudy\Invocation;
+use Rasuvaeff\Understudy\Outcome;
+use Rasuvaeff\Understudy\Runtime\DoubleState;
+use Rasuvaeff\Understudy\Runtime\Runtime;
+use Rasuvaeff\Understudy\Runtime\RuntimeContext;
 use Rasuvaeff\Understudy\Tests\Fixture\Book;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
 use Rasuvaeff\Understudy\Tests\Fixture\Clock;
@@ -29,6 +36,16 @@ use function Rasuvaeff\Understudy\when;
  */
 #[Test]
 #[Covers(Understudy::class)]
+#[Covers(Runtime::class)]
+#[Covers(RuntimeContext::class)]
+#[Covers(DoubleState::class)]
+#[Covers(Expectation::class)]
+#[Covers(Invocation::class)]
+#[Covers(Outcome::class)]
+#[Covers(FailureReport::class)]
+#[Covers(ContextOwnershipViolation::class)]
+#[Covers(ForgottenDouble::class)]
+#[Covers(VerificationFailed::class)]
 final class LedgerTest
 {
     #[AfterTest]
@@ -298,7 +315,11 @@ final class LedgerTest
     {
         $repository = Understudy::for(BookRepository::class);
 
-        Expect::exception(ContextOwnershipViolation::class);
+        Expect::exception(ContextOwnershipViolation::class)->withMessage(
+            'This understudy belongs to a different runtime context. '
+            . 'Configure and verify it in the scope or Fiber that created it; '
+            . 'only normal method calls may cross context boundaries.',
+        );
 
         Understudy::scope(
             static fn() => Understudy::verifySequence(fn() => $repository->count()),
@@ -458,7 +479,11 @@ final class LedgerTest
     {
         $outer = Understudy::for(BookRepository::class);
 
-        Expect::exception(ContextOwnershipViolation::class);
+        Expect::exception(ContextOwnershipViolation::class)->withMessage(
+            'This understudy belongs to a different runtime context. '
+            . 'Configure and verify it in the scope or Fiber that created it; '
+            . 'only normal method calls may cross context boundaries.',
+        );
 
         Understudy::scope(static function () use ($outer): void {
             expect(fn() => $outer->count());
@@ -469,7 +494,11 @@ final class LedgerTest
     {
         $escaped = Understudy::scope(static fn(): BookRepository => Understudy::for(BookRepository::class));
 
-        Expect::exception(ForgottenDouble::class)->withMessageContaining('count()');
+        Expect::exception(ForgottenDouble::class)->withMessage(
+            "This understudy is no longer known to Understudy, but `count()` was called on it.\n"
+            . 'It was created before a reset(); create doubles inside the test that uses them '
+            . 'rather than sharing one across tests.',
+        );
 
         $escaped->count();
     }
@@ -538,7 +567,329 @@ final class LedgerTest
         Assert::same($repository->count(), 7);
     }
 
+    // --- verifyAll reporting -------------------------------------------------
+
+    public function verifyAllReportsEveryUnmetExpectationInOneMessage(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->count());
+        expect(fn() => $repository->titles());
+
+        // Reported in the order the claims were written, which is not the
+        // order the ledger keeps them in.
+        Expect::exception(VerificationFailed::class)->withMessage(
+            "Understudy `BookRepository` expected `count()` to be called exactly 1 time, but it was called never.\n\n"
+            . 'Understudy `BookRepository` expected `titles()` to be called exactly 1 time, but it was called never.',
+        );
+
+        Understudy::verifyAll();
+    }
+
+    public function theActualCountIsSpelledOutInTheFailure(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->count())->times(3);
+
+        $repository->count();
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            'Understudy `BookRepository` expected `count()` to be called exactly 3 times, but it was called 1 time.',
+        );
+
+        Understudy::verifyAll();
+    }
+
+    public function aRepeatedCallIsCountedInThePlural(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->count())->times(3);
+
+        $repository->count();
+        $repository->count();
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            'Understudy `BookRepository` expected `count()` to be called exactly 3 times, but it was called 2 times.',
+        );
+
+        Understudy::verifyAll();
+    }
+
+    #[ExpectNoAssertions]
+    public function strictStubsAcceptsAStubThatWasUsed(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->count())->returns(7);
+        $repository->count();
+
+        Understudy::verifyAll(strictStubs: true);
+    }
+
+    #[ExpectNoAssertions]
+    public function anUnusedStubIsFineWithoutStrictStubs(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->count())->returns(7);
+
+        Understudy::verifyAll();
+    }
+
+    #[ExpectNoAssertions]
+    public function allVerifiedIgnoresAnUnusedStub(): void
+    {
+        // `allVerified()` is about claims and stray calls, not about stubs
+        // that turned out to be unnecessary.
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->count())->returns(7);
+        expect(fn() => $repository->titles())->returns([]);
+
+        $repository->titles();
+
+        Understudy::allVerified($repository);
+    }
+
+    #[ExpectNoAssertions]
+    public function allVerifiedIgnoresAnotherDoublesOrdering(): void
+    {
+        $primary = Understudy::for(BookRepository::class);
+        $secondary = Understudy::for(BookRepository::class);
+
+        expect(fn() => $secondary->count())->ordered();
+        expect(fn() => $secondary->titles())->ordered();
+        expect(fn() => $primary->count());
+
+        $secondary->titles();
+        $secondary->count();
+        $primary->count();
+
+        Understudy::allVerified($primary);
+    }
+
+    #[ExpectNoAssertions]
+    public function checkpointRetiresTheExpectationsItSettled(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->count());
+        $repository->count();
+
+        Understudy::checkpoint();
+
+        // The claim was settled at the checkpoint: a later call is no longer
+        // its business, so it cannot fail on the count.
+        $repository->count();
+
+        Understudy::verifyAll();
+    }
+
+    #[ExpectNoAssertions]
+    public function aScopeIsLeftEvenWhenItsCallbackThrows(): void
+    {
+        $outer = Understudy::for(BookRepository::class);
+
+        try {
+            Understudy::scope(static function (): void {
+                throw new \DomainException('the real problem');
+            });
+        } catch (\DomainException) {
+            // The point is what happens next, not the exception itself.
+        }
+
+        // Still inside the scope, this would be a ContextOwnershipViolation.
+        when(fn() => $outer->count())->returns(1);
+    }
+
+    #[ExpectNoAssertions]
+    public function aScopeIsLeftEvenWhenItsOwnVerificationFails(): void
+    {
+        $outer = Understudy::for(BookRepository::class);
+
+        try {
+            Understudy::scope(static function (): void {
+                $inner = Understudy::for(BookRepository::class);
+                expect(fn() => $inner->count());
+            });
+        } catch (VerificationFailed) {
+            // Same again: the scope must be popped before this is rethrown.
+        }
+
+        when(fn() => $outer->count())->returns(1);
+    }
+
+    public function allVerifiedFindsAnOrderingViolationOnALaterDouble(): void
+    {
+        // The double under verification is not the first one registered, so
+        // the scan has to skip past the others rather than stop at them.
+        $primary = Understudy::for(BookRepository::class);
+        $secondary = Understudy::for(BookRepository::class);
+
+        expect(fn() => $primary->count());
+        expect(fn() => $secondary->count())->ordered();
+        expect(fn() => $secondary->titles())->ordered();
+
+        $primary->count();
+        $secondary->titles();
+        $secondary->count();
+
+        Expect::exception(VerificationFailed::class)->withMessageContaining('but it happened first');
+
+        Understudy::allVerified($secondary);
+    }
+
+    // --- fibers --------------------------------------------------------------
+
+    public function aCallFromAnotherFiberIsRecordedByTheOwner(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        $fiber = new \Fiber(static function () use ($repository): void {
+            $repository->count();
+        });
+        $fiber->start();
+
+        Assert::same(count(Understudy::calls(fn() => $repository->count())), 1);
+    }
+
+    public function aResetInsideAFiberForgetsThatFibersDoubles(): void
+    {
+        $fiber = new \Fiber(static function (): BookRepository {
+            $inside = Understudy::for(BookRepository::class);
+            Understudy::reset();
+
+            return $inside;
+        });
+        $fiber->start();
+        /** @var BookRepository $escaped */
+        $escaped = $fiber->getReturn();
+
+        Expect::exception(ForgottenDouble::class)->withMessageContaining('count()');
+
+        $escaped->count();
+    }
+
+    public function aResetInsideAFiberStartsTheCallOrderAgain(): void
+    {
+        $sequences = [];
+
+        $fiber = new \Fiber(static function () use (&$sequences): void {
+            $first = Understudy::for(BookRepository::class);
+            $first->count();
+
+            Understudy::reset();
+
+            $second = Understudy::for(BookRepository::class);
+            $second->count();
+
+            /** @var list<int> $sequences */
+            $sequences = array_map(
+                static fn(Invocation $invocation): int => $invocation->sequence,
+                Understudy::calls(fn() => $second->count()),
+            );
+        });
+        $fiber->start();
+
+        Assert::same($sequences, [1]);
+    }
+
+    public function scopesNestInsideAFiberLikeAnywhereElse(): void
+    {
+        $escaped = null;
+
+        $fiber = new \Fiber(static function () use (&$escaped): void {
+            $outer = Understudy::for(BookRepository::class);
+            when(fn() => $outer->count())->returns(1);
+
+            $escaped = Understudy::scope(static function (): Clock {
+                $inner = Understudy::for(Clock::class);
+                when(fn() => $inner->now())->returns(5);
+
+                Assert::same($inner->now(), 5);
+
+                return $inner;
+            });
+
+            Assert::same($outer->count(), 1);
+
+            // Back in the fiber's own context: configuring the outer double
+            // would be a ContextOwnershipViolation from inside the scope.
+            when(fn() => $outer->titles())->returns(['Dune']);
+
+            Assert::same($outer->titles(), ['Dune']);
+        });
+        $fiber->start();
+
+        Assert::instanceOf($escaped, Clock::class);
+
+        Expect::exception(ForgottenDouble::class)->withMessageContaining('now()');
+
+        $escaped->now();
+    }
+
+    // --- invocations in flight -----------------------------------------------
+
+    public function anInFlightInvocationHasNoOutcomeYet(): void
+    {
+        // `answers()` runs while the call is still in progress: the outcome
+        // is filled in by the dispatcher only once the answer is known.
+        $repository = Understudy::for(BookRepository::class);
+        $seen = [];
+
+        when(fn() => $repository->count())->answers(
+            static function (Invocation $invocation) use (&$seen): int {
+                $seen = [
+                    'returned' => $invocation->didReturn(),
+                    'threw' => $invocation->didThrow(),
+                    'value' => $invocation->returned(),
+                    'error' => $invocation->thrown(),
+                ];
+
+                return 7;
+            },
+        );
+
+        Assert::same($repository->count(), 7);
+        Assert::same($seen, ['returned' => false, 'threw' => false, 'value' => null, 'error' => null]);
+    }
+
+    public function aCheckpointDropsTheCallsItAccountedFor(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->count());
+        $repository->count();
+        $repository->titles();
+
+        Understudy::checkpoint();
+
+        // The settled call is gone; the one nothing claimed is still there to
+        // be explained.
+        Assert::same(Understudy::calls(fn() => $repository->count()), []);
+        Assert::same(count(Understudy::calls(fn() => $repository->titles())), 1);
+    }
+
+    #[ExpectNoAssertions]
+    public function verifySequenceAfterACheckpointSeesOnlyTheNewCalls(): void
+    {
+        // The settled calls are dropped from the log, and what remains has to
+        // be a list again — verifySequence() reads it by position.
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->count());
+        $repository->count();
+        $repository->titles();
+
+        Understudy::checkpoint();
+
+        Understudy::verifySequence(fn() => $repository->titles());
+    }
+
     // --- transcript ----------------------------------------------------------
+
 
     public function transcriptShowsEveryCallWithItsOutcome(): void
     {
@@ -556,11 +907,19 @@ final class LedgerTest
             // Recorded either way.
         }
 
+        $repository->tag('alpha');
+
         $transcript = Understudy::transcript($repository);
 
-        Assert::string($transcript)->contains('catalogue');
-        Assert::string($transcript)->contains('count() -> returned 7');
-        Assert::string($transcript)->contains('titles() -> threw RuntimeException');
+        // Asserted whole: the transcript is read by a human looking for the
+        // call that surprised them, so every part of the line is contract.
+        Assert::same(
+            $transcript,
+            "Understudy `catalogue` received 3 call(s):\n"
+            . "  #1 count() -> returned 7\n"
+            . "  #2 titles() -> threw RuntimeException\n"
+            . "  #3 tag('alpha', 1) -> returned ''",
+        );
     }
 
     public function transcriptSaysSoWhenNothingHappened(): void

--- a/tests/UnderstudyTest.php
+++ b/tests/UnderstudyTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Rasuvaeff\Understudy\Tests;
 
 use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Codegen\Blueprint;
+use Rasuvaeff\Understudy\Codegen\DoubleFactory;
+use Rasuvaeff\Understudy\Codegen\MethodSignature;
 use Rasuvaeff\Understudy\Exception\ForgottenDouble;
 use Rasuvaeff\Understudy\Exception\InvalidCallSpecification;
 use Rasuvaeff\Understudy\Exception\MatcherLeaked;
@@ -12,10 +15,20 @@ use Rasuvaeff\Understudy\Exception\NeverMethodCalled;
 use Rasuvaeff\Understudy\Exception\StrictModeViolation;
 use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
 use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Expectation\Expectation;
+use Rasuvaeff\Understudy\FailureReport;
 use Rasuvaeff\Understudy\Invocation;
+use Rasuvaeff\Understudy\Outcome;
+use Rasuvaeff\Understudy\Runtime\DoubleState;
+use Rasuvaeff\Understudy\Runtime\InvocationSignal;
+use Rasuvaeff\Understudy\Runtime\Mode;
+use Rasuvaeff\Understudy\Runtime\Runtime;
+use Rasuvaeff\Understudy\Runtime\RuntimeContext;
 use Rasuvaeff\Understudy\Tests\Fixture\Book;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
 use Rasuvaeff\Understudy\Tests\Fixture\Clock;
+use Rasuvaeff\Understudy\Tests\Fixture\HashedContract;
+use Rasuvaeff\Understudy\Tests\Fixture\HashedContractToo;
 use Rasuvaeff\Understudy\Tests\Fixture\Named;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntersectionAlpha;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntersectionBeta;
@@ -37,11 +50,31 @@ use Testo\Expect;
 use Testo\Lifecycle\AfterTest;
 use Testo\Test;
 
+use function Rasuvaeff\Understudy\expect;
 use function Rasuvaeff\Understudy\verify;
 use function Rasuvaeff\Understudy\when;
 
 #[Test]
 #[Covers(Understudy::class)]
+#[Covers(Runtime::class)]
+#[Covers(RuntimeContext::class)]
+#[Covers(DoubleState::class)]
+#[Covers(InvocationSignal::class)]
+#[Covers(Mode::class)]
+#[Covers(Invocation::class)]
+#[Covers(Outcome::class)]
+#[Covers(FailureReport::class)]
+#[Covers(Expectation::class)]
+#[Covers(DoubleFactory::class)]
+#[Covers(Blueprint::class)]
+#[Covers(MethodSignature::class)]
+#[Covers(ForgottenDouble::class)]
+#[Covers(InvalidCallSpecification::class)]
+#[Covers(MatcherLeaked::class)]
+#[Covers(NeverMethodCalled::class)]
+#[Covers(StrictModeViolation::class)]
+#[Covers(UnsupportedTarget::class)]
+#[Covers(VerificationFailed::class)]
 final class UnderstudyTest
 {
     #[AfterTest]
@@ -77,7 +110,10 @@ final class UnderstudyTest
     {
         $double = Understudy::for(WriterInt::class);
 
-        Expect::exception(InvalidCallSpecification::class)->withMessageContaining('Static method `describe()`');
+        Expect::exception(InvalidCallSpecification::class)->withMessage(
+            "Static method `describe()` cannot be called on an understudy because static calls have no instance state.\n"
+            . 'Inject an instance dependency and double that contract instead.',
+        );
 
         $double::describe();
     }
@@ -220,7 +256,10 @@ final class UnderstudyTest
     {
         $repository = Understudy::for(BookRepository::class);
 
-        Expect::exception(NeverMethodCalled::class)->withMessageContaining('abort()');
+        Expect::exception(NeverMethodCalled::class)->withMessage(
+            "Understudy `BookRepository` received a call to `abort()`, which is declared `: never` and cannot return.\n"
+            . 'Configure what it throws: when(fn () => $double->abort(...))->throws(new SomeException())',
+        );
 
         $repository->abort('stop');
     }
@@ -241,7 +280,10 @@ final class UnderstudyTest
         $repository = Understudy::for(BookRepository::class);
         Understudy::strict($repository);
 
-        Expect::exception(StrictModeViolation::class)->withMessageContaining('count()');
+        Expect::exception(StrictModeViolation::class)->withMessage(
+            "Understudy `BookRepository` is strict and received an unexpected call to `count()`.\n"
+            . 'Configure it first: when(fn () => $double->count(...))->returns(...)',
+        );
 
         $repository->count();
     }
@@ -414,14 +456,20 @@ final class UnderstudyTest
 
     public function specificationClosureWithoutACallIsRejected(): void
     {
-        Expect::exception(InvalidCallSpecification::class)->withMessageContaining('exactly one direct call');
+        Expect::exception(InvalidCallSpecification::class)->withMessage(
+            'The specification closure did not call a method on an understudy. '
+            . 'It must contain exactly one direct call, for example: '
+            . 'when(fn () => $repository->find(123))',
+        );
 
         Understudy::when(static fn(): bool => true);
     }
 
     public function specificationClosureFailureKeepsTheOriginalCause(): void
     {
-        Expect::exception(InvalidCallSpecification::class)->withPrevious(\DomainException::class);
+        Expect::exception(InvalidCallSpecification::class)
+            ->withPrevious(\DomainException::class)
+            ->withMessage('The specification closure threw before it reached an understudy: closure blew up');
 
         Understudy::when(static function (): never {
             throw new \DomainException('closure blew up');
@@ -430,7 +478,11 @@ final class UnderstudyTest
 
     public function classTargetsAreRejectedWithAnActionableMessage(): void
     {
-        Expect::exception(UnsupportedTarget::class)->withMessageContaining('interface');
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            'Cannot create an understudy for `' . Book::class . '`: only interfaces can be doubled in this '
+            . 'version. Double the interface it implements, or introduce one for the dependency you need to '
+            . 'stand in for.',
+        );
 
         Understudy::for(Book::class);
     }
@@ -476,7 +528,23 @@ final class UnderstudyTest
 
         when(fn() => $registry->slots())->returns(['a' => 1]);
 
-        Assert::same($registry->slots(), ['a' => 1]);
+        $notices = [];
+        set_error_handler(static function (int $severity, string $message) use (&$notices): bool {
+            $notices[] = $message;
+
+            return true;
+        });
+
+        try {
+            $value = $registry->slots();
+        } finally {
+            restore_error_handler();
+        }
+
+        Assert::same($value, ['a' => 1]);
+        // Returning the dispatch expression directly raises "Only variable
+        // references should be returned by reference".
+        Assert::same($notices, []);
     }
 
     public function aNeverMethodConfiguredToReturnIsRejected(): void
@@ -487,7 +555,10 @@ final class UnderstudyTest
 
         when(fn() => $repository->abort('stop'))->returns('nope');
 
-        Expect::exception(NeverMethodCalled::class)->withMessageContaining('cannot');
+        Expect::exception(NeverMethodCalled::class)->withMessage(
+            "Understudy `BookRepository` has `abort()` configured to return, but the method is declared `: never` and cannot.\n"
+            . 'Configure it to throw instead: when(fn () => $double->abort(...))->throws(new SomeException())',
+        );
 
         $repository->abort('stop');
     }
@@ -499,7 +570,11 @@ final class UnderstudyTest
         $repository = Understudy::for(BookRepository::class);
         Understudy::reset();
 
-        Expect::exception(ForgottenDouble::class)->withMessageContaining('count()');
+        Expect::exception(ForgottenDouble::class)->withMessage(
+            "This understudy is no longer known to Understudy, but `count()` was called on it.\n"
+            . 'It was created before a reset(); create doubles inside the test that uses them '
+            . 'rather than sharing one across tests.',
+        );
 
         $repository->count();
     }
@@ -559,10 +634,11 @@ final class UnderstudyTest
         // wildcard for that one argument — worse than any error message.
         $sink = Understudy::for(VariadicSink::class);
 
-        Expect::exception(InvalidCallSpecification::class)
-            ->withMessageContaining('remaining()')
-            ->withMessageContaining('argument #1')
-            ->withMessageContaining('write()');
+        Expect::exception(InvalidCallSpecification::class)->withMessage(
+            '`remaining()` stands for the whole variadic tail, so it may only be the last argument, '
+            . "but it was given as argument #1 of `write()`.\n"
+            . 'Move it to the end, or use Arg::any() to match that one argument.',
+        );
 
         Understudy::when(fn() => $sink->write(Arg::remaining(), 1));
     }
@@ -571,7 +647,11 @@ final class UnderstudyTest
     {
         $sink = Understudy::for(VariadicSink::class);
 
-        Expect::exception(InvalidCallSpecification::class)->withMessageContaining('none()');
+        Expect::exception(InvalidCallSpecification::class)->withMessage(
+            '`none()` stands for the whole variadic tail, so it may only be the last argument, '
+            . "but it was given as argument #1 of `write()`.\n"
+            . 'Move it to the end, or use Arg::any() to match that one argument.',
+        );
 
         Understudy::when(fn() => $sink->write(Arg::none(), 1));
     }
@@ -600,9 +680,10 @@ final class UnderstudyTest
         // receive one.
         $repository = Understudy::for(BookRepository::class);
 
-        Expect::exception(MatcherLeaked::class)
-            ->withMessageContaining('find()')
-            ->withMessageContaining('any()');
+        Expect::exception(MatcherLeaked::class)->withMessage(
+            "Argument #1 of `find()` was given the matcher `any()` during a real call.\n"
+            . 'Matchers belong inside when()/verify()/calls(), not in the call the code under test makes.',
+        );
 
         $repository->find(Arg::any());
     }
@@ -637,5 +718,143 @@ final class UnderstudyTest
 
         Assert::same($first->now(), 100);
         Assert::same($second->now(), 0);
+    }
+
+    // --- verify() failure reports --------------------------------------------
+
+    public function aMethodThatWasNeverCalledSaysExactlyThat(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        // Another method was called, so there is a log — but none of it is
+        // about `count()`, and listing it would be noise.
+        $repository->titles();
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            'Understudy `BookRepository` expected `count()` to be called at least 1 time, but it was never called.',
+        );
+
+        verify(fn() => $repository->count());
+    }
+
+    public function callsToTheSameMethodAreListedWithTheDifferingArgumentMarked(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        $repository->tag('alpha');
+        $repository->tag('beta');
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            "Understudy `BookRepository` expected `tag('gamma', 1)` to be called at least 1 time, but it was never called.\n\n"
+            . "The following calls to `tag` were made during this test:\n"
+            . "    tag(*'alpha'*, 1)\n"
+            . "    tag(*'beta'*, 1)",
+        );
+
+        verify(fn() => $repository->tag('gamma'));
+    }
+
+    public function aPlainCountMismatchNeedsNoCallLog(): void
+    {
+        // Every call to the method matched: repeating them under "these are
+        // the calls" would tell the reader nothing new.
+        $repository = Understudy::for(BookRepository::class);
+
+        $repository->count();
+        $repository->count();
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            'Understudy `BookRepository` expected `count()` to be called exactly 3 times, but it was called 2 times.',
+        );
+
+        verify(fn() => $repository->count(), times: 3);
+    }
+
+    public function aRangeIsSpelledOutAsARange(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        $repository->count();
+        $repository->count();
+        $repository->count();
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            'Understudy `BookRepository` expected `count()` to be called between 0 and 2 times, but it was called 3 times.',
+        );
+
+        verify(fn() => $repository->count(), minimum: 0, maximum: 2);
+    }
+
+    public function anAtLeastFailureNamesTheLowerBound(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            'Understudy `BookRepository` expected `count()` to be called at least 2 times, but it was never called.',
+        );
+
+        verify(fn() => $repository->count(), minimum: 2);
+    }
+
+    public function averificationThatWantedNothingSaysNever(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        $repository->count();
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            'Understudy `BookRepository` expected `count()` to be called never, but it was called 1 time.',
+        );
+
+        verify(fn() => $repository->count(), never: true);
+    }
+
+    public function theGeneratedClassIsNamedAfterAHashOfItsContracts(): void
+    {
+        // The suffix is a fixed-width digest: a shorter or longer slice would
+        // change how likely two contract sets are to collide.
+        // A contract no other test doubles: otherwise the blueprint cache
+        // answers and the naming code never runs here.
+        $double = Understudy::for(HashedContract::class);
+
+        Assert::true((bool) preg_match(
+            '/^Rasuvaeff\\\\Understudy\\\\Codegen\\\\Generated\\\\Understudy_[0-9a-f]{16}$/',
+            $double::class,
+        ));
+    }
+
+    public function twoContractSetsGetTwoGeneratedClasses(): void
+    {
+        Assert::true(
+            Understudy::for(HashedContract::class)::class !== Understudy::for(HashedContractToo::class)::class,
+        );
+    }
+
+    public function configuringAForgottenDoubleIsRejected(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        Understudy::reset();
+
+        Expect::exception(InvalidCallSpecification::class)->withMessage(
+            'The specification closure did not call a method on an understudy. '
+            . 'It must contain exactly one direct call, for example: '
+            . 'when(fn () => $repository->find(123))',
+        );
+
+        Understudy::label($repository, 'catalogue');
+    }
+
+    public function anExpectationWithoutAnActionStopsTheSearch(): void
+    {
+        // The expectation matched first and has no action of its own, so the
+        // mode's default answers; the stub behind it is not consulted.
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->tag(Arg::any()))->returns('stub');
+        expect(fn() => $repository->tag('alpha'));
+
+        Assert::same($repository->tag('alpha'), '');
+
+        Understudy::verifyAll();
     }
 }


### PR DESCRIPTION
## Why

Half the package generated no mutants at all. 25 of 53 `src/` types were named in no `#[Covers]` attribute, and testo builds its coverage report from attribution rather than from executed lines — so Infection never generated mutants for them. `Runtime`, `DoubleState`, `Expectation`, `Invocation`, `FailureReport`, `DoubleFactory` and `Blueprint` were invisible to the mutation gate while every test ran straight through them.

`Not Covered: 0` and "MSI 86%" read as a guarantee that did not exist.

## Numbers

| Stage | Mutants | Escaped | MSI |
|---|---|---|---|
| Before | 1022 | 137 | 86% |
| After honest `#[Covers]` | 1440 | 214 | 84% (below the 85 gate) |
| After killing what survived | 1440 | 54 | 96% |

`minMsi` goes 85 → 95, leaving 18 mutants of margin for the randomness of the property tests.

## What the new tests do

Mostly exactness rather than new scenarios:

- whole failure messages instead of substrings, and the whole transcript;
- boundary cases for string truncation (including multibyte and non-repeating input, so an offset shift shows) and for nesting depth, keys included;
- fixtures for every return-type compatibility rule — `never`, `mixed`, `object`, `bool`/`true`, `iterable` vs `array` vs a `\Traversable` class, `callable`/`Closure`, class-to-interface, DNF intersections, atom supersession, union overlap rendered as `A|(B&S)`;
- fiber tests for owner-routed calls, scope nesting, and a reset that touches only the current context.

## One real fix

A variadic tail declared by reference in one target and by value in another named the same target on both lines of the rejection. It now names the target that set the mode and the one that broke it.

## The 54 survivors, classified

`array_values()` kept for the list type (every consumer re-indexes or iterates), `ltrim()` before `is_a`/`interface_exists` (PHP accepts the leading backslash), `break` as a loop exit, the blueprint cache, an unreachable parameter-name fallback, and `??=` in `recordOutcome` (two call sites, mutually exclusive). No ignores were added: the honest gate is cleaner than a hidden one.

## Verification

`composer build` and `composer rector` are green, and the suite was run on 8.3, 8.4 and 8.5 — which is how a version-dependent assertion was caught before CI: Reflection reports `self` verbatim on 8.3/8.4 and resolves it to the declaring interface on 8.5, so that one assertion accepts either rendering.