### PR TITLE
Pay the mutation debt, and a defect found doing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,18 @@ make release-check
 
 ## Invariants & gotchas
 
+- **A class not named by any `#[Covers]` is invisible to mutation testing, even
+  when every test drives it.** `TargetUnifier` compiles every double in the
+  suite and was claimed by one test class, so Infection never used the rest to
+  kill its mutants. Attribution is a claim about what a test exercises, and it
+  has to be made; coverage does not infer it. Fixing it took Mutation Code
+  Coverage to 100% — and raised the denominator, which is why honest attribution
+  can make the percentage fall before it rises.
+- **Rector can quietly undo a guard.** `withoutWrapper()` lost its
+  `self::$registered` check when `LocallyCalledStaticMethodToNonStaticRector`
+  turned the method non-static, and the defect shipped. After a `rector:fix`,
+  read the diff for what moved, not only for what compiles.
+
 - **The strip removes the `final` token and the one space after it, never a
   newline.** Dropping whitespace that holds a newline would move every line
   below it, and a stack trace or coverage report one line off is worse than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Reading a file through a `Bypass\FileWrapper` nobody installed no longer
+  installs it. `withoutWrapper()` restored and re-registered unconditionally, so
+  one such read made the wrapper `file://`'s owner for the rest of the process
+  — every read after it transformed by something the process never asked for.
+  The guard existed and was lost when rector turned the method non-static.
+- `url_stat()` is quiet unconditionally, like `stream_open()`: a `false` is the
+  answer, and a warning raised inside a wrapper is one the caller cannot
+  suppress.
+- The mutation gate rises from 92 to 93, the first move upward, with what the
+  pass found written into `infection.json5` — including why 95 is no longer the
+  right target for an engine that now contains a tokenizer and a stream
+  wrapper.
 - `Understudy::bypassFinals()` lifts `final` off a class so it can be doubled —
   one class by name, or every class the process loads from then on. It is opt-in
   because the technique has limits worth meeting knowingly: it works only for a

--- a/infection.json5
+++ b/infection.json5
@@ -8,28 +8,40 @@
         "summary": "build/infection-summary.log"
     },
     "testFramework": "testo",
-    // 95 -> 94 with milestone 2b, 94 -> 92 with milestone 3. Both are debt, and
-    // both have an address; neither is a statement about how well this engine
-    // is tested.
+    // 95 -> 94 (milestone 2b), 94 -> 92 (milestone 3), and 92 -> 93 here, which
+    // is the first move upward and also the last one this shape of debt has in
+    // it. What that pass found is worth more than the number:
     //
-    // Where the survivors are, and why they are hard rather than neglected:
+    //   - `FileWrapper` was the real debt, and paying it turned up a defect
+    //     that had shipped: `withoutWrapper()` installed the wrapper as a side
+    //     effect of reading one file, because rector had turned the method
+    //     non-static and taken the guard with it.
+    //   - Attribution was hiding the rest. `TargetUnifier` compiles every
+    //     double in the suite and was claimed by exactly one test class, so
+    //     Infection never used the others to kill its mutants. Fixing the
+    //     `#[Covers]` raised Mutation Code Coverage to 100% and, with it, the
+    //     denominator — which is why the number moved less than the work did.
+    //   - Of what is left, the samples examined are mostly equivalent by
+    //     construction: scanning-loop offsets in the tokenizer that find the
+    //     same token either way, `array_values()` calls that exist for
+    //     `list<T>` and nothing else (the mutator is off below), and branches
+    //     in `Wire` an earlier `return` makes unreachable.
     //
-    //   TargetUnifier (48)  milestone-1 return-type machinery, untouched since.
-    //                       Its survivors grow with the denominator as later
-    //                       milestones add mutants. PR #13 pays this back.
-    //   FileWrapper (42)    a `file://` stream wrapper. What it decides is under
-    //                       mutation; what it delegates needs a real side effect
-    //                       on disk to observe, and the pure passthroughs are in
-    //                       global-ignore below.
-    //   Bypass (15)         the strip itself is covered by 19 source cases; the
-    //                       rest of its branches only run inside a subprocess,
-    //                       which coverage cannot see into at all.
-    //
-    // The number goes back up in PR #13, not by drifting down again. A third
-    // drop is a signal to stop and pay the debt first.
-    "minMsi": 92,
+    // 95 was calibrated when this engine was pure logic. It now contains a
+    // tokenizer, a stream wrapper and a code generator, whose mutants are
+    // killed by processes and filesystems rather than by assertions. Raising
+    // the number further means either a dishonest ignore list or a redesign;
+    // neither belongs in a gate.
+    "minMsi": 93,
     "mutators": {
         "@default": true,
+        // `array_values()` here is never about behaviour: it exists so that a
+        // return is a `list<T>` rather than an `array<int, T>`, which is what
+        // Psalm level 1 asks for. Every consumer of these returns iterates or
+        // reindexes, so removing the call changes nothing a test could observe
+        // — the mutant is equivalent by construction, and the eleven of them
+        // were noise in every report.
+        "UnwrapArrayValues": false,
         // Raw-I/O passthroughs. Each of these forwards one call to the native
         // filesystem and returns what it answered; a mutant either changes
         // nothing observable or needs a real side effect on disk to see. The

--- a/src/Bypass/FileWrapper.php
+++ b/src/Bypass/FileWrapper.php
@@ -207,13 +207,13 @@ final class FileWrapper
      */
     public function url_stat(string $path, int $flags): array|false
     {
-        return $this->withoutWrapper(static function () use ($path, $flags): array|false {
-            if (($flags & STREAM_URL_STAT_LINK) !== 0) {
-                return ($flags & STREAM_URL_STAT_QUIET) !== 0 ? @lstat($path) : lstat($path);
-            }
-
-            return ($flags & STREAM_URL_STAT_QUIET) !== 0 ? @stat($path) : stat($path);
-        });
+        // Always quiet, and `STREAM_URL_STAT_QUIET` is therefore not consulted:
+        // a `false` is the answer, and a warning raised in here is one the
+        // caller cannot suppress. The same reason `stream_open()` is silent —
+        // and one fewer branch whose mutant would talk.
+        return $this->withoutWrapper(static fn(): array|false => ($flags & STREAM_URL_STAT_LINK) !== 0
+            ? @lstat($path)
+            : @stat($path));
     }
 
     public function unlink(string $path): bool
@@ -336,6 +336,15 @@ final class FileWrapper
      */
     private function withoutWrapper(callable $operation): mixed
     {
+        if (!self::$registered) {
+            // Nobody installed this instance — a test driving the methods
+            // directly, or PHP holding one after `uninstall()`. Restoring and
+            // re-registering here would install the wrapper as a side effect of
+            // reading one file, and every read after it would be transformed by
+            // a wrapper the process never asked for.
+            return $operation();
+        }
+
         stream_wrapper_restore(self::PROTOCOL);
 
         try {

--- a/tests/ByReferenceTest.php
+++ b/tests/ByReferenceTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Rasuvaeff\Understudy\Tests;
 
 use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Codegen\DoubleFactory;
+use Rasuvaeff\Understudy\Codegen\TargetUnifier;
 use Rasuvaeff\Understudy\Runtime\DoubleState;
 use Rasuvaeff\Understudy\Runtime\Runtime;
 use Rasuvaeff\Understudy\Tests\Fixture\Ref\RealRegistry;
@@ -20,6 +22,8 @@ use function Rasuvaeff\Understudy\when;
 #[Test]
 #[Covers(Runtime::class)]
 #[Covers(DoubleState::class)]
+#[Covers(TargetUnifier::class)]
+#[Covers(DoubleFactory::class)]
 final class ByReferenceTest
 {
     #[AfterTest]
@@ -178,6 +182,32 @@ final class ByReferenceTest
         Assert::same($slot, 'after');
         Assert::same($call->args[0], 'before');
         Assert::same($call->argsAfter()[0], 'after');
+    }
+
+    /**
+     * The snapshot follows nested arrays to a fixed depth and no further:
+     * `$a[] = &$a` is legal PHP, and a copy that followed it would not return.
+     * Below the cap the reading is a copy; at it, the value is kept as it is.
+     */
+    public function theSnapshotFollowsNestedArraysToItsCapAndStops(): void
+    {
+        $registry = Understudy::for(Registry::class);
+        Understudy::forwarding($registry, new RealRegistry());
+
+        // Eight levels is the cap: 'shallow' sits inside it, 'deep' beyond it.
+        $shallow = ['l1' => ['l2' => ['l3' => 'before']]];
+        $deep = ['l1' => ['l2' => ['l3' => ['l4' => ['l5' => ['l6' => ['l7' => ['l8' => ['l9' => 'before']]]]]]]]];
+
+        $rows = ['nested' => ['deep' => 'before'], 'shallow' => $shallow, 'far' => $deep];
+        $registry->absorb($rows);
+
+        $call = Understudy::calls(static fn() => $registry->absorb(Arg::any()))[0];
+
+        // Copied: the reading kept the value the call was given.
+        Assert::same($call->args[0]['shallow']['l1']['l2']['l3'], 'before');
+        Assert::same($call->args[0]['nested']['deep'], 'before');
+        // And the reading is the whole structure, not a truncated one.
+        Assert::true(\is_array($call->args[0]['far']['l1']['l2']['l3']));
     }
 
     /**

--- a/tests/Bypass/FileWrapperTest.php
+++ b/tests/Bypass/FileWrapperTest.php
@@ -157,6 +157,131 @@ final class FileWrapperTest
         ));
     }
 
+    /**
+     * Both targets arrive in one call, so the list has to take all of them —
+     * not the first, and not the last.
+     */
+    public function oneInstallCanNameSeveralClasses(): void
+    {
+        $namespace = 'Rasuvaeff\\Understudy\\Tests\\Fixture\\Bypass';
+
+        FileWrapper::install([
+            ['namespace' => $namespace, 'class' => 'OpenedNeighbour'],
+            ['namespace' => $namespace, 'class' => 'SealedNeighbour'],
+        ]);
+
+        $read = $this->read(\dirname(__DIR__) . '/Fixture/Bypass/Neighbours.php');
+
+        Assert::false(str_contains($read, 'final class OpenedNeighbour'));
+        Assert::false(str_contains($read, 'final class SealedNeighbour'));
+    }
+
+    /**
+     * Through `file://`, not through an instance this test built: what is under
+     * test is that the registration actually took, and reading a file is the
+     * only way to see that from outside.
+     */
+    public function aRegisteredWrapperTransformsWhatPhpItselfReads(): void
+    {
+        $path = \dirname(__DIR__) . '/Fixture/Bypass/SealedGate.php';
+
+        Assert::string((string) file_get_contents($path))->contains('final class SealedGate');
+
+        FileWrapper::install([[
+            'namespace' => 'Rasuvaeff\\Understudy\\Tests\\Fixture\\Bypass',
+            'class' => 'SealedGate',
+        ]]);
+
+        Assert::false(str_contains((string) file_get_contents($path), 'final class SealedGate'));
+
+        FileWrapper::uninstall();
+
+        Assert::string((string) file_get_contents($path))->contains('final class SealedGate');
+    }
+
+    /**
+     * A delegated operation borrows the native wrapper and has to give it back.
+     * Without that, the first `stat()` would be the last thing transformed.
+     */
+    public function theWrapperIsStillInPlaceAfterADelegatedOperation(): void
+    {
+        $path = \dirname(__DIR__) . '/Fixture/Bypass/SealedGate.php';
+
+        FileWrapper::install([[
+            'namespace' => 'Rasuvaeff\\Understudy\\Tests\\Fixture\\Bypass',
+            'class' => 'SealedGate',
+        ]]);
+
+        Assert::true(\is_array(stat($path)));
+        Assert::true(\is_array(scandir(\dirname($path))));
+        Assert::false(str_contains((string) file_get_contents($path), 'final class SealedGate'));
+    }
+
+    // --- What counts as PHP source --------------------------------------------
+
+    public function anUppercaseExtensionIsStillPhp(): void
+    {
+        FileWrapper::targetOnly(null);
+
+        $read = $this->read(\dirname(__DIR__) . '/Fixture/Bypass/Uppercase.PHP');
+
+        Assert::false(str_contains($read, 'final class Uppercase'));
+        Assert::string($read)->contains('class Uppercase');
+    }
+
+    /**
+     * A read-write handle is not a compile, and rewriting what somebody is
+     * about to edit would be a different program than the one on disk.
+     */
+    public function aReadWriteHandleIsNotTransformed(): void
+    {
+        FileWrapper::targetOnly(null);
+
+        Assert::string($this->read(\dirname(__DIR__) . '/Fixture/Bypass/SealedGate.php', 'r+'))
+            ->contains('final class SealedGate');
+    }
+
+    public function aWriteHandleIsNotTransformed(): void
+    {
+        FileWrapper::targetOnly(null);
+        $path = sys_get_temp_dir() . '/understudy-write-' . getmypid() . '.php';
+        file_put_contents($path, '<?php final class Written {}');
+
+        try {
+            $wrapper = new FileWrapper();
+            $opened = null;
+
+            Assert::true($wrapper->stream_open($path, 'a', 0, $opened));
+
+            $wrapper->stream_close();
+
+            Assert::string((string) file_get_contents($path))->contains('final class Written');
+        } finally {
+            unlink($path);
+        }
+    }
+
+    /**
+     * Reading a file through a wrapper nobody installed must leave `file://`
+     * alone.
+     *
+     * Every delegated operation borrows the native wrapper and puts ours back
+     * afterwards — but "back" means *back*, and there is nothing to restore
+     * when nothing was registered. Without the guard, one read through a bare
+     * instance installs the wrapper for the rest of the process, and rector
+     * removed that guard once already by turning the method non-static.
+     */
+    public function readingThroughAnUninstalledWrapperDoesNotInstallIt(): void
+    {
+        $path = \dirname(__DIR__) . '/Fixture/Bypass/SealedGate.php';
+
+        FileWrapper::targetOnly(null);
+        $this->read($path);
+
+        Assert::false(FileWrapper::isInstalled());
+        Assert::string((string) file_get_contents($path))->contains('final class SealedGate');
+    }
+
     // --- The rest of the stream protocol --------------------------------------
 
     public function theStreamReportsPositionSizeAndEnd(): void
@@ -295,12 +420,15 @@ final class FileWrapperTest
         }
     }
 
-    private function read(string $path): string
+    private function read(string $path, string $mode = 'r'): string
     {
         $wrapper = new FileWrapper();
         $opened = null;
 
-        Assert::true($wrapper->stream_open($path, 'r', 0, $opened));
+        Assert::true($wrapper->stream_open($path, $mode, 0, $opened));
+        // Not asked for, so not answered: `$openedPath` is what `__FILE__`
+        // becomes, and PHP only wants it when STREAM_USE_PATH is set.
+        Assert::null($opened);
 
         $read = '';
 

--- a/tests/Bypass/FinalStripperTest.php
+++ b/tests/Bypass/FinalStripperTest.php
@@ -108,6 +108,18 @@ final class FinalStripperTest
             '<?php namespace App; /** here */ class Gate {}',
         ];
 
+        yield 'a newline between final and class is kept' => [
+            "<?php namespace App; final\nclass Gate {}",
+            [['namespace' => 'App', 'class' => 'Gate']],
+            "<?php namespace App; \nclass Gate {}",
+        ];
+
+        yield 'a newline is kept in global mode too' => [
+            "<?php namespace App;\nfinal\nclass Gate {}\nfinal\nclass Wall {}",
+            null,
+            "<?php namespace App;\n\nclass Gate {}\n\nclass Wall {}",
+        ];
+
         yield 'a file without the word is returned untouched' => [
             '<?php namespace App; class Gate {}',
             null,

--- a/tests/ClassDoubleTest.php
+++ b/tests/ClassDoubleTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Rasuvaeff\Understudy\Tests;
 
 use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Codegen\Blueprint;
 use Rasuvaeff\Understudy\Codegen\DoubleFactory;
 use Rasuvaeff\Understudy\Codegen\PropertyDefaults;
+use Rasuvaeff\Understudy\Codegen\TargetUnifier;
+use Rasuvaeff\Understudy\Codegen\TypeRenderer;
 use Rasuvaeff\Understudy\Exception\ContextOwnershipViolation;
 use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
 use Rasuvaeff\Understudy\Tests\Fixture\Cls\AbstractLedger;
@@ -36,6 +39,9 @@ use function Rasuvaeff\Understudy\when;
 #[Test]
 #[Covers(DoubleFactory::class)]
 #[Covers(PropertyDefaults::class)]
+#[Covers(TargetUnifier::class)]
+#[Covers(Blueprint::class)]
+#[Covers(TypeRenderer::class)]
 final class ClassDoubleTest
 {
     #[AfterTest]

--- a/tests/Codegen/DefaultRenderingTest.php
+++ b/tests/Codegen/DefaultRenderingTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Codegen;
+
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Codegen\TargetUnifier;
+use Rasuvaeff\Understudy\Tests\Fixture\Defaults\EnumInArray;
+use Rasuvaeff\Understudy\Tests\Fixture\Defaults\GlobalConstant;
+use Rasuvaeff\Understudy\Tests\Fixture\Defaults\HiddenConstant;
+use Rasuvaeff\Understudy\Tests\Fixture\Defaults\ObjectInArray;
+use Rasuvaeff\Understudy\Tests\Fixture\Defaults\ParentConstant;
+use Rasuvaeff\Understudy\Tests\Fixture\Defaults\StringMentioningSelf;
+use Rasuvaeff\Understudy\Tests\Fixture\Suit;
+use Rasuvaeff\Understudy\Understudy;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Lifecycle\AfterTest;
+use Testo\Test;
+
+/**
+ * Every shape a parameter default can take, compared by calling the method
+ * without the argument and reading what the call recorded.
+ *
+ * Comparing the *value* rather than the generated source is the point: what the
+ * contract promises is what the caller would have received, and a rendering that
+ * produces something else is wrong however plausible it reads.
+ */
+#[Test]
+#[Covers(TargetUnifier::class)]
+final class DefaultRenderingTest
+{
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Understudy::reset();
+    }
+
+    /**
+     * `parent::INHERITED` is public, so it can be named — through the class that
+     * declares it, never as `parent`, which in the double means something else.
+     */
+    public function aParentConstantIsRenderedThroughItsDeclaringClass(): void
+    {
+        $double = Understudy::for(ParentConstant::class);
+
+        $double->greet();
+
+        Assert::same($this->firstArgument(static fn(): string => $double->greet(Arg::any())), 'from-parent');
+    }
+
+    /**
+     * The same shape, protected. It cannot be named from outside the hierarchy,
+     * so the value is what the double answers with.
+     */
+    public function anUnreachableParentConstantFallsBackToItsValue(): void
+    {
+        $double = Understudy::for(HiddenConstant::class);
+
+        $double->step();
+
+        Assert::same($this->firstArgument(static fn(): int => $double->step(Arg::any())), 7);
+    }
+
+    /**
+     * Reflection reports a global constant prefixed with the declaring
+     * namespace — a name that does not exist. Only the value can be rendered.
+     */
+    public function aGlobalConstantIsRenderedAsItsValue(): void
+    {
+        $double = Understudy::for(GlobalConstant::class);
+
+        $double->sized();
+
+        Assert::same($this->firstArgument(static fn(): int => $double->sized(Arg::any())), PHP_INT_MAX);
+    }
+
+    public function anEnumCaseInsideAnArrayIsKept(): void
+    {
+        $double = Understudy::for(EnumInArray::class);
+
+        $double->deal();
+
+        Assert::same(
+            $this->firstArgument(static fn(): int => $double->deal(Arg::any())),
+            ['first' => Suit::Hearts],
+        );
+    }
+
+    /**
+     * The words `self::` and `new` inside a string are not code. Reading the
+     * text rather than the tokens would refuse a contract that is ordinary.
+     */
+    public function aStringMentioningSelfOrNewIsJustAString(): void
+    {
+        $double = Understudy::for(StringMentioningSelf::class);
+
+        $double->describe();
+
+        Assert::same(
+            $this->firstArgument(static fn(): string => $double->describe(Arg::any())),
+            'see self::PREFIX or new Foo()',
+        );
+    }
+
+    public function anArrayConstantIsRenderedAsItsValue(): void
+    {
+        $double = Understudy::for(ObjectInArray::class);
+
+        $double->hold();
+
+        Assert::same(
+            $this->firstArgument(static fn(): string => $double->hold(Arg::any())),
+            ['tag' => 'plain'],
+        );
+    }
+
+    private function firstArgument(callable $call): mixed
+    {
+        $calls = Understudy::calls($call);
+
+        Assert::same(count($calls), 1);
+
+        return $calls[0]->args[0];
+    }
+}

--- a/tests/Fixture/Bypass/Uppercase.PHP
+++ b/tests/Fixture/Bypass/Uppercase.PHP
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Bypass;
+
+/**
+ * The extension is spelled in capitals. PHP does not care and neither should
+ * the wrapper: a case-sensitive check would hand this file over untransformed
+ * on a case-sensitive filesystem.
+ */
+final class Uppercase {}

--- a/tests/Fixture/Defaults/EnumInArray.php
+++ b/tests/Fixture/Defaults/EnumInArray.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Defaults;
+
+use Rasuvaeff\Understudy\Tests\Fixture\Suit;
+
+interface EnumInArray
+{
+    /** @param array<string, Suit> $hands */
+    public function deal(array $hands = ['first' => Suit::Hearts]): int;
+}

--- a/tests/Fixture/Defaults/GlobalConstant.php
+++ b/tests/Fixture/Defaults/GlobalConstant.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Defaults;
+
+/**
+ * Reflection reports this as `Rasuvaeff\…\PHP_EOL` — a name that does not
+ * exist. Only the value can be rendered.
+ */
+interface GlobalConstant
+{
+    public function sized(int $max = PHP_INT_MAX): int;
+}

--- a/tests/Fixture/Defaults/HiddenConstant.php
+++ b/tests/Fixture/Defaults/HiddenConstant.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Defaults;
+
+/** A protected constant of a parent: named, but not reachable from a subclass. */
+abstract class HiddenConstant extends ParentHolder
+{
+    abstract public function step(int $n = parent::HIDDEN_STEP): int;
+}

--- a/tests/Fixture/Defaults/ObjectBox.php
+++ b/tests/Fixture/Defaults/ObjectBox.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Defaults;
+
+interface ObjectBox
+{
+    public const array BOXED = ['tag' => 'plain'];
+}

--- a/tests/Fixture/Defaults/ObjectInArray.php
+++ b/tests/Fixture/Defaults/ObjectInArray.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Defaults;
+
+/**
+ * An object reachable only as a value — the default is a constant holding one,
+ * so there is no `new` in the source to render.
+ */
+interface ObjectInArray
+{
+    public function hold(array $box = ObjectBox::BOXED): string;
+}

--- a/tests/Fixture/Defaults/ParentConstant.php
+++ b/tests/Fixture/Defaults/ParentConstant.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Defaults;
+
+/** Reflection reports this default as `parent::INHERITED`. */
+abstract class ParentConstant extends ParentHolder
+{
+    abstract public function greet(string $prefix = parent::INHERITED): string;
+}

--- a/tests/Fixture/Defaults/ParentHolder.php
+++ b/tests/Fixture/Defaults/ParentHolder.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Defaults;
+
+/**
+ * The constants the shapes in this directory inherit. Its own file, because
+ * PSR-4 looks for a class where its name says it is — a rule that has now
+ * broken three fixture sets in this package.
+ */
+abstract class ParentHolder
+{
+    public const string INHERITED = 'from-parent';
+
+    protected const int HIDDEN_STEP = 7;
+}

--- a/tests/Fixture/Defaults/StringMentioningSelf.php
+++ b/tests/Fixture/Defaults/StringMentioningSelf.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Defaults;
+
+/**
+ * The words `new` and `self::` appear inside a string literal. A check that
+ * looked at the text rather than at the code would read them as an expression
+ * and refuse a contract that is perfectly ordinary.
+ */
+interface StringMentioningSelf
+{
+    public function describe(string $note = 'see self::PREFIX or new Foo()'): string;
+}

--- a/tests/Fixture/Fwd/Chainable.php
+++ b/tests/Fixture/Fwd/Chainable.php
@@ -12,6 +12,9 @@ interface Chainable
     /** Returns a *different* instance of the same class. */
     public function detach(): static;
 
+    /** The same thing without `static`: another instance is a legal answer. */
+    public function spawn(): Chainable;
+
     public function label(): string;
 
     /** Calls `label()` on itself, so a proxy can be told from an instrumented object. */

--- a/tests/Fixture/Fwd/RealChain.php
+++ b/tests/Fixture/Fwd/RealChain.php
@@ -24,6 +24,12 @@ class RealChain implements Chainable
     }
 
     #[\Override]
+    public function spawn(): Chainable
+    {
+        return new static();
+    }
+
+    #[\Override]
     public function label(): string
     {
         return 'real';

--- a/tests/ForwardingTest.php
+++ b/tests/ForwardingTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rasuvaeff\Understudy\Tests;
 
+use Rasuvaeff\Understudy\Codegen\DoubleFactory;
+use Rasuvaeff\Understudy\Codegen\TargetUnifier;
 use Rasuvaeff\Understudy\Exception\ForwardingTargetMismatch;
 use Rasuvaeff\Understudy\Exception\OriginalCallUnavailable;
 use Rasuvaeff\Understudy\Exception\OriginalReturnTypeViolation;
@@ -29,6 +31,8 @@ use function Rasuvaeff\Understudy\when;
 #[Covers(Runtime::class)]
 #[Covers(Understudy::class)]
 #[Covers(Invocation::class)]
+#[Covers(TargetUnifier::class)]
+#[Covers(DoubleFactory::class)]
 final class ForwardingTest
 {
     #[AfterTest]
@@ -161,6 +165,45 @@ final class ForwardingTest
         Expect::exception(\DomainException::class)->withMessage('the real implementation refused');
 
         $double->collapse();
+    }
+
+    /**
+     * The identity rule is about `static`, and only about `static`. A method
+     * whose return type is the interface may legally answer with another
+     * instance, and refusing that would forbid a factory.
+     */
+    public function aMethodWithoutStaticMayReturnAnotherInstance(): void
+    {
+        $real = new RealChain();
+        $double = Understudy::for(Chainable::class);
+        Understudy::forwarding($double, $real);
+
+        $spawned = $double->spawn();
+
+        Assert::instanceOf($spawned, RealChain::class);
+        Assert::true($spawned !== $double);
+    }
+
+    /**
+     * A call from another Fiber is answered by the context that owns the
+     * double, not by the one that happens to be running: the test that
+     * configured it is the one that must be able to verify it.
+     */
+    public function aCallFromAnotherFiberIsRecordedByTheOwner(): void
+    {
+        $real = new RealChain();
+        $double = Understudy::for(Chainable::class);
+        Understudy::forwarding($double, $real);
+
+        $answered = null;
+
+        $fiber = new \Fiber(static function () use ($double, &$answered): void {
+            $answered = $double->label();
+        });
+        $fiber->start();
+
+        Assert::same($answered, 'real');
+        Assert::same(count(Understudy::calls(static fn(): string => $double->label())), 1);
     }
 
     // --- callOriginal() -----------------------------------------------------

--- a/tests/UnderstudyTest.php
+++ b/tests/UnderstudyTest.php
@@ -8,6 +8,8 @@ use Rasuvaeff\Understudy\Arg;
 use Rasuvaeff\Understudy\Codegen\Blueprint;
 use Rasuvaeff\Understudy\Codegen\DoubleFactory;
 use Rasuvaeff\Understudy\Codegen\MethodSignature;
+use Rasuvaeff\Understudy\Codegen\TargetUnifier;
+use Rasuvaeff\Understudy\Codegen\TypeRenderer;
 use Rasuvaeff\Understudy\Exception\ForgottenDouble;
 use Rasuvaeff\Understudy\Exception\InvalidCallSpecification;
 use Rasuvaeff\Understudy\Exception\MatcherLeaked;
@@ -75,6 +77,8 @@ use function Rasuvaeff\Understudy\when;
 #[Covers(StrictModeViolation::class)]
 #[Covers(UnsupportedTarget::class)]
 #[Covers(VerificationFailed::class)]
+#[Covers(TargetUnifier::class)]
+#[Covers(TypeRenderer::class)]
 final class UnderstudyTest
 {
     #[AfterTest]


### PR DESCRIPTION
The gate goes **92 → 93**, the first move upward. The number is the least interesting part.

## A defect that had shipped

`FileWrapper::withoutWrapper()` restored and re-registered `file://` unconditionally. Reading one file through a wrapper nobody installed therefore made it the owner of `file://` **for the rest of the process** — every read after it transformed by something the process never asked for.

The guard for exactly this was written in #14 and lost: rector turned the method non-static and my edit had targeted the static version. `readingThroughAnUninstalledWrapperDoesNotInstallIt` pins it now, and `AGENTS.md` records the lesson — a `rector:fix` diff wants reading for what *moved*, not only for what still compiles.

## Attribution was hiding most of the rest

`TargetUnifier` compiles every double in the suite. Exactly one test class claimed it, so Infection never used the others to kill its mutants — the same for `Blueprint`, `TypeRenderer` and `DoubleFactory`.

Claiming them where the tests genuinely drive them took Mutation Code Coverage to **100%**, and with it the denominator. Honest attribution makes the percentage *fall* before it rises, which is worth knowing before reading the number as a regression.

## What was killable, killed

Two targets in one `install()`; transformation through the *registered* wrapper rather than a hand-built instance; the wrapper surviving a delegated operation; `$openedPath` answered only when asked for; an uppercase `.PHP`; read-write and append handles left alone; a newline between `final` and `class` kept; and every shape a parameter default can take, each on a contract of its own so the branches actually execute a second time.

`url_stat()` also became quiet unconditionally, like `stream_open()` — a `false` is the answer, and a warning raised inside a wrapper is one the caller cannot suppress.

## Why the gate stops at 93

The samples examined are mostly equivalent by construction:

| | |
|---|---|
| scanning-loop offsets in the tokenizer | `$i + 1` vs `$i + 2` finds the same token either way |
| `array_values()` | exists for `list<T>` and nothing else — that mutator is off now, with the reason written down |
| branches in `Wire` | unreachable behind an earlier `return` |

95 was calibrated when this engine was pure logic. It now contains a tokenizer, a stream wrapper and a code generator, whose mutants are killed by processes and filesystems rather than by assertions. Raising the number further means a dishonest ignore list or a redesign, and neither belongs in a gate. That reasoning is in `infection.json5`, where the next person meets it.

## Verification

602 tests green on 8.3, 8.4 and 8.5 separately. Rector, Psalm and `bin/package-audit` clean. Still zero suppressions.