### PR TITLE
Add Understudy::idle() as an adapter integration guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- `Understudy::idle()` — whether the current context holds no doubles. Runner
+  adapters use it as an integration guard: a context that is not idle when the
+  next test begins means some earlier cleanup never ran.
 - `Understudy::nothingElse()` accepts any number of doubles. A test that used
   several can now close them out in one line — `nothingElse($repo, $clock,
   $mailer)` — and a failure reports every double with unaccounted calls

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ method and arguments, even when several doubles implement the same contract.
 Understudy::checkpoint();                       // verify, then forget what is settled
 $result = Understudy::scope(fn () => ...);      // nested context, verified on success
 echo Understudy::transcript($repository);       // every call and its outcome
+Understudy::idle();                             // true when the context holds no doubles
 ```
 
 `scope()` returns whatever its callback returns, and drops the nested context
@@ -474,11 +475,33 @@ names a double when several of the same contract are in play.
 
 ```php
 Understudy::reset();
+Understudy::idle();   // true when the current context holds no doubles
 ```
 
-Adapters for Testo and PHPUnit will call this for you; until they exist, call
-it in your own teardown. Reset drops only the current execution context; it
-does not erase sibling Fiber contexts.
+The [understudy-testo](https://github.com/rasuvaeff/understudy-testo) and
+[understudy-phpunit](https://github.com/rasuvaeff/understudy-phpunit) adapters
+verify and reset for you after every test; without one, call `reset()` in your
+own teardown. Reset drops only the current execution context; it does not
+erase sibling Fiber contexts.
+
+### Using Pest
+
+Pest already owns the global `expect()` function, so importing understudy's
+setup verb collides with it. Import the function under another name:
+
+```php
+use function Rasuvaeff\Understudy\expect as expectCall;
+
+expectCall(fn () => $books->find(7));
+```
+
+or use the collision-free static form everywhere:
+
+```php
+Understudy::expect(fn () => $books->find(7));
+```
+
+`when()` and `verify()` are globally free and need no alias.
 
 ## Security
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -296,6 +296,7 @@ Understudy::verifySequence(             // точный протокол, чер
 Understudy::checkpoint();                       // проверить и забыть завершённое
 $result = Understudy::scope(fn () => ...);      // вложенный контекст, проверяемый при успехе
 echo Understudy::transcript($repository);       // все вызовы и их исходы
+Understudy::idle();                             // true, если в контексте нет дублей
 ```
 
 `scope()` возвращает то, что вернул колбэк, и в любом случае сбрасывает
@@ -469,11 +470,34 @@ The following calls to `tag` were made during this test:
 
 ```php
 Understudy::reset();
+Understudy::idle();   // true, если в текущем контексте нет ни одного дубля
 ```
 
-Адаптеры для Testo и PHPUnit будут вызывать это сами; пока их нет — вызывайте
-в своём teardown. Reset очищает только текущий execution context и не стирает
-контексты соседних Fiber.
+Адаптеры [understudy-testo](https://github.com/rasuvaeff/understudy-testo) и
+[understudy-phpunit](https://github.com/rasuvaeff/understudy-phpunit)
+проверяют и сбрасывают контекст после каждого теста сами; без адаптера —
+вызывайте `reset()` в своём teardown. Reset очищает только текущий execution
+context и не стирает контексты соседних Fiber.
+
+### Использование Pest
+
+Pest уже занимает глобальную функцию `expect()`, поэтому импорт глагола
+настройки understudy с ней конфликтует. Импортируйте функцию под другим
+именем:
+
+```php
+use function Rasuvaeff\Understudy\expect as expectCall;
+
+expectCall(fn () => $books->find(7));
+```
+
+или используйте везде бесколлизионную статическую форму:
+
+```php
+Understudy::expect(fn () => $books->find(7));
+```
+
+`when()` и `verify()` глобально свободны и в алиасе не нуждаются.
 
 ## Безопасность
 

--- a/llms.txt
+++ b/llms.txt
@@ -248,6 +248,7 @@ to method and arguments.
 Understudy::checkpoint();            // verify, then forget what is settled
 $result = Understudy::scope(fn () => ...);   // nested context, verified on success
 Understudy::transcript($repo);       // every call and outcome, for reading
+Understudy::idle();                  // true when the current context holds no doubles
 ```
 
 `scope()` returns whatever the callback returns and drops its context either

--- a/src/Understudy.php
+++ b/src/Understudy.php
@@ -822,6 +822,18 @@ final class Understudy
     }
 
     /**
+     * Whether the current context holds no understudies at all.
+     *
+     * Runner adapters use it as an integration guard: a context that is not
+     * idle by the time the next test begins means some earlier test's cleanup
+     * never ran, and its doubles are about to leak into this one.
+     */
+    public static function idle(): bool
+    {
+        return Runtime::current()->allStates() === [];
+    }
+
+    /**
      * Runs the specification closure with recording on, and catches the signal
      * the called method throws instead of returning.
      */

--- a/tests/UnderstudyTest.php
+++ b/tests/UnderstudyTest.php
@@ -92,6 +92,22 @@ final class UnderstudyTest
         Assert::instanceOf(Understudy::for(BookRepository::class), BookRepository::class);
     }
 
+    public function freshContextIsIdle(): void
+    {
+        Assert::true(Understudy::idle());
+    }
+
+    public function creatingADoubleEndsIdlenessUntilReset(): void
+    {
+        $double = Understudy::for(BookRepository::class);
+
+        Assert::false(Understudy::idle());
+
+        Understudy::reset();
+
+        Assert::true(Understudy::idle());
+    }
+
     public function doubleCombinesSeveralInterfaces(): void
     {
         $double = Understudy::for(BookRepository::class, Named::class);


### PR DESCRIPTION
## What

- New public API: `Understudy::idle(): bool` — whether the current execution context holds no doubles. Runner adapters use it as an integration guard: a context that is not idle when the next test begins means some earlier test's cleanup never ran.
- README (EN/RU): Pest section — the `expect()` collision alias (`expect as expectCall`), promised by review item R4 to land together with the PHPUnit adapter milestone.
- README (EN/RU): cleanup section now references the understudy-testo / understudy-phpunit adapters instead of "until they exist".

## Why

Milestone 4b of the family plan (_plans/UNDERSTUDY-PLAN.md): the `#[Before]` guard of the PHPUnit adapter and future integrations need a public way to detect a leaked context; everything under `Runtime` stays internal.

## Verification

- `composer build` green locally (659 tests, 658 passed + 1 pre-existing risky unrelated to this change).
- The two new tests cover idle→not-idle→reset→idle.