### PR TITLE
A model-based property over the ledger lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- A model-based property over the ledger lifecycle — stub/expect → dispatch →
+  verify → checkpoint — driven by `Gen::commands()` + `StateMachine`. Any
+  random interleaving of configuration, dispatch and verification commands has
+  to keep the double's answers, its call log and its accounting in lock-step
+  with a pure model, including most-recent-first matching, claim accounting,
+  verify marking, `nothingElse()` accounting and checkpoint settling. Four
+  pinned examples carry the layerings that were wrong before: a newer claim
+  shadowing an older stub, checkpoint survival of stubs, accounting through an
+  explicit verify, and a violated claim failing both checks.
 - The comparative benchmarks are re-measured after the dispatch work, and both
   READMEs carry the new figures. Per-call cost went from 1.75µs to 0.82µs and
   building a double from 2.08µs to 1.28µs; PHPUnit improved by more, and is now

--- a/tests/EngineLifecyclePropertyTest.php
+++ b/tests/EngineLifecyclePropertyTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests;
+
+use Rasuvaeff\PropertyTesting\ArbitraryInterface;
+use Rasuvaeff\PropertyTesting\Classify;
+use Rasuvaeff\PropertyTesting\Gen;
+use Rasuvaeff\PropertyTesting\Property;
+use Rasuvaeff\PropertyTesting\StateMachine\CommandSequence;
+use Rasuvaeff\PropertyTesting\StateMachine\StateMachine;
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Cardinality;
+use Rasuvaeff\Understudy\Defaults\TypeDefaultResolver;
+use Rasuvaeff\Understudy\Expectation\Expectation;
+use Rasuvaeff\Understudy\Invocation;
+use Rasuvaeff\Understudy\Runtime\DoubleState;
+use Rasuvaeff\Understudy\Runtime\Runtime;
+use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
+use Rasuvaeff\Understudy\Tests\Support\ConfigureExpectCommand;
+use Rasuvaeff\Understudy\Tests\Support\ConfigureStubCommand;
+use Rasuvaeff\Understudy\Tests\Support\DispatchFindCommand;
+use Rasuvaeff\Understudy\Tests\Support\EngineHarness;
+use Rasuvaeff\Understudy\Tests\Support\EngineState;
+use Rasuvaeff\Understudy\Tests\Support\RequireNothingElseCommand;
+use Rasuvaeff\Understudy\Tests\Support\SettleCheckpointCommand;
+use Rasuvaeff\Understudy\Tests\Support\VerifyCallsCommand;
+use Rasuvaeff\Understudy\Tests\Support\VerifyEverythingCommand;
+use Rasuvaeff\Understudy\Understudy;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Lifecycle\AfterTest;
+use Testo\Test;
+
+/**
+ * Model-based test for the ledger lifecycle the plan calls the engine's
+ * core loop: stub/expect → dispatch → verify → checkpoint. Any sequence of
+ * configuration, dispatch and verification commands must keep the real
+ * double's answers, its call log and its accounting in lock-step with the
+ * pure {@see EngineState} model — most-recent-first matching, claim
+ * accounting, verify marking and checkpoint settling included.
+ *
+ * The commands are deliberately drawn from a small closed world: one method
+ * (`find(int): ?Book`), literal or wildcard arguments, plain `returns()`
+ * stubs and action-less claims. Everything richer is pinned by the unit
+ * suites; what only a long random interleaving can surface is exactly this
+ * loop.
+ */
+#[Test]
+#[Covers(Understudy::class)]
+#[Covers(Runtime::class)]
+#[Covers(DoubleState::class)]
+#[Covers(Expectation::class)]
+#[Covers(Cardinality::class)]
+#[Covers(Invocation::class)]
+#[Covers(TypeDefaultResolver::class)]
+final class EngineLifecyclePropertyTest
+{
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Understudy::reset();
+    }
+
+    #[Property(runs: 200)]
+    public function theLedgerTracksTheModel(CommandSequence $sequence): void
+    {
+        $harness = null;
+
+        StateMachine::check(
+            $sequence,
+            static function () use (&$harness): EngineHarness {
+                /** @var EngineHarness $harness */
+                $harness = new EngineHarness(Understudy::for(BookRepository::class));
+
+                return $harness;
+            },
+        );
+
+        \assert($harness instanceof EngineHarness);
+
+        Classify::cover($harness->stubAnswers > 0, 'a stub answered', 5);
+        Classify::cover($harness->countedClaims > 0, 'a matched claim fell through to the default', 5);
+        Classify::cover($harness->unmatchedDefaults > 0, 'an unmatched call answered with the default', 5);
+        Classify::cover($harness->verifiesPassed > 0, 'an explicit verify passed', 5);
+        Classify::cover($harness->verifiesFailed > 0, 'an explicit verify failed', 5);
+        Classify::cover($harness->settledCheckpoints > 0, 'a checkpoint settled', 5);
+
+        // The runner advanced its own copy of the model; folding the same
+        // pure transitions here gives the end state the real log must have
+        // reached — every dispatch recorded exactly once, whatever the
+        // interleaving did to matching, accounting and settling in between.
+        $model = $sequence->initialModel;
+        \assert($model instanceof EngineState);
+
+        foreach ($sequence->commands as $command) {
+            if ($command->preCondition($model)) {
+                $model = $command->nextState($model);
+            }
+        }
+
+        Assert::same(count(Understudy::calls(fn() => $harness->double->find(Arg::any()))), $model->callCount());
+    }
+
+    /**
+     * @return array<string, ArbitraryInterface>
+     */
+    public static function theLedgerTracksTheModelGenerators(): array
+    {
+        return [
+            // Swarmed: each sequence draws a random subset of the command
+            // shapes, so phases that use only part of the vocabulary are an
+            // ordinary case rather than a lucky roll.
+            'sequence' => Gen::swarm(Gen::commands(
+                new EngineState(),
+                self::commandGenerators(),
+                minLength: 0,
+                maxLength: 24,
+            )),
+        ];
+    }
+
+    /**
+     * The layerings the ledger got wrong before, pinned before the random
+     * phase: shadowing, checkpoint survival, accounting through verify.
+     *
+     * @return iterable<string, CommandSequence>
+     */
+    public static function theLedgerTracksTheModelExamples(): iterable
+    {
+        yield 'a newer claim shadows an older stub and answers the default' => [new CommandSequence(
+            new EngineState(),
+            [
+                new ConfigureStubCommand(anyArgument: false, literalId: 2),
+                new ConfigureExpectCommand(anyArgument: false, literalId: 2, minimum: 1, maximum: 1),
+                new DispatchFindCommand(id: 2),
+                new RequireNothingElseCommand(),
+            ],
+        )];
+
+        yield 'checkpoint drops a satisfied claim but keeps the stub answering' => [new CommandSequence(
+            new EngineState(),
+            [
+                new ConfigureStubCommand(anyArgument: false, literalId: 1),
+                new ConfigureExpectCommand(anyArgument: true, literalId: 0, minimum: 0, maximum: null),
+                new DispatchFindCommand(id: 1),
+                new SettleCheckpointCommand(),
+                new DispatchFindCommand(id: 1),
+            ],
+        )];
+
+        yield 'verify accounts stubbed calls for nothingElse' => [new CommandSequence(
+            new EngineState(),
+            [
+                new ConfigureStubCommand(anyArgument: false, literalId: 3),
+                new DispatchFindCommand(id: 3),
+                new RequireNothingElseCommand(),
+                new VerifyCallsCommand(anyArgument: false, literalId: 3, minimum: 1, maximum: 1),
+                new RequireNothingElseCommand(),
+            ],
+        )];
+
+        yield 'a violated claim fails both verifyAll and the checkpoint' => [new CommandSequence(
+            new EngineState(),
+            [
+                new ConfigureExpectCommand(anyArgument: false, literalId: 1, minimum: 2, maximum: null),
+                new VerifyEverythingCommand(),
+                new SettleCheckpointCommand(),
+                new RequireNothingElseCommand(),
+            ],
+        )];
+    }
+
+    /**
+     * @return list<ArbitraryInterface>
+     */
+    private static function commandGenerators(): array
+    {
+        $argument = Gen::bool();
+        $literal = Gen::intBetween(1, 3);
+
+        return [
+            Gen::map(
+                Gen::tuple($argument, $literal),
+                static fn(array $tuple): ConfigureStubCommand
+                    => new ConfigureStubCommand(anyArgument: $tuple[0], literalId: $tuple[1]),
+            ),
+            Gen::map(
+                Gen::tuple(
+                    $argument,
+                    $literal,
+                    Gen::intBetween(0, 2),
+                    Gen::flatMap(
+                        Gen::intBetween(0, 2),
+                        static fn(int $minimum): ArbitraryInterface => Gen::elements([
+                            null,
+                            $minimum,
+                            $minimum + 2,
+                        ]),
+                    ),
+                ),
+                static fn(array $tuple): ConfigureExpectCommand => new ConfigureExpectCommand(
+                    anyArgument: $tuple[0],
+                    literalId: $tuple[1],
+                    minimum: $tuple[2],
+                    maximum: self::atLeastMinimum($tuple[2], $tuple[3]),
+                ),
+            ),
+            Gen::map(Gen::intBetween(1, 3), static fn(int $id): DispatchFindCommand => new DispatchFindCommand(id: $id)),
+            Gen::map(
+                Gen::tuple(
+                    $argument,
+                    $literal,
+                    Gen::intBetween(0, 2),
+                    Gen::flatMap(
+                        Gen::intBetween(0, 2),
+                        static fn(int $minimum): ArbitraryInterface => Gen::elements([
+                            null,
+                            $minimum,
+                            $minimum + 2,
+                        ]),
+                    ),
+                ),
+                static fn(array $tuple): VerifyCallsCommand => new VerifyCallsCommand(
+                    anyArgument: $tuple[0],
+                    literalId: $tuple[1],
+                    minimum: $tuple[2],
+                    maximum: self::atLeastMinimum($tuple[2], $tuple[3]),
+                ),
+            ),
+            Gen::constant(new VerifyEverythingCommand()),
+            Gen::constant(new SettleCheckpointCommand()),
+            Gen::constant(new RequireNothingElseCommand()),
+        ];
+    }
+
+    /**
+     * Keeps the drawn upper bound honest: never below the minimum it is
+     * paired with, unbounded when the element draw said so.
+     */
+    private static function atLeastMinimum(int $minimum, ?int $drawn): ?int
+    {
+        return $drawn === null ? null : max($minimum, $drawn);
+    }
+}

--- a/tests/Support/ConfigureExpectCommand.php
+++ b/tests/Support/ConfigureExpectCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+use Rasuvaeff\PropertyTesting\StateMachine\Command;
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Understudy;
+
+use function Rasuvaeff\Understudy\expect;
+
+/**
+ * Declares an `expect()` claim on the double with explicit cardinality.
+ * Claims carry no action on purpose: a matched claim falls through to the
+ * mode's own answer while still counting the call and accounting for it,
+ * which is precisely the pairing the ledger has to keep straight.
+ */
+final readonly class ConfigureExpectCommand implements Command
+{
+    public function __construct(
+        private bool $anyArgument,
+        private int $literalId,
+        private int $minimum,
+        private ?int $maximum,
+    ) {}
+
+    #[\Override]
+    public function preCondition(mixed $model): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function nextState(mixed $model): EngineState
+    {
+        \assert($model instanceof EngineState);
+
+        return $model->withSpec(new EngineSpec(
+            anyArgument: $this->anyArgument,
+            literalId: $this->literalId,
+            isClaim: true,
+            answerTitle: '',
+            minimum: $this->minimum,
+            maximum: $this->maximum,
+        ));
+    }
+
+    #[\Override]
+    public function run(mixed $model, mixed $system): int
+    {
+        \assert($model instanceof EngineState);
+        \assert($system instanceof EngineHarness);
+
+        expect(fn() => $system->double->find($this->argument()))
+            ->times(minimum: $this->minimum, maximum: $this->maximum);
+
+        return count(Understudy::calls(fn() => $system->double->find(Arg::any())));
+    }
+
+    #[\Override]
+    public function postCondition(mixed $model, mixed $result): bool
+    {
+        \assert($model instanceof EngineState);
+        \assert(\is_int($result));
+
+        return $result === $model->callCount();
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return sprintf(
+            'expect(find(%s), %s)',
+            $this->describeArgument(),
+            $this->maximum === null ? "at least {$this->minimum}" : "{$this->minimum}..{$this->maximum}",
+        );
+    }
+
+    private function argument(): mixed
+    {
+        return $this->anyArgument ? Arg::any() : $this->literalId;
+    }
+
+    private function describeArgument(): string
+    {
+        return $this->anyArgument ? 'any' : (string) $this->literalId;
+    }
+}

--- a/tests/Support/ConfigureStubCommand.php
+++ b/tests/Support/ConfigureStubCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+use Rasuvaeff\PropertyTesting\StateMachine\Command;
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Tests\Fixture\Book;
+use Rasuvaeff\Understudy\Understudy;
+use Rasuvaeff\Understudy\WhenBuilder;
+
+use function Rasuvaeff\Understudy\when;
+
+/**
+ * Registers a `when()` stub on the double. The answer title encodes the
+ * registration index from the pre-state model, so a dispatch later in the
+ * sequence names exactly which specification answered it.
+ */
+final readonly class ConfigureStubCommand implements Command
+{
+    public function __construct(
+        private bool $anyArgument,
+        private int $literalId,
+    ) {}
+
+    #[\Override]
+    public function preCondition(mixed $model): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function nextState(mixed $model): EngineState
+    {
+        \assert($model instanceof EngineState);
+
+        return $model->withSpec(new EngineSpec(
+            anyArgument: $this->anyArgument,
+            literalId: $this->literalId,
+            isClaim: false,
+            answerTitle: 's' . count($model->specs),
+        ));
+    }
+
+    #[\Override]
+    public function run(mixed $model, mixed $system): int
+    {
+        \assert($model instanceof EngineState);
+        \assert($system instanceof EngineHarness);
+
+        /** @var WhenBuilder<mixed> $builder */
+        $builder = when(fn() => $system->double->find($this->argument()));
+        $builder->returns(new Book('s' . count($model->specs)));
+
+        // Recording must not itself dispatch: the log the model knows about
+        // is still the whole log.
+        return count(Understudy::calls(fn() => $system->double->find(Arg::any())));
+    }
+
+    #[\Override]
+    public function postCondition(mixed $model, mixed $result): bool
+    {
+        \assert($model instanceof EngineState);
+        \assert(\is_int($result));
+
+        return $result === $model->callCount();
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return 'stub(find(' . $this->describeArgument() . '))';
+    }
+
+    private function argument(): mixed
+    {
+        return $this->anyArgument ? Arg::any() : $this->literalId;
+    }
+
+    private function describeArgument(): string
+    {
+        return $this->anyArgument ? 'any' : (string) $this->literalId;
+    }
+}

--- a/tests/Support/DispatchFindCommand.php
+++ b/tests/Support/DispatchFindCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+use Rasuvaeff\PropertyTesting\StateMachine\Command;
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Tests\Fixture\Book;
+use Rasuvaeff\Understudy\Understudy;
+
+/**
+ * Dispatches one real call against the double and observes what answered.
+ * The oracle is the model: the last matching specification decides the
+ * answer — its title when it carries an action, the loose default (`null`
+ * for `?Book`) when it does not or none matches — and the log grows by
+ * exactly one entry, accounted precisely when a claim matched.
+ */
+final readonly class DispatchFindCommand implements Command
+{
+    public function __construct(
+        private int $id,
+    ) {}
+
+    #[\Override]
+    public function preCondition(mixed $model): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function nextState(mixed $model): EngineState
+    {
+        \assert($model instanceof EngineState);
+
+        return $model->afterDispatch($this->id);
+    }
+
+    #[\Override]
+    public function run(mixed $model, mixed $system): array
+    {
+        \assert($model instanceof EngineState);
+        \assert($system instanceof EngineHarness);
+
+        /** @var Book|null $answer */
+        $answer = $system->double->find($this->id);
+
+        $answering = $model->answerFor($this->id);
+
+        if ($answering === null) {
+            ++$system->unmatchedDefaults;
+        } elseif ($answering->hasAction()) {
+            ++$system->stubAnswers;
+        } else {
+            ++$system->countedClaims;
+        }
+
+        return [
+            $answer === null ? null : $answer->title,
+            count(Understudy::calls(fn() => $system->double->find(Arg::any()))),
+        ];
+    }
+
+    #[\Override]
+    public function postCondition(mixed $model, mixed $result): bool
+    {
+        \assert($model instanceof EngineState);
+        \assert(\is_array($result));
+
+        [$title, $logSize] = $result;
+
+        if ($logSize !== $model->callCount() + 1) {
+            return false;
+        }
+
+        $answering = $model->answerFor($this->id);
+        $expectedTitle = $answering !== null && $answering->hasAction() ? $answering->answerTitle : null;
+
+        return $title === $expectedTitle;
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return "find({$this->id})";
+    }
+}

--- a/tests/Support/EngineHarness.php
+++ b/tests/Support/EngineHarness.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
+
+/**
+ * Mutable holder for the system-under-test side of the engine lifecycle
+ * property. The double itself carries no counters — that is the library's
+ * whole point — so branch classification for the coverage gates accumulates
+ * here instead, written by {@see EngineCommand} runs.
+ */
+final class EngineHarness
+{
+    public int $stubAnswers = 0;
+    public int $countedClaims = 0;
+    public int $unmatchedDefaults = 0;
+    public int $verifiesPassed = 0;
+    public int $verifiesFailed = 0;
+    public int $settledCheckpoints = 0;
+
+    public function __construct(public readonly BookRepository $double) {}
+}

--- a/tests/Support/EngineSpec.php
+++ b/tests/Support/EngineSpec.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+/**
+ * One configured call in the model behind
+ * {@see \Rasuvaeff\Understudy\Tests\EngineLifecyclePropertyTest}: a `find()`
+ * specification with a literal-or-wildcard argument, registered either as a
+ * stub (`when()`, permission only) or as a claim (`expect()`, a cardinality
+ * promise).
+ *
+ * The model tracks what the engine's ledger tracks: how often this
+ * specification matched, and whether those matches stay inside the promised
+ * bounds. Everything else — chains, ordered claims, matchers richer than a
+ * literal or a wildcard — is deliberately out of scope; it is pinned by the
+ * unit suites.
+ */
+final readonly class EngineSpec
+{
+    public function __construct(
+        public bool $anyArgument,
+        public int $literalId,
+        public bool $isClaim,
+        public string $answerTitle,
+        public int $minimum = 0,
+        public ?int $maximum = null,
+        public int $matched = 0,
+    ) {}
+
+    public function accepts(int $id): bool
+    {
+        return $this->anyArgument || $this->literalId === $id;
+    }
+
+    public function hasAction(): bool
+    {
+        return !$this->isClaim;
+    }
+
+    public function withinCardinality(): bool
+    {
+        return $this->matched >= $this->minimum
+            && ($this->maximum === null || $this->matched <= $this->maximum);
+    }
+
+    public function withMatch(): self
+    {
+        return new self(
+            anyArgument: $this->anyArgument,
+            literalId: $this->literalId,
+            isClaim: $this->isClaim,
+            answerTitle: $this->answerTitle,
+            minimum: $this->minimum,
+            maximum: $this->maximum,
+            matched: $this->matched + 1,
+        );
+    }
+
+    public function describe(): string
+    {
+        return sprintf(
+            '%s(find(%s))',
+            $this->isClaim ? 'expect' : 'when',
+            $this->anyArgument ? 'any' : (string) $this->literalId,
+        );
+    }
+}

--- a/tests/Support/EngineState.php
+++ b/tests/Support/EngineState.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+/**
+ * The model the engine lifecycle is checked against: the specifications
+ * registered so far, in registration order, and the log of dispatched
+ * `find()` calls with one accounted flag per entry.
+ *
+ * Immutable by construction — every transition returns a fresh instance — so
+ * the state machine runner can replay a shrunk sequence deterministically.
+ *
+ * The oracle walks the specifications backwards (most recently registered
+ * first) without using any matcher implementation of the engine's.
+ */
+final readonly class EngineState
+{
+    /**
+     * @param list<EngineSpec> $specs      registration order, oldest first
+     * @param list<int>        $loggedIds  the argument of every dispatched call, in order
+     * @param list<bool>       $accounted  per logged call, whether something accounted for it
+     */
+    public function __construct(
+        public array $specs = [],
+        public array $loggedIds = [],
+        public array $accounted = [],
+    ) {}
+
+    /**
+     * The specification that would answer `find($id)`: the last registered
+     * one whose predicate accepts the call.
+     */
+    public function answerFor(int $id): ?EngineSpec
+    {
+        foreach (array_reverse($this->specs) as $spec) {
+            if ($spec->accepts($id)) {
+                return $spec;
+            }
+        }
+
+        return null;
+    }
+
+    public function afterDispatch(int $id): self
+    {
+        $answering = null;
+
+        foreach ($this->specs as $index => $spec) {
+            if ($spec->accepts($id)) {
+                $answering = $index;
+            }
+        }
+
+        $specs = $this->specs;
+
+        if ($answering !== null) {
+            $specs[$answering] = $specs[$answering]->withMatch();
+        }
+
+        return new self(
+            specs: $specs,
+            loggedIds: [...$this->loggedIds, $id],
+            accounted: [...$this->accounted, $answering !== null && $specs[$answering]->isClaim],
+        );
+    }
+
+    public function withSpec(EngineSpec $spec): self
+    {
+        return new self(
+            specs: [...$this->specs, $spec],
+            loggedIds: $this->loggedIds,
+            accounted: $this->accounted,
+        );
+    }
+
+    /**
+     * A successful explicit verify claims every logged call the probe
+     * matches, idempotently over what was already accounted for.
+     */
+    public function withVerified(bool $anyArgument, int $literalId): self
+    {
+        $accounted = [];
+
+        foreach ($this->loggedIds as $index => $logged) {
+            $matched = $anyArgument || $logged === $literalId;
+
+            $accounted[] = $this->accounted[$index] || $matched;
+        }
+
+        return new self(specs: $this->specs, loggedIds: $this->loggedIds, accounted: $accounted);
+    }
+
+    /**
+     * A settled checkpoint drops the satisfied claims and every accounted
+     * call; stubs and unaccounted calls carry into the next phase.
+     */
+    public function settled(): self
+    {
+        $specs = array_values(array_filter(
+            $this->specs,
+            static fn(EngineSpec $spec): bool => !$spec->isClaim,
+        ));
+
+        $loggedIds = [];
+        $accounted = [];
+
+        foreach ($this->loggedIds as $index => $logged) {
+            if ($this->accounted[$index]) {
+                continue;
+            }
+
+            $loggedIds[] = $logged;
+            $accounted[] = false;
+        }
+
+        return new self(specs: $specs, loggedIds: $loggedIds, accounted: $accounted);
+    }
+
+    public function callCount(): int
+    {
+        return count($this->loggedIds);
+    }
+
+    public function hasUnaccountedCalls(): bool
+    {
+        return in_array(false, $this->accounted, true);
+    }
+
+    public function claimsViolated(): bool
+    {
+        foreach ($this->specs as $spec) {
+            if ($spec->isClaim && !$spec->withinCardinality()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * How many logged calls the given probe matches — the number an explicit
+     * verify counts over the whole log.
+     */
+    public function matchingCallCount(bool $anyArgument, int $literalId): int
+    {
+        $matches = 0;
+
+        foreach ($this->loggedIds as $logged) {
+            if ($anyArgument || $logged === $literalId) {
+                ++$matches;
+            }
+        }
+
+        return $matches;
+    }
+}

--- a/tests/Support/RequireNothingElseCommand.php
+++ b/tests/Support/RequireNothingElseCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+use Rasuvaeff\PropertyTesting\StateMachine\Command;
+use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Understudy;
+
+/**
+ * Runs `nothingElse()` and observes whether the engine found an unaccounted
+ * call. The model knows exactly which log entries something accounted for —
+ * a matched claim or a successful explicit verify — so this pins the whole
+ * accounting chain end to end.
+ */
+final readonly class RequireNothingElseCommand implements Command
+{
+    #[\Override]
+    public function preCondition(mixed $model): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function nextState(mixed $model): EngineState
+    {
+        \assert($model instanceof EngineState);
+
+        return $model;
+    }
+
+    #[\Override]
+    public function run(mixed $model, mixed $system): bool
+    {
+        \assert($system instanceof EngineHarness);
+
+        $threw = false;
+
+        try {
+            Understudy::nothingElse($system->double);
+        } catch (VerificationFailed) {
+            $threw = true;
+        }
+
+        return $threw;
+    }
+
+    #[\Override]
+    public function postCondition(mixed $model, mixed $result): bool
+    {
+        \assert($model instanceof EngineState);
+        \assert(\is_bool($result));
+
+        return $result === $model->hasUnaccountedCalls();
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return 'nothingElse()';
+    }
+}

--- a/tests/Support/SettleCheckpointCommand.php
+++ b/tests/Support/SettleCheckpointCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+use Rasuvaeff\PropertyTesting\StateMachine\Command;
+use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Understudy;
+
+/**
+ * Runs `checkpoint()`: verify the context, then settle it — satisfied claims
+ * and accounted calls dropped, stubs and unaccounted calls carried into the
+ * next phase. The model applies the same transition, but only when the check
+ * passed; a violated claim means nothing was settled.
+ */
+final readonly class SettleCheckpointCommand implements Command
+{
+    #[\Override]
+    public function preCondition(mixed $model): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function nextState(mixed $model): EngineState
+    {
+        \assert($model instanceof EngineState);
+
+        return $model->claimsViolated() ? $model : $model->settled();
+    }
+
+    #[\Override]
+    public function run(mixed $model, mixed $system): bool
+    {
+        \assert($system instanceof EngineHarness);
+
+        $threw = false;
+
+        try {
+            Understudy::checkpoint();
+        } catch (VerificationFailed) {
+            $threw = true;
+        }
+
+        if (!$threw) {
+            ++$system->settledCheckpoints;
+        }
+
+        return $threw;
+    }
+
+    #[\Override]
+    public function postCondition(mixed $model, mixed $result): bool
+    {
+        \assert($model instanceof EngineState);
+        \assert(\is_bool($result));
+
+        return $result === $model->claimsViolated();
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return 'checkpoint()';
+    }
+}

--- a/tests/Support/VerifyCallsCommand.php
+++ b/tests/Support/VerifyCallsCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+use Rasuvaeff\PropertyTesting\StateMachine\Command;
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Understudy;
+
+/**
+ * Runs an explicit `verify()` over the whole log and observes whether the
+ * engine accepted the cardinality. The model predicts acceptance from its
+ * own count of matching calls; on acceptance every matching call becomes
+ * accounted for, which later `nothingElse` commands go on to notice.
+ */
+final readonly class VerifyCallsCommand implements Command
+{
+    public function __construct(
+        private bool $anyArgument,
+        private int $literalId,
+        private int $minimum,
+        private ?int $maximum,
+    ) {}
+
+    #[\Override]
+    public function preCondition(mixed $model): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function nextState(mixed $model): EngineState
+    {
+        \assert($model instanceof EngineState);
+
+        $matches = $model->matchingCallCount($this->anyArgument, $this->literalId);
+        $accepted = $this->accepts($matches);
+
+        return $accepted ? $model->withVerified($this->anyArgument, $this->literalId) : $model;
+    }
+
+    #[\Override]
+    public function run(mixed $model, mixed $system): array
+    {
+        \assert($model instanceof EngineState);
+        \assert($system instanceof EngineHarness);
+
+        $threw = false;
+
+        try {
+            Understudy::verify(
+                fn() => $system->double->find($this->argument()),
+                minimum: $this->minimum,
+                maximum: $this->maximum,
+            );
+        } catch (VerificationFailed) {
+            $threw = true;
+        }
+
+        if ($threw) {
+            ++$system->verifiesFailed;
+        } else {
+            ++$system->verifiesPassed;
+        }
+
+        return [$threw, $this->observedLogSize($system)];
+    }
+
+    #[\Override]
+    public function postCondition(mixed $model, mixed $result): bool
+    {
+        \assert($model instanceof EngineState);
+        \assert(\is_array($result));
+
+        [$threw, $logSize] = $result;
+
+        $predicted = !$this->accepts($model->matchingCallCount($this->anyArgument, $this->literalId));
+
+        return $threw === $predicted && $logSize === $model->callCount();
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return sprintf(
+            'verify(find(%s), %s)',
+            $this->describeArgument(),
+            $this->maximum === null ? "at least {$this->minimum}" : "{$this->minimum}..{$this->maximum}",
+        );
+    }
+
+    private function accepts(int $matches): bool
+    {
+        return $matches >= $this->minimum
+            && ($this->maximum === null || $matches <= $this->maximum);
+    }
+
+    private function argument(): mixed
+    {
+        return $this->anyArgument ? Arg::any() : $this->literalId;
+    }
+
+    private function observedLogSize(EngineHarness $system): int
+    {
+        return count(Understudy::calls(fn() => $system->double->find(Arg::any())));
+    }
+
+    private function describeArgument(): string
+    {
+        return $this->anyArgument ? 'any' : (string) $this->literalId;
+    }
+}

--- a/tests/Support/VerifyEverythingCommand.php
+++ b/tests/Support/VerifyEverythingCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+use Rasuvaeff\PropertyTesting\StateMachine\Command;
+use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Understudy;
+
+/**
+ * Runs `verifyAll()` — every claim in the context checked against its
+ * cardinality — and observes whether the engine accepted. Nothing settles:
+ * the model is unchanged whether the check passed or failed.
+ */
+final readonly class VerifyEverythingCommand implements Command
+{
+    #[\Override]
+    public function preCondition(mixed $model): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function nextState(mixed $model): EngineState
+    {
+        \assert($model instanceof EngineState);
+
+        return $model;
+    }
+
+    #[\Override]
+    public function run(mixed $model, mixed $system): bool
+    {
+        \assert($system instanceof EngineHarness);
+
+        $threw = false;
+
+        try {
+            Understudy::verifyAll();
+        } catch (VerificationFailed) {
+            $threw = true;
+        }
+
+        return $threw;
+    }
+
+    #[\Override]
+    public function postCondition(mixed $model, mixed $result): bool
+    {
+        \assert($model instanceof EngineState);
+        \assert(\is_bool($result));
+
+        return $result === $model->claimsViolated();
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return 'verifyAll()';
+    }
+}


### PR DESCRIPTION
## What

The one property §8 of the plan calls the most valuable of the missing ones: `Gen::commands()` + `StateMachine::check()` over the engine's core loop — stub/expect → dispatch → verify → checkpoint.

A random sequence of seven command shapes (register a stub, declare a claim with cardinality, dispatch `find($id)`, run an explicit verify, run `verifyAll()`, settle a checkpoint, demand `nothingElse()`) is driven against a fresh double, and every step's observable outcome — what answered, how big the log is, whether verification threw — is checked against a pure `EngineState` model. The model re-derives most-recent-first matching, claim accounting, verify marking and checkpoint settling without touching any matcher implementation of the engine's.

## Shape

The 4-file pattern from `yii3-webhooks`: model (`EngineState` + `EngineSpec`), commands (`*Command` implementing `Rasuvaeff\PropertyTesting\StateMachine\Command`), harness (`EngineHarness`, branch counters for the coverage gates), test (`EngineLifecyclePropertyTest`).

- 200 random runs, sequences up to 24 commands, swarmed so partial vocabularies are ordinary.
- Four pinned examples: a newer claim shadowing an older stub; checkpoint keeping stubs while dropping satisfied claims; verify accounting stubbed calls for `nothingElse`; a violated claim failing both `verifyAll()` and the checkpoint.
- Six `Classify::cover` gates keep every dispatcher branch reachable across the batch.

## Deliberately out of scope

Chains (`then()`), ordered claims, matchers richer than literal/wildcard, strict mode, forwarding, fibers — all pinned by the unit suites. This property covers only the loop that only a long random interleaving can surface.

## Verification

```
composer build   PASS
make mutation    2310 mutants, Covered Code MSI 93% (gate 92)
composer test    654 tests · 10442 assertions, passed