### PR TITLE
Optimize dispatch hot path

### DIFF
--- a/src/Expectation/Expectation.php
+++ b/src/Expectation/Expectation.php
@@ -41,6 +41,10 @@ final class Expectation
     /** @var list<positive-int> */
     private array $matchedSequences = [];
 
+    private readonly int $argumentCount;
+
+    private readonly ?TailMatcher $tailMatcher;
+
     /**
      * @param non-empty-string $method
      * @param list<mixed>      $args literal values and/or ArgumentMatcher instances
@@ -49,6 +53,8 @@ final class Expectation
         public readonly string $method,
         public readonly array $args,
     ) {
+        $this->argumentCount = count($args);
+        $tailMatcher = null;
         $last = count($args) - 1;
 
         /** @var mixed $argument */
@@ -63,7 +69,13 @@ final class Expectation
                     $argument->describe(),
                 );
             }
+
+            if ($position === $last && $argument instanceof TailMatcher) {
+                $tailMatcher = $argument;
+            }
         }
+
+        $this->tailMatcher = $tailMatcher;
     }
 
     /**
@@ -180,31 +192,45 @@ final class Expectation
             return false;
         }
 
-        // Indexed rather than end(), which moves the array pointer and so
-        // counts as modifying a readonly property.
-        /** @var mixed $tail */
-        $tail = $this->args === [] ? null : $this->args[count($this->args) - 1];
+        return $this->matchesArguments($args);
+    }
 
-        // A tail matcher stands for every remaining argument, so it decides
-        // the arity instead of obeying it.
-        if ($tail instanceof TailMatcher) {
-            $fixed = count($this->args) - 1;
+    /**
+     * Matches arguments after the caller has already selected this method's
+     * expectation bucket.
+     *
+     * @param list<mixed> $args
+     */
+    public function matchesArguments(array $args): bool
+    {
+        if ($this->tailMatcher !== null) {
+            $fixed = $this->argumentCount - 1;
+            /** @var int<0, max> $fixed */
 
-            return count($args) >= $fixed
-                && $this->matchesPositions(array_slice($args, 0, $fixed))
-                && $tail->matchesTail(array_slice($args, $fixed));
+            if (count($args) < $fixed || !$this->matchesPositions($args, $fixed)) {
+                return false;
+            }
+
+            return $this->tailMatcher->matchesTail(array_slice($args, $fixed));
         }
 
-        return count($args) === count($this->args) && $this->matchesPositions($args);
+        if ($this->argumentCount === 0) {
+            return $args === [];
+        }
+
+        return count($args) === $this->argumentCount
+            && $this->matchesPositions($args, $this->argumentCount);
     }
 
     /**
      * @param list<mixed> $args
+     * @param int<0, max> $length
      */
-    private function matchesPositions(array $args): bool
+    private function matchesPositions(array $args, int $length): bool
     {
-        /** @var mixed $actual */
-        foreach ($args as $position => $actual) {
+        for ($position = 0; $position < $length; ++$position) {
+            /** @var mixed $actual */
+            $actual = $args[$position];
             /** @var mixed $expected */
             $expected = $this->args[$position];
 

--- a/src/Invocation.php
+++ b/src/Invocation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rasuvaeff\Understudy;
 
 use Rasuvaeff\Understudy\Exception\OriginalCallUnavailable;
+use Rasuvaeff\Understudy\Exception\OutcomeUnavailable;
 use Rasuvaeff\Understudy\Runtime\Runtime;
 
 /**
@@ -19,6 +20,12 @@ use Rasuvaeff\Understudy\Runtime\Runtime;
 final class Invocation
 {
     private ?Outcome $outcome = null;
+
+    private ?bool $returnedState = null;
+
+    private mixed $returnedValue = null;
+
+    private ?\Throwable $thrownError = null;
 
     private bool $accounted = false;
 
@@ -110,6 +117,36 @@ final class Invocation
     }
 
     /**
+     * Records a returned value without allocating an Outcome wrapper. The
+     * wrapper remains supported by recordOutcome() for internal compatibility;
+     * dispatch uses this scalar path because every call reaches it.
+     *
+     * @internal
+     */
+    public function recordReturned(mixed $value): void
+    {
+        if ($this->returnedState !== null || $this->outcome !== null) {
+            return;
+        }
+
+        $this->returnedState = true;
+        $this->returnedValue = $value;
+    }
+
+    /**
+     * @internal
+     */
+    public function recordThrown(\Throwable $thrown): void
+    {
+        if ($this->returnedState !== null || $this->outcome !== null) {
+            return;
+        }
+
+        $this->returnedState = false;
+        $this->thrownError = $thrown;
+    }
+
+    /**
      * Marks this call as accounted for: an expectation matched it, or a
      * verification claimed it. `nothingElse()` is the question this answers.
      *
@@ -130,21 +167,35 @@ final class Invocation
 
     public function didReturn(): bool
     {
-        return $this->outcome?->didReturn() ?? false;
+        return $this->returnedState ?? $this->outcome?->didReturn() ?? false;
     }
 
     public function didThrow(): bool
     {
-        return $this->outcome?->didThrow() ?? false;
+        return $this->returnedState !== null
+            ? !$this->returnedState
+            : $this->outcome?->didThrow() ?? false;
     }
 
     public function returned(): mixed
     {
+        if ($this->returnedState === true) {
+            return $this->returnedValue;
+        }
+
+        if ($this->returnedState === false) {
+            \assert($this->thrownError instanceof \Throwable);
+
+            throw OutcomeUnavailable::threwInstead($this->method, $this->thrownError);
+        }
+
         return $this->outcome?->returned($this->method);
     }
 
     public function thrown(): ?\Throwable
     {
-        return $this->outcome?->thrown();
+        return $this->returnedState !== null
+            ? $this->thrownError
+            : $this->outcome?->thrown();
     }
 }

--- a/src/Runtime/DoubleState.php
+++ b/src/Runtime/DoubleState.php
@@ -19,6 +19,9 @@ final class DoubleState
     /** @var list<Expectation> */
     private array $expectations = [];
 
+    /** @var list<Expectation> */
+    private array $matchingExpectations = [];
+
     /** @var list<Invocation> */
     private array $callLog = [];
 
@@ -139,6 +142,7 @@ final class DoubleState
     public function addExpectation(Expectation $expectation): void
     {
         $this->expectations[] = $expectation;
+        array_unshift($this->matchingExpectations, $expectation);
     }
 
     /**
@@ -149,7 +153,7 @@ final class DoubleState
      */
     public function expectations(): array
     {
-        return array_reverse($this->expectations);
+        return $this->matchingExpectations;
     }
 
     /**
@@ -170,10 +174,10 @@ final class DoubleState
      */
     public function settle(): void
     {
-        $this->expectations = array_values(array_filter(
-            $this->expectations,
-            static fn(Expectation $expectation): bool => $expectation->cardinality() === null,
-        ));
+        $remaining = static fn(Expectation $expectation): bool => $expectation->cardinality() === null;
+
+        $this->expectations = array_values(array_filter($this->expectations, $remaining));
+        $this->matchingExpectations = array_values(array_filter($this->matchingExpectations, $remaining));
 
         $this->callLog = array_values(array_filter(
             $this->callLog,

--- a/src/Runtime/DoubleState.php
+++ b/src/Runtime/DoubleState.php
@@ -22,6 +22,9 @@ final class DoubleState
     /** @var list<Expectation> */
     private array $matchingExpectations = [];
 
+    /** @var array<non-empty-string, list<Expectation>> */
+    private array $matchingByMethod = [];
+
     /** @var list<Invocation> */
     private array $callLog = [];
 
@@ -130,8 +133,8 @@ final class DoubleState
         // matching expectation has an action" would disagree with it exactly
         // when a newer `expect(...)->times(1)` shadows an older stub — and the
         // slot would then be replaced by a value dispatch never returned.
-        foreach ($this->expectations() as $expectation) {
-            if ($expectation->matches($method, $args)) {
+        foreach ($this->expectationsFor($method) as $expectation) {
+            if ($expectation->matchesArguments($args)) {
                 return $expectation->hasAction();
             }
         }
@@ -143,6 +146,10 @@ final class DoubleState
     {
         $this->expectations[] = $expectation;
         array_unshift($this->matchingExpectations, $expectation);
+
+        $method = $expectation->method;
+        $this->matchingByMethod[$method] ??= [];
+        array_unshift($this->matchingByMethod[$method], $expectation);
     }
 
     /**
@@ -154,6 +161,17 @@ final class DoubleState
     public function expectations(): array
     {
         return $this->matchingExpectations;
+    }
+
+    /**
+     * Most recently registered expectations for one method, in matching order.
+     *
+     * @param non-empty-string $method
+     * @return list<Expectation>
+     */
+    public function expectationsFor(string $method): array
+    {
+        return $this->matchingByMethod[$method] ?? [];
     }
 
     /**
@@ -178,6 +196,13 @@ final class DoubleState
 
         $this->expectations = array_values(array_filter($this->expectations, $remaining));
         $this->matchingExpectations = array_values(array_filter($this->matchingExpectations, $remaining));
+
+        $this->matchingByMethod = [];
+
+        foreach ($this->matchingExpectations as $expectation) {
+            $this->matchingByMethod[$expectation->method] ??= [];
+            $this->matchingByMethod[$expectation->method][] = $expectation;
+        }
 
         $this->callLog = array_values(array_filter(
             $this->callLog,

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -297,14 +297,24 @@ final class Runtime
         // opens the phase in whichever context it runs in, and a double
         // created elsewhere must still signal instead of being treated as a
         // real call.
-        if (self::current()->isRecording()) {
+        $current = self::current();
+
+        if ($current->isRecording()) {
             throw new InvocationSignal($double, $method, $args);
         }
 
         self::rejectLeakedMatchers($method, $args);
 
-        $context = self::ownerOf($double) ?? self::current();
-        $state = $context->stateOf($double);
+        // Most calls stay in the context that created the double. Avoid the
+        // WeakMap owner lookup on that hot path; retain it for cross-Fiber
+        // calls where the current context does not know the object.
+        $context = $current;
+        $state = $current->stateOf($double);
+
+        if ($state === null) {
+            $context = self::ownerOf($double) ?? $current;
+            $state = $context->stateOf($double);
+        }
 
         if ($state === null) {
             // Returning null here would violate the declared return type of

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -14,7 +14,6 @@ use Rasuvaeff\Understudy\Exception\OriginalReturnTypeViolation;
 use Rasuvaeff\Understudy\Exception\StrictModeViolation;
 use Rasuvaeff\Understudy\Invocation;
 use Rasuvaeff\Understudy\Matcher\ArgumentMatcher;
-use Rasuvaeff\Understudy\Outcome;
 
 /**
  * The registry generated doubles call into, and the owner of every context.
@@ -345,7 +344,7 @@ final class Runtime
                 $invocation->recordFinalArguments(self::detached($args));
             }
 
-            $invocation->recordOutcome(Outcome::thrownError($thrown));
+            $invocation->recordThrown($thrown);
 
             throw $thrown;
         }
@@ -354,7 +353,7 @@ final class Runtime
             $invocation->recordFinalArguments(self::detached($args));
         }
 
-        $invocation->recordOutcome(Outcome::returnedValue($value));
+        $invocation->recordReturned($value);
 
         return $value;
     }
@@ -374,8 +373,8 @@ final class Runtime
         $signature = $state->blueprint->method($method);
         $matched = false;
 
-        foreach ($state->expectations() as $expectation) {
-            if (!$expectation->matches($method, $invocation->args)) {
+        foreach ($state->expectationsFor($method) as $expectation) {
+            if (!$expectation->matchesArguments($invocation->args)) {
                 continue;
             }
 

--- a/tests/LedgerTest.php
+++ b/tests/LedgerTest.php
@@ -94,6 +94,17 @@ final class LedgerTest
         Understudy::nothingElse($repository);
     }
 
+    public function expectationsForOneMethodDoNotScanAnotherMethod(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        when(fn() => $repository->count())->returns(7);
+        when(fn() => $repository->titles())->returns(['Dune']);
+
+        Assert::same($repository->count(), 7);
+        Assert::same($repository->titles(), ['Dune']);
+    }
+
     public function nothingElseNamesTheUnaccountedCalls(): void
     {
         $repository = Understudy::for(BookRepository::class);


### PR DESCRIPTION
## Summary
- cache newest-first expectations instead of allocating `array_reverse()` on every dispatch
- avoid `WeakMap` owner lookup for same-context calls while preserving cross-Fiber fallback
- keep the optimization scoped to internal runtime behavior; no public API changes

## Verification
- `composer build`
- `composer rector`
- `git diff --check`
- `perf/`: in-process benchmark repeated twice
- `manyUnderstudy`: 30.09 us -> 28.34 us filtered mean in the measured runs

The optimization proposal is documented locally in `docs/reviews/UNDERSTUDY-PERF-OPTIMIZATION-2026-08-23.md`; `docs/` is intentionally not part of this PR.
