### PR TITLE
Declare the abstract static a target leaves unimplemented

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,14 @@ make release-check
   `RuntimeContext` uses `SplObjectStorage`.
 - **Recording is a depth counter, not a boolean.** A nested recording phase
   must not switch the enclosing one off when it unwinds.
+- **An abstract static has nothing to inherit, so the double declares it.**
+  Both shapes reach this: a class target's own `abstract public static`, and an
+  interface static an abstract class implementing that interface never fills
+  in — Reflection reports the latter with the *interface* as its declaring
+  class. Treating either as inherited leaves the generated concrete subclass
+  without an implementation, and PHP answers that with a fatal error naming the
+  method, not an exception. `isOverridable()` is what routes them; only an
+  implemented static on a class target belongs in `$classStatics`.
 - **Multi-target methods are unified, not compared.** Parameters are
   contravariant, so `write(int)` and `write(string)` share the implementation
   `write(int|string)`; refusing them on signature difference would reject a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- `for()` on an abstract class no longer dies on an abstract static. A static
+  the target leaves unimplemented — its own, or one an interface declares and
+  the abstract class never fills in — has nothing for the generated subclass to
+  inherit, so it is declared there like any other contract member. It was being
+  treated as inherited instead, and PHP answered the generated class with a
+  fatal error naming the missing method: not an exception, so nothing could
+  report it. Calling it still refuses with the usual `InvalidCallSpecification`;
+  a static has no instance state to dispatch.
 - `wire()` accepts an override for a variadic tail. It takes a list, every
   element is checked against the declared type, and anything else is refused by
   name before the constructor runs. Filling a tail passes the parameters before

--- a/src/Codegen/TargetUnifier.php
+++ b/src/Codegen/TargetUnifier.php
@@ -47,14 +47,12 @@ final class TargetUnifier
             foreach ($target->getMethods($filter) as $method) {
                 if (self::isOverridable($method, $target)) {
                     $byName[$method->getName()][] = $method;
-                } elseif (!$target->isInterface()
-                    && $method->isStatic()
-                    && !$method->getDeclaringClass()->isInterface()
-                ) {
-                    // A class static method is inherited by the generated
-                    // subclass. Keep it only for compatibility checks against
-                    // same-named interface declarations; it must not be
-                    // rendered as a dispatcher of its own.
+                } elseif ($method->isStatic()) {
+                    // What is left here is an implemented static on a class
+                    // target: the generated subclass inherits it. Keep it only
+                    // for compatibility checks against same-named interface
+                    // declarations; it must not be rendered as a dispatcher of
+                    // its own.
                     $classStatics[$method->getName()] = $method;
                 }
             }
@@ -130,7 +128,12 @@ final class TargetUnifier
             return false;
         }
 
-        return !$method->isStatic() || $target->isInterface();
+        // An abstract static has nothing to inherit — a class target can carry
+        // one either by declaring it itself or by leaving an interface's
+        // unimplemented — so the generated class has to declare it. PHP
+        // refuses a concrete subclass that does not, and refuses it with a
+        // fatal error rather than an exception a test could catch.
+        return !$method->isStatic() || $target->isInterface() || $method->isAbstract();
     }
 
     private static function staticContractSatisfies(

--- a/tests/ClassDoubleTest.php
+++ b/tests/ClassDoubleTest.php
@@ -11,6 +11,7 @@ use Rasuvaeff\Understudy\Codegen\PropertyDefaults;
 use Rasuvaeff\Understudy\Codegen\TargetUnifier;
 use Rasuvaeff\Understudy\Codegen\TypeRenderer;
 use Rasuvaeff\Understudy\Exception\ContextOwnershipViolation;
+use Rasuvaeff\Understudy\Exception\InvalidCallSpecification;
 use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
 use Rasuvaeff\Understudy\Tests\Fixture\Cls\AbstractLedger;
 use Rasuvaeff\Understudy\Tests\Fixture\Cls\Bookkeeper;
@@ -27,6 +28,7 @@ use Rasuvaeff\Understudy\Tests\Fixture\Cls\ReadonlyLedger;
 use Rasuvaeff\Understudy\Tests\Fixture\Cls\SealedLedger;
 use Rasuvaeff\Understudy\Tests\Fixture\Cls\Stamp;
 use Rasuvaeff\Understudy\Tests\Fixture\Suit;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\AbstractStaticFromInterface;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingContract;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingWiderParameter;
 use Rasuvaeff\Understudy\Understudy;
@@ -170,6 +172,26 @@ final class ClassDoubleTest
         $double = Understudy::for(\StaticTargetForReview::class, \StaticContractForReview::class);
 
         Assert::same($double::ping(), 7);
+    }
+
+    /**
+     * Before this was checked, `for()` on such a class reached `eval()` and
+     * PHP answered with a fatal error naming the unimplemented method — not an
+     * exception, so nothing downstream could report it.
+     */
+    public function anAbstractTargetWithAnUnimplementedInterfaceStaticIsBuilt(): void
+    {
+        $double = Understudy::for(AbstractStaticFromInterface::class);
+
+        Assert::instanceOf($double, AbstractStaticFromInterface::class);
+        Assert::instanceOf($double, StaticPingContract::class);
+
+        Expect::exception(InvalidCallSpecification::class)->withMessage(
+            "Static method `ping()` cannot be called on an understudy because static calls have no instance state.\n"
+            . 'Inject an instance dependency and double that contract instead.',
+        );
+
+        $double::ping('abc');
     }
 
     /**

--- a/tests/Codegen/TargetUnifierTest.php
+++ b/tests/Codegen/TargetUnifierTest.php
@@ -8,6 +8,8 @@ use Rasuvaeff\Understudy\Codegen\MethodSignature;
 use Rasuvaeff\Understudy\Codegen\TargetUnifier;
 use Rasuvaeff\Understudy\Codegen\TypeRenderer;
 use Rasuvaeff\Understudy\Exception\UnsupportedTarget;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\AbstractOwnStatic;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\AbstractStaticFromInterface;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\AggregateUnion;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArityOne;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ArityTwo;
@@ -580,6 +582,28 @@ final class TargetUnifierTest
         );
 
         $this->unify(StaticPingNarrowerParameter::class, StaticPingContract::class);
+    }
+
+    /**
+     * An abstract static has no implementation for the generated subclass to
+     * inherit, so it has to be declared there. PHP refuses a concrete subclass
+     * that leaves one unimplemented, and refuses it with a fatal error — the
+     * one failure a target check exists to reach first.
+     */
+    public function anUnimplementedInterfaceStaticIsRedeclaredByTheDouble(): void
+    {
+        $signature = $this->unify(AbstractStaticFromInterface::class)['ping'] ?? null;
+
+        Assert::instanceOf($signature, MethodSignature::class);
+        Assert::true($signature->static);
+    }
+
+    public function anAbstractStaticDeclaredOnTheClassIsRedeclaredByTheDouble(): void
+    {
+        $signature = $this->unify(AbstractOwnStatic::class)['tag'] ?? null;
+
+        Assert::instanceOf($signature, MethodSignature::class);
+        Assert::true($signature->static);
     }
 
     public function aStaticReturnConflictNamesBothDeclarations(): void

--- a/tests/Fixture/Unify/AbstractOwnStatic.php
+++ b/tests/Fixture/Unify/AbstractOwnStatic.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+abstract class AbstractOwnStatic
+{
+    abstract public static function tag(): string;
+}

--- a/tests/Fixture/Unify/AbstractStaticFromInterface.php
+++ b/tests/Fixture/Unify/AbstractStaticFromInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+abstract class AbstractStaticFromInterface implements StaticPingContract {}


### PR DESCRIPTION
Found while reviewing the static-contract check merged in #15: the check refuses an *inherited* static that cannot satisfy an interface declaration, but there is a case where nothing is inherited at all and the double was left without an implementation.

## The failure

`Understudy::for()` on an abstract class carrying an unimplemented static died with a PHP fatal error from inside `eval()`:

```
Class Rasuvaeff\Understudy\Codegen\Generated\Understudy_f2cdf0bd contains
1 abstract method and must therefore be declared abstract or implement
the remaining method (Pinger::ping)
```

A fatal, not an exception — the one failure mode the target checks exist to reach first, and nothing downstream could report it.

## Two shapes reach it

```php
interface Pinger { public static function ping(string $v): int; }
abstract class AbstractPinger implements Pinger {}      // never fills it in

abstract class OwnAbstractStatic {
    abstract public static function tag(): string;      // its own
}
```

Reflection reports the first with the **interface** as its declaring class, which is exactly what the unifier read to decide the static was inherited and could be dropped from the dispatchers. The second was dropped by the same branch through `$method->isStatic()` alone.

## The fix

`isOverridable()` now routes an abstract static to the dispatcher path: there is no implementation to inherit, so the generated class has to declare one. `$classStatics` — the set kept only to check an inherited implementation against a same-named interface declaration — is left holding what it always meant, implemented statics on a class target, so the two remaining conjuncts on that branch went with the case that moved.

Calling such a static on the double still refuses with the usual `InvalidCallSpecification`; a static has no instance state to dispatch, and that is unchanged.

## Verification

- `composer build` — 645 tests, 10 436 assertions
- `composer mutation` — 2300 mutants, MSI 93.13% (gate 92)
- `composer rector`

Tests: two at the unifier level (`AbstractStaticFromInterface`, `AbstractOwnStatic`) asserting the signature is emitted and is static, and one end-to-end in `ClassDoubleTest` that builds the double, asserts it is an instance of both the abstract class and the interface, and pins the refusal message for the static call.