### PR TITLE
Structured failures, golden messages, and a Mockery migration table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,31 @@ make release-check
 
 ## Invariants & gotchas
 
+- **Module boundaries.** `Codegen`, `Runtime`, `Expectation`, `Matcher`,
+  `Defaults`, `Bypass` and `Wiring` are `@internal`, and the arrows between
+  them are part of the design: `Matcher` depends on nothing but leaf
+  formatting (`Expectation\ArgumentFormatter`) and the language — a matcher
+  runs while the code under test is executing; only `Runtime` and the
+  `Understudy` facade see everything else. A PR pointing a dependency the
+  other way — a matcher reaching into `Runtime`, or anything into `Matcher`
+  beyond its interface — is restructured, not merged.
+- **Adding an `Arg::*` matcher is four files and no engine edits.** A class in
+  `src/Matcher/` implementing `ArgumentMatcher` (`matches()`, `describe()`),
+  a static factory on `Arg` returning `mixed` (the widening union with every
+  parameter type is what lets it be passed where the contract declares
+  anything), a test in `tests/` covering both verdicts plus `describe()`, and
+  a README/llms.txt row. The dispatcher talks to matchers only through the
+  interface — `DoubleState` never names a concrete matcher. A matcher must
+  not throw on a hostile argument: matching runs inside the code under test,
+  and a matcher that breaks is a test broken by its own tooling
+  (`Arg::which()` catching a throwing getter is the precedent).
+- **Golden files for rendered reports.** A failure message that renders calls
+  — a call log, an argument marked with `*` — belongs in
+  `tests/fixtures/messages/<name>.txt`, read through
+  `Support\GoldenMessage::read()`. Single-line messages stay inline. There is
+  no update flag: a wording change edits the `.txt` by hand, and the diff of
+  the file IS the wording review.
+
 - **A class not named by any `#[Covers]` is invisible to mutation testing, even
   when every test drives it.** `TargetUnifier` compiles every double in the
   suite and was claimed by one test class, so Infection never used the rest to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+- **Structured failures.** `VerificationFailed::failures()` answers a
+  `list<VerificationFailure>` — one record per failed claim, each carrying
+  its `FailureKind` (`UnmetExpectation`, `StrictStubUnused`, `OutOfOrder`,
+  `OutOfSequence`, `UnaccountedCalls`, `UnusedDouble`), the double's label,
+  the call specification, the claimed bounds, the actual count, the observed
+  calls as `Invocation` records, and its own rendered summary. The exception
+  message is exactly the summaries joined with a blank line — there is no
+  path where the two disagree. For tooling that acts on a failure rather than
+  printing it: runner adapters, IDE plugins, report aggregators. The readonly
+  fields of `VerificationFailure` and `FailureKind` are frozen public API
+  from v0.1.0; renaming, removing or retyping one is a major-version change.
+- **Golden files for rendered reports.** Multi-line failure messages moved to
+  `tests/fixtures/messages/*.txt`, read through
+  `Support\GoldenMessage::read()`: a wording review now reads a `.txt` diff
+  instead of PHP string concatenation. The convention is written into
+  AGENTS.md; single-line messages stay inline.
+- **A migration table for Mockery users** in both READMEs — no aliases and no
+  converter, by policy: migration help belongs in documentation. The two rows
+  that bite carry the dogfooding lessons: a spy counter counted every call,
+  an `expect()` counts only calls matching its arguments (so every migrated
+  counter needs `nothingElse()`), and incidental setup written as
+  `shouldReceive(...)->once()` becomes `when()`, not `expect()`.
+- AGENTS.md now states the module boundaries (a matcher depends on nothing
+  but leaf formatting; only `Runtime` and the facade see everything) and the
+  four-file walkthrough for adding an `Arg::*` matcher.
+
 - **`Understudy::lastCall(callable $call): ?Invocation`** — the newest
   recorded call matching the specification, or null when there was none. The
   null-safe replacement for reading `count($calls) - 1` out of `calls()`:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ The call-closure form comes from [MockK](https://mockk.io) (Kotlin),
 (C#), and [mocktail](https://pub.dev/packages/mocktail) (Dart). No PHP library
 had it.
 
+## Migrating from Mockery
+
+No aliases and no converter — the table maps the verb you know to the shape
+here. Two rows are traps, marked ⚠.
+
+| Mockery | Understudy | Notes |
+|---|---|---|
+| `Mockery::mock(BookRepository::class)` | `Understudy::for(BookRepository::class)` | |
+| `$mock->shouldReceive('find')` | `when(fn () => $mock->find(...))` | a real call; no method-name string |
+| `->once()` / `->twice()` / `->times(3)` | `expect(fn () => ...)->times(3)` | an `expect()` is checked by `verifyAll()` / the adapter |
+| `->atLeast()->once()` | `expect(...)->times(minimum: 1)` | |
+| `->andReturn($book)` | `->returns($book)` | |
+| `->andReturnUsing(fn ...)` | `->answers(fn (Invocation $i) => ...)` | arguments come from `$i->args` |
+| `->andThrow(new NotFound())` | `->throws(new NotFound())` | |
+| `->with(123, Mockery::any())` | inside the closure: `find(123, Arg::any())` | |
+| `Mockery::on(fn ($x) => ...)` | `Arg::satisfies(fn ($x) => ...)` | |
+| `$mock->shouldNotHaveReceived('save')` | `Understudy::unused($mock)` | |
+| `$mock->shouldHaveReceived('save')` | `verify(fn () => $mock->save(...))` | after the fact; add `nothingElse()` — see below |
+| `Mockery::close()` | adapter's `reset()`, or your own teardown | |
+| ⚠ `->shouldReceive(...)->once()` used as setup | `when(...)->returns(...)` | a `when()` is permission, not a claim — if you only needed a value, `expect()` would make incidental setup a failing test |
+| ⚠ a spy counting every call | `expect()` + `Understudy::nothingElse($mock)` | `expect()` counts only calls matching **its** arguments; without `nothingElse()` a second call with different arguments passes — a hand-rolled counter caught it, the migration must not lose it |
+
 ## Performance
 
 Against Mockery 1.6.15, Prophecy 1.26.1 and PHPUnit 12.5.33 on PHP 8.5.6.

--- a/README.ru.md
+++ b/README.ru.md
@@ -31,6 +31,28 @@ when(fn () => $repository->find(123))->returns($book);
 (C#), [mocktail](https://pub.dev/packages/mocktail) (Dart). В PHP её не было
 ни у кого.
 
+## Миграция с Mockery
+
+Ни алиасов, ни конвертера — таблица переводит знакомый глагол в здешнюю форму.
+Две строки — ловушки, помечены ⚠.
+
+| Mockery | Understudy | Примечание |
+|---|---|---|
+| `Mockery::mock(BookRepository::class)` | `Understudy::for(BookRepository::class)` | |
+| `$mock->shouldReceive('find')` | `when(fn () => $mock->find(...))` | настоящий вызов; без строки с именем метода |
+| `->once()` / `->twice()` / `->times(3)` | `expect(fn () => ...)->times(3)` | `expect()` проверяется `verifyAll()` или адаптером |
+| `->atLeast()->once()` | `expect(...)->times(minimum: 1)` | |
+| `->andReturn($book)` | `->returns($book)` | |
+| `->andReturnUsing(fn ...)` | `->answers(fn (Invocation $i) => ...)` | аргументы — из `$i->args` |
+| `->andThrow(new NotFound())` | `->throws(new NotFound())` | |
+| `->with(123, Mockery::any())` | в замыкании: `find(123, Arg::any())` | |
+| `Mockery::on(fn ($x) => ...)` | `Arg::satisfies(fn ($x) => ...)` | |
+| `$mock->shouldNotHaveReceived('save')` | `Understudy::unused($mock)` | |
+| `$mock->shouldHaveReceived('save')` | `verify(fn () => $mock->save(...))` | пост-фактум; добавьте `nothingElse()` — см. ниже |
+| `Mockery::close()` | reset() адаптера или свой teardown | |
+| ⚠ `->shouldReceive(...)->once()` как setup | `when(...)->returns(...)` | `when()` — разрешение, а не утверждение: если нужно было только значение, `expect()` превратит случайную настройку в падающий тест |
+| ⚠ шпион со счётчиком всех вызовов | `expect()` + `Understudy::nothingElse($mock)` | `expect()` считает только вызовы под **своими** аргументами; без `nothingElse()` второй вызов с другими аргументами проходит — рукописный счётчик это ловил, миграция не должна это терять |
+
 ## Производительность
 
 Против Mockery 1.6.15, Prophecy 1.26.1 и PHPUnit 12.5.33 на PHP 8.5.6.

--- a/llms.txt
+++ b/llms.txt
@@ -340,6 +340,32 @@ All implement `Rasuvaeff\Understudy\Exception\UnderstudyError`.
 | `OriginalReturnTypeViolation` | a forwarded `static` method returned another instance of the real class |
 | `VerificationFailed` | a verification about the tested code failed |
 
+### Structured failures — `failures()`
+
+```php
+try {
+    Understudy::verifyAll();
+} catch (VerificationFailed $e) {
+    foreach ($e->failures() as $failure) {
+        $failure->kind;             // FailureKind::UnmetExpectation | StrictStubUnused
+                                    // | OutOfOrder | OutOfSequence | UnaccountedCalls
+                                    // | UnusedDouble
+        $failure->double;           // label of the double
+        $failure->expectation;      // call spec, e.g. 'find(1)'
+        $failure->expectedMinimum;  // claimed lower bound, or null
+        $failure->expectedMaximum;  // claimed upper bound (null = unbounded), or null
+        $failure->actualCount;
+        $failure->observedCalls;    // list<Invocation> the report shows
+        $failure->expectedCalls;    // OutOfSequence only: the specified protocol
+        $failure->summary;          // this failure's rendered text
+    }
+}
+```
+
+The readonly fields of `VerificationFailure`/`FailureKind` are frozen public
+API from v0.1.0 — renaming, removing or retyping one is a major-version
+change. New kinds and newly-populated fields are additive.
+
 ## Not supported
 
 Static method mocking, patching at the point of use, deep stubs, duck doubles,

--- a/resources/skills/rasuvaeff-understudy/SKILL.md
+++ b/resources/skills/rasuvaeff-understudy/SKILL.md
@@ -199,6 +199,28 @@ and fatals on an empty log at runtime.
 `transcript()` retains every invocation until `reset()`. Do not drive a double
 through an unbounded hot loop when the arguments hold large object graphs.
 
+## Structured failures
+
+A caught `VerificationFailed` carries `->failures(): list<VerificationFailure>`
+— one record per failed claim, each with `kind` (`FailureKind::*`),
+`double`, `expectation`, `expectedMinimum`/`expectedMaximum`, `actualCount`,
+`observedCalls`, `expectedCalls`, and its own rendered `summary`. The
+exception's message is exactly the summaries joined with a blank line. Use
+the records when a tool needs to act on a failure; use the message when a
+human reads it. The fields are frozen public API from v0.1.0.
+
+## Migrating from Mockery or a hand-rolled spy
+
+The README carries a rosetta table; the two rows that actually bite:
+
+- A spy counter counted **every** call; `expect()` counts only calls matching
+  **its** arguments. Every migrated counter claim needs
+  `Understudy::nothingElse($double)` beside it, or the migration silently
+  weakens the test.
+- Incidental setup written as `shouldReceive(...)->once()` becomes `when()`,
+  not `expect()` — an `expect()` turns "the test needed this value" into a
+  claim about the code under test that fails when the implementation changes.
+
 ## Replaced doubles and `strictStubs`
 
 A fixture field reassigned mid-test (`$this->generator = $this->fixedGenerator(...)`)

--- a/src/Exception/VerificationFailed.php
+++ b/src/Exception/VerificationFailed.php
@@ -4,17 +4,53 @@ declare(strict_types=1);
 
 namespace Rasuvaeff\Understudy\Exception;
 
+use Rasuvaeff\Understudy\VerificationFailure;
+
 /**
  * A verification about what the code under test did (or did not) do failed.
  * This is the one exception that reports on the tested code rather than on
  * misuse of Understudy, so adapters map it to a test failure.
  *
+ * The message is the rendered report for a human; {@see failures()} carries
+ * the same facts as {@see VerificationFailure} records for tooling. Both are
+ * built from one list — there is no path where they disagree.
+ *
  * @api
  */
 final class VerificationFailed extends \RuntimeException implements UnderstudyError
 {
-    public static function withReport(string $report): self
+    /**
+     * @param list<VerificationFailure> $failures
+     */
+    private function __construct(
+        string $message,
+        private readonly array $failures,
+    ) {
+        parent::__construct($message);
+    }
+
+    /**
+     * @param non-empty-list<VerificationFailure> $failures
+     */
+    public static function of(array $failures): self
     {
-        return new self($report);
+        return new self(
+            implode("\n\n", array_map(
+                static fn(VerificationFailure $failure): string => $failure->summary,
+                $failures,
+            )),
+            $failures,
+        );
+    }
+
+    /**
+     * Every failure this exception reports, in the order the message states
+     * them. Non-empty whenever this exception was thrown by Understudy.
+     *
+     * @return list<VerificationFailure>
+     */
+    public function failures(): array
+    {
+        return $this->failures;
     }
 }

--- a/src/FailureKind.php
+++ b/src/FailureKind.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy;
+
+/**
+ * What kind of verification claim a {@see VerificationFailure} reports.
+ *
+ * @api
+ */
+enum FailureKind
+{
+    /** An `expect()` or `verify()` claim about how often a call happens was not met. */
+    case UnmetExpectation;
+
+    /** `verifyAll(strictStubs: true)` found a stub the code under test never used. */
+    case StrictStubUnused;
+
+    /** An `expect(...)->ordered()` constraint was violated. */
+    case OutOfOrder;
+
+    /** `verifySequence()` saw a different protocol than the one specified. */
+    case OutOfSequence;
+
+    /** A call arrived that no `expect()` matched and no successful `verify()` claimed. */
+    case UnaccountedCalls;
+
+    /** `unused()` found calls on a double expected to receive none. */
+    case UnusedDouble;
+}

--- a/src/FailureReport.php
+++ b/src/FailureReport.php
@@ -27,6 +27,8 @@ final class FailureReport
      * @param list<Invocation>  $callLog
      * @param non-empty-string  $method
      * @param list<mixed>       $expectedArgs
+     *
+     * @return non-empty-string
      */
     public static function render(
         string $label,

--- a/src/Understudy.php
+++ b/src/Understudy.php
@@ -196,7 +196,7 @@ final class Understudy
         }
 
         if ($failures !== []) {
-            throw VerificationFailed::withReport(implode("\n\n", $failures));
+            throw VerificationFailed::of($failures);
         }
     }
 
@@ -204,10 +204,8 @@ final class Understudy
      * Ordered expectations must be satisfied in the order they were declared,
      * relative to each other. Calls in between are none of their business —
      * `verifySequence()` is the tool for an exact protocol.
-     *
-     * @return non-empty-string|null
      */
-    private static function checkOrdering(?DoubleState $only = null, ?RuntimeContext $context = null): ?string
+    private static function checkOrdering(?DoubleState $only = null, ?RuntimeContext $context = null): ?VerificationFailure
     {
         /** @var list<array{DoubleState, Expectation}> $ordered */
         $ordered = [];
@@ -250,11 +248,16 @@ final class Understudy
             $first = min($sequences);
 
             if ($previousLabel !== null && $first < $previousLast) {
-                return sprintf(
-                    "Understudy `%s` expected `%s` to be called after `%s`, but it happened first.",
-                    $state->label(),
-                    $expectation->describe(),
-                    $previousLabel,
+                return new VerificationFailure(
+                    kind: FailureKind::OutOfOrder,
+                    summary: sprintf(
+                        "Understudy `%s` expected `%s` to be called after `%s`, but it happened first.",
+                        $state->label(),
+                        $expectation->describe(),
+                        $previousLabel,
+                    ),
+                    double: $state->label(),
+                    expectation: $expectation->describe(),
                 );
             }
 
@@ -265,10 +268,7 @@ final class Understudy
         return null;
     }
 
-    /**
-     * @return non-empty-string|null
-     */
-    private static function checkExpectation(DoubleState $state, Expectation $expectation, bool $strictStubs): ?string
+    private static function checkExpectation(DoubleState $state, Expectation $expectation, bool $strictStubs): ?VerificationFailure
     {
         $cardinality = $expectation->cardinality();
         $count = $expectation->matchCount();
@@ -277,11 +277,17 @@ final class Understudy
             // A plain stub is permission, not a claim — unless strict stubs
             // turn "configured but never used" into a failure of its own.
             return $strictStubs && $count === 0
-                ? sprintf(
-                    "Understudy `%s` has a stub for `%s` that was never used.\n"
-                    . 'Remove it, or drop strictStubs if the call is genuinely optional.',
-                    $state->label(),
-                    $expectation->describe(),
+                ? new VerificationFailure(
+                    kind: FailureKind::StrictStubUnused,
+                    summary: sprintf(
+                        "Understudy `%s` has a stub for `%s` that was never used.\n"
+                        . 'Remove it, or drop strictStubs if the call is genuinely optional.',
+                        $state->label(),
+                        $expectation->describe(),
+                    ),
+                    double: $state->label(),
+                    expectation: $expectation->describe(),
+                    actualCount: 0,
                 )
                 : null;
         }
@@ -290,12 +296,20 @@ final class Understudy
             return null;
         }
 
-        return sprintf(
-            'Understudy `%s` expected `%s` to be called %s, but it was called %s.',
-            $state->label(),
-            $expectation->describe(),
-            $cardinality->describe(),
-            $count === 0 ? 'never' : ($count === 1 ? '1 time' : $count . ' times'),
+        return new VerificationFailure(
+            kind: FailureKind::UnmetExpectation,
+            summary: sprintf(
+                'Understudy `%s` expected `%s` to be called %s, but it was called %s.',
+                $state->label(),
+                $expectation->describe(),
+                $cardinality->describe(),
+                $count === 0 ? 'never' : ($count === 1 ? '1 time' : $count . ' times'),
+            ),
+            double: $state->label(),
+            expectation: $expectation->describe(),
+            expectedMinimum: $cardinality->minimum,
+            expectedMaximum: $cardinality->maximum,
+            actualCount: $count,
         );
     }
 
@@ -344,16 +358,32 @@ final class Understudy
             return;
         }
 
-        throw VerificationFailed::withReport(FailureReport::render(
-            label: $state->label(),
-            expectation: $probe->describe(),
-            expectedLow: $low,
-            expectedHigh: $high,
-            actual: $matches,
-            callLog: $state->callLog(),
-            method: $signal->method,
-            expectedArgs: $signal->args,
+        $sameMethod = array_values(array_filter(
+            $state->callLog(),
+            static fn(Invocation $invocation): bool => $invocation->method === $signal->method,
         ));
+
+        throw VerificationFailed::of([
+            new VerificationFailure(
+                kind: FailureKind::UnmetExpectation,
+                summary: FailureReport::render(
+                    label: $state->label(),
+                    expectation: $probe->describe(),
+                    expectedLow: $low,
+                    expectedHigh: $high,
+                    actual: $matches,
+                    callLog: $state->callLog(),
+                    method: $signal->method,
+                    expectedArgs: $signal->args,
+                ),
+                double: $state->label(),
+                expectation: $probe->describe(),
+                expectedMinimum: $low,
+                expectedMaximum: $high,
+                actualCount: $matches,
+                observedCalls: $sameMethod,
+            ),
+        ]);
     }
 
     /**
@@ -620,12 +650,22 @@ final class Understudy
             return;
         }
 
-        throw VerificationFailed::withReport(sprintf(
-            "Understudy `%s` was expected to be unused, but received %d call(s):\n%s",
-            $state->label(),
-            count($log),
-            FailureReport::renderCallLog($log),
-        ));
+        throw VerificationFailed::of([
+            new VerificationFailure(
+                kind: FailureKind::UnusedDouble,
+                summary: sprintf(
+                    "Understudy `%s` was expected to be unused, but received %d call(s):\n%s",
+                    $state->label(),
+                    count($log),
+                    FailureReport::renderCallLog($log),
+                ),
+                double: $state->label(),
+                expectedMinimum: 0,
+                expectedMaximum: 0,
+                actualCount: count($log),
+                observedCalls: $log,
+            ),
+        ]);
     }
 
     /**
@@ -675,17 +715,23 @@ final class Understudy
             ));
 
             if ($unaccounted !== []) {
-                $failures[] = sprintf(
-                    "Understudy `%s` received %d call(s) nothing accounted for:\n%s",
-                    $state->label(),
-                    count($unaccounted),
-                    FailureReport::renderCallLog($unaccounted),
+                $failures[] = new VerificationFailure(
+                    kind: FailureKind::UnaccountedCalls,
+                    summary: sprintf(
+                        "Understudy `%s` received %d call(s) nothing accounted for:\n%s",
+                        $state->label(),
+                        count($unaccounted),
+                        FailureReport::renderCallLog($unaccounted),
+                    ),
+                    double: $state->label(),
+                    actualCount: count($unaccounted),
+                    observedCalls: $unaccounted,
                 );
             }
         }
 
         if ($failures !== []) {
-            throw VerificationFailed::withReport(implode("\n\n", $failures));
+            throw VerificationFailed::of($failures);
         }
     }
 
@@ -718,16 +764,22 @@ final class Understudy
         ));
 
         if ($unaccounted !== []) {
-            $failures[] = sprintf(
-                "Understudy `%s` received %d call(s) nothing accounted for:\n%s",
-                $state->label(),
-                count($unaccounted),
-                FailureReport::renderCallLog($unaccounted),
+            $failures[] = new VerificationFailure(
+                kind: FailureKind::UnaccountedCalls,
+                summary: sprintf(
+                    "Understudy `%s` received %d call(s) nothing accounted for:\n%s",
+                    $state->label(),
+                    count($unaccounted),
+                    FailureReport::renderCallLog($unaccounted),
+                ),
+                double: $state->label(),
+                actualCount: count($unaccounted),
+                observedCalls: $unaccounted,
             );
         }
 
         if ($failures !== []) {
-            throw VerificationFailed::withReport(implode("\n\n", $failures));
+            throw VerificationFailed::of($failures);
         }
     }
 
@@ -751,7 +803,7 @@ final class Understudy
         $mismatch = self::firstSequenceMismatch($probes, $log);
 
         if ($mismatch !== null) {
-            throw VerificationFailed::withReport($mismatch);
+            throw VerificationFailed::of([$mismatch]);
         }
 
         foreach ($log as $invocation) {
@@ -789,17 +841,26 @@ final class Understudy
     /**
      * @param list<array{object, Expectation}> $probes
      * @param list<Invocation>                 $log
-     *
-     * @return non-empty-string|null
      */
-    private static function firstSequenceMismatch(array $probes, array $log): ?string
+    private static function firstSequenceMismatch(array $probes, array $log): ?VerificationFailure
     {
+        $expected = array_map(
+            static fn(array $probe): string => $probe[1]->describe(),
+            $probes,
+        );
+
         if (count($log) !== count($probes)) {
-            return sprintf(
-                "Expected exactly %d call(s) in this order, but %d happened:\n%s",
-                count($probes),
-                count($log),
-                FailureReport::renderCallLog($log),
+            return new VerificationFailure(
+                kind: FailureKind::OutOfSequence,
+                summary: sprintf(
+                    "Expected exactly %d call(s) in this order, but %d happened:\n%s",
+                    count($probes),
+                    count($log),
+                    FailureReport::renderCallLog($log),
+                ),
+                actualCount: count($log),
+                observedCalls: $log,
+                expectedCalls: $expected,
             );
         }
 
@@ -807,21 +868,35 @@ final class Understudy
             $invocation = $log[$position];
 
             if (!$invocation->belongsTo($double)) {
-                return sprintf(
-                    "Call #%d was expected to be `%s` on one understudy, but the same call was made on a different understudy.\n\nThe calls made were:\n%s",
-                    $position + 1,
-                    $probe->describe(),
-                    FailureReport::renderCallLog($log),
+                return new VerificationFailure(
+                    kind: FailureKind::OutOfSequence,
+                    summary: sprintf(
+                        "Call #%d was expected to be `%s` on one understudy, but the same call was made on a different understudy.\n\nThe calls made were:\n%s",
+                        $position + 1,
+                        $probe->describe(),
+                        FailureReport::renderCallLog($log),
+                    ),
+                    expectation: $probe->describe(),
+                    actualCount: count($log),
+                    observedCalls: $log,
+                    expectedCalls: $expected,
                 );
             }
 
             if (!$probe->matches($invocation->method, $invocation->args)) {
-                return sprintf(
-                    "Call #%d was expected to be `%s`, but it was `%s`.\n\nThe calls made were:\n%s",
-                    $position + 1,
-                    $probe->describe(),
-                    FailureReport::renderCall($invocation),
-                    FailureReport::renderCallLog($log),
+                return new VerificationFailure(
+                    kind: FailureKind::OutOfSequence,
+                    summary: sprintf(
+                        "Call #%d was expected to be `%s`, but it was `%s`.\n\nThe calls made were:\n%s",
+                        $position + 1,
+                        $probe->describe(),
+                        FailureReport::renderCall($invocation),
+                        FailureReport::renderCallLog($log),
+                    ),
+                    expectation: $probe->describe(),
+                    actualCount: count($log),
+                    observedCalls: $log,
+                    expectedCalls: $expected,
                 );
             }
         }

--- a/src/VerificationFailure.php
+++ b/src/VerificationFailure.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy;
+
+/**
+ * The structured half of one verification failure — the same facts the
+ * rendered message states, addressable by field.
+ *
+ * For tooling that wants to do something with a failure other than print it:
+ * a runner adapter, an IDE plugin, a report aggregator. The rendered message
+ * stays the human surface; this class is the machine one.
+ *
+ * Which fields are set depends on the kind:
+ *
+ * | Kind | `double` | `expectation` | `expectedMinimum`/`expectedMaximum` | `actualCount` | `observedCalls` | `expectedCalls` |
+ * |---|---|---|---|---|---|---|
+ * | `UnmetExpectation` | label | call spec | the claimed bounds | matched calls | calls to the same method | — |
+ * | `StrictStubUnused` | label | call spec | — | `0` | — | — |
+ * | `OutOfOrder` | label | the call that came first | — | — | — | — |
+ * | `OutOfSequence` | — | the mismatched position | — | calls made | the whole protocol | the specified sequence |
+ * | `UnaccountedCalls` | label | — | — | unaccounted calls | the unaccounted calls | — |
+ * | `UnusedDouble` | label | — | `0`/`0` | calls received | every call | — |
+ *
+ * The readonly fields of this class, of {@see FailureKind}, and of the
+ * exceptions carrying them are frozen public API from v0.1.0: renaming,
+ * removing or retyping any of them is a major-version change. New kinds and
+ * newly-populated fields are additive and may arrive in a minor.
+ *
+ * @api
+ */
+final readonly class VerificationFailure
+{
+    /**
+     * @param string|null             $double           the label of the double the claim is about
+     * @param string|null             $expectation      the call specification, as failure messages render it
+     * @param int<0, max>|null        $expectedMinimum
+     * @param int<0, max>|null        $expectedMaximum
+     * @param int<0, max>|null        $actualCount
+     * @param list<Invocation>|null   $observedCalls    the calls the rendered report shows
+     * @param list<string>|null       $expectedCalls    the specified sequence, for `OutOfSequence`
+     * @param non-empty-string        $summary          this failure's rendered text; the exception's
+     *                                                  message is these joined with a blank line
+     */
+    public function __construct(
+        public FailureKind $kind,
+        public string $summary,
+        public ?string $double = null,
+        public ?string $expectation = null,
+        public ?int $expectedMinimum = null,
+        public ?int $expectedMaximum = null,
+        public ?int $actualCount = null,
+        public ?array $observedCalls = null,
+        public ?array $expectedCalls = null,
+    ) {}
+}

--- a/tests/LastCallAndForgetTest.php
+++ b/tests/LastCallAndForgetTest.php
@@ -15,6 +15,7 @@ use Rasuvaeff\Understudy\Tests\Fixture\Book;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
 use Rasuvaeff\Understudy\Understudy;
 use Testo\Assert;
+use Testo\Assert\ExpectNoAssertions;
 use Testo\Codecov\Covers;
 use Testo\Expect;
 use Testo\Lifecycle\AfterTest;
@@ -84,6 +85,7 @@ final class LastCallAndForgetTest
         Assert::null(Understudy::lastCall(fn() => $repository->find(8)));
     }
 
+    #[ExpectNoAssertions]
     public function aForgottenDoubleIsInvisibleToStrictStubs(): void
     {
         $replaced = Understudy::for(BookRepository::class);

--- a/tests/LedgerTest.php
+++ b/tests/LedgerTest.php
@@ -18,6 +18,7 @@ use Rasuvaeff\Understudy\Runtime\RuntimeContext;
 use Rasuvaeff\Understudy\Tests\Fixture\Book;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
 use Rasuvaeff\Understudy\Tests\Fixture\Clock;
+use Rasuvaeff\Understudy\Tests\Support\GoldenMessage;
 use Rasuvaeff\Understudy\Understudy;
 use Testo\Assert;
 use Testo\Assert\ExpectNoAssertions;
@@ -647,8 +648,7 @@ final class LedgerTest
         // Reported in the order the claims were written, which is not the
         // order the ledger keeps them in.
         Expect::exception(VerificationFailed::class)->withMessage(
-            "Understudy `BookRepository` expected `count()` to be called exactly 1 time, but it was called never.\n\n"
-            . 'Understudy `BookRepository` expected `titles()` to be called exactly 1 time, but it was called never.',
+            GoldenMessage::read('verify-all-two-unmet-expectations-in-declaration-order'),
         );
 
         Understudy::verifyAll();

--- a/tests/Support/GoldenMessage.php
+++ b/tests/Support/GoldenMessage.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+/**
+ * Reads a golden file for a multi-line failure message, from
+ * `tests/fixtures/messages/<name>.txt`.
+ *
+ * A rendered report — a header, a call log, an argument marked with `*` — is
+ * a document, not a string literal: a wording review reads the `.txt` diff,
+ * not PHP concatenation. Single-line messages stay inline; a message grows a
+ * golden file when it starts rendering calls.
+ *
+ * A single trailing newline is trimmed on read, so the file can carry the
+ * final newline editors add.
+ */
+final class GoldenMessage
+{
+    public static function read(string $name): string
+    {
+        $path = __DIR__ . '/../fixtures/messages/' . $name . '.txt';
+
+        if (!is_file($path)) {
+            throw new \RuntimeException('Missing golden message file: ' . $path);
+        }
+
+        /** @var string $content */
+        $content = file_get_contents($path);
+
+        return rtrim($content, "\n");
+    }
+}

--- a/tests/UnderstudyTest.php
+++ b/tests/UnderstudyTest.php
@@ -45,6 +45,7 @@ use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticReturn;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\WideReturn;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\WriterInt;
 use Rasuvaeff\Understudy\Tests\Fixture\VariadicSink;
+use Rasuvaeff\Understudy\Tests\Support\GoldenMessage;
 use Rasuvaeff\Understudy\Understudy;
 use Testo\Assert;
 use Testo\Assert\ExpectNoAssertions;
@@ -778,10 +779,7 @@ final class UnderstudyTest
         $repository->tag('beta');
 
         Expect::exception(VerificationFailed::class)->withMessage(
-            "Understudy `BookRepository` expected `tag('gamma', 1)` to be called at least 1 time, but it was never called.\n\n"
-            . "The following calls to `tag` were made during this test:\n"
-            . "    tag(*'alpha'*, 1)\n"
-            . "    tag(*'beta'*, 1)",
+            GoldenMessage::read('verify-lists-same-method-calls-with-marked-argument'),
         );
 
         verify(fn() => $repository->tag('gamma'));

--- a/tests/VerificationFailureTest.php
+++ b/tests/VerificationFailureTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests;
+
+use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\FailureKind;
+use Rasuvaeff\Understudy\Tests\Fixture\Book;
+use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
+use Rasuvaeff\Understudy\Understudy;
+use Rasuvaeff\Understudy\VerificationFailure;
+use Testo\Assert;
+use Testo\Codecov\Covers;
+use Testo\Lifecycle\AfterTest;
+use Testo\Test;
+
+use function Rasuvaeff\Understudy\expect;
+use function Rasuvaeff\Understudy\verify;
+use function Rasuvaeff\Understudy\when;
+
+/**
+ * `failures()`: the structured half of a VerificationFailed report. Every
+ * kind states its facts in addressable fields, and the rendered message is
+ * exactly the summaries joined with a blank line — there is no path where
+ * the two disagree.
+ */
+#[Test]
+#[Covers(VerificationFailed::class)]
+#[Covers(VerificationFailure::class)]
+#[Covers(FailureKind::class)]
+final class VerificationFailureTest
+{
+    #[AfterTest]
+    public function tearDown(): void
+    {
+        Understudy::reset();
+    }
+
+    public function verifyReportsAnUnmetExpectationWithBoundsAndCalls(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        when(fn() => $repository->find(1))->returns(new Book('title'));
+        $repository->find(1);
+        $repository->find(1);
+
+        $failure = self::catch(fn() => verify(fn() => $repository->find(1), times: 1));
+
+        Assert::same(count($failure->failures()), 1);
+
+        $record = $failure->failures()[0];
+
+        Assert::same($record->kind, FailureKind::UnmetExpectation);
+        Assert::same($record->double, 'BookRepository');
+        Assert::same($record->expectation, 'find(1)');
+        Assert::same($record->expectedMinimum, 1);
+        Assert::same($record->expectedMaximum, 1);
+        Assert::same($record->actualCount, 2);
+        Assert::same(count($record->observedCalls ?? []), 2);
+        Assert::null($record->expectedCalls);
+    }
+
+    public function verifyAllReportsAnUnmetExpectationClaim(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->count())->times(2);
+
+        $repository->count();
+
+        $record = self::firstFailureOf(fn() => Understudy::verifyAll());
+
+        Assert::same($record->kind, FailureKind::UnmetExpectation);
+        Assert::same($record->expectation, 'count()');
+        Assert::same($record->expectedMinimum, 2);
+        Assert::same($record->expectedMaximum, 2);
+        Assert::same($record->actualCount, 1);
+    }
+
+    public function strictStubsReportsAnUnusedStub(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        when(fn() => $repository->find(7))->returns(new Book('title'));
+
+        $record = self::firstFailureOf(fn() => Understudy::verifyAll(strictStubs: true));
+
+        Assert::same($record->kind, FailureKind::StrictStubUnused);
+        Assert::same($record->expectation, 'find(7)');
+        Assert::same($record->actualCount, 0);
+    }
+
+    public function orderingViolationsReportTheCallThatCameFirst(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->count())->ordered();
+        expect(fn() => $repository->titles())->ordered();
+
+        $repository->titles();
+        $repository->count();
+
+        $record = self::firstFailureOf(fn() => Understudy::verifyAll());
+
+        Assert::same($record->kind, FailureKind::OutOfOrder);
+        Assert::same($record->double, 'BookRepository');
+        Assert::same($record->expectation, 'titles()');
+    }
+
+    public function nothingElseReportsUnaccountedCalls(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $book = new Book('title');
+        when(fn() => $repository->save(Arg::any()))->returns(true);
+        $repository->save($book);
+
+        $record = self::firstFailureOf(fn() => Understudy::nothingElse($repository));
+
+        Assert::same($record->kind, FailureKind::UnaccountedCalls);
+        Assert::same($record->actualCount, 1);
+        Assert::same($record->observedCalls[0]->args, [$book]);
+    }
+
+    public function unusedReportsEveryCallWithZeroBounds(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $repository->count();
+
+        $record = self::firstFailureOf(fn() => Understudy::unused($repository));
+
+        Assert::same($record->kind, FailureKind::UnusedDouble);
+        Assert::same($record->expectedMinimum, 0);
+        Assert::same($record->expectedMaximum, 0);
+        Assert::same($record->actualCount, 1);
+    }
+
+    public function verifySequenceReportsExpectedAndObservedProtocol(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $book = new Book('title');
+
+        $repository->save($book);
+        $repository->count();
+
+        $record = self::firstFailureOf(
+            fn() => Understudy::verifySequence(
+                fn() => $repository->count(),
+                fn() => $repository->save($book),
+            ),
+        );
+
+        Assert::same($record->kind, FailureKind::OutOfSequence);
+        Assert::same($record->expectedCalls, ['count()', 'save(' . Book::class . ')']);
+        Assert::same($record->actualCount, 2);
+        Assert::same(count($record->observedCalls ?? []), 2);
+        Assert::null($record->double);
+    }
+
+    public function allVerifiedReportsBothHalvesInMessageOrder(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $book = new Book('title');
+
+        expect(fn() => $repository->count())->times(2);
+        $repository->save($book);
+
+        $failure = self::catch(fn() => Understudy::allVerified($repository));
+
+        Assert::same(count($failure->failures()), 2);
+        Assert::same($failure->failures()[0]->kind, FailureKind::UnmetExpectation);
+        Assert::same($failure->failures()[1]->kind, FailureKind::UnaccountedCalls);
+    }
+
+    public function theMessageIsTheSummariesJoinedWithABlankLine(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $book = new Book('title');
+
+        expect(fn() => $repository->count())->times(2);
+        $repository->save($book);
+
+        $failure = self::catch(fn() => Understudy::allVerified($repository));
+
+        Assert::same(
+            $failure->getMessage(),
+            implode("\n\n", array_map(
+                static fn($record): string => $record->summary,
+                $failure->failures(),
+            )),
+        );
+    }
+
+    private static function catch(callable $body): VerificationFailed
+    {
+        try {
+            $body();
+        } catch (VerificationFailed $failure) {
+            return $failure;
+        }
+
+        throw new \LogicException('the verification was expected to fail');
+    }
+
+    private static function firstFailureOf(callable $body): VerificationFailure
+    {
+        return self::catch($body)->failures()[0];
+    }
+}

--- a/tests/fixtures/messages/verify-all-two-unmet-expectations-in-declaration-order.txt
+++ b/tests/fixtures/messages/verify-all-two-unmet-expectations-in-declaration-order.txt
@@ -1,0 +1,3 @@
+Understudy `BookRepository` expected `count()` to be called exactly 1 time, but it was called never.
+
+Understudy `BookRepository` expected `titles()` to be called exactly 1 time, but it was called never.

--- a/tests/fixtures/messages/verify-lists-same-method-calls-with-marked-argument.txt
+++ b/tests/fixtures/messages/verify-lists-same-method-calls-with-marked-argument.txt
@@ -1,0 +1,5 @@
+Understudy `BookRepository` expected `tag('gamma', 1)` to be called at least 1 time, but it was never called.
+
+The following calls to `tag` were made during this test:
+    tag(*'alpha'*, 1)
+    tag(*'beta'*, 1)


### PR DESCRIPTION
## What

The pre-v0.1.0 batch taken from reviewing [jasonmccreary/double](https://github.com/jasonmccreary/double) — the parts that are process and contract, not API philosophy.

### Structured failures (the semver-relevant one)

`VerificationFailed::failures()` answers a `list<VerificationFailure>` — one record per failed claim:

- `kind` — `FailureKind`: `UnmetExpectation` · `StrictStubUnused` · `OutOfOrder` · `OutOfSequence` · `UnaccountedCalls` · `UnusedDouble`
- `double`, `expectation`, `expectedMinimum`/`expectedMaximum`, `actualCount`, `observedCalls` (`list<Invocation>`), `expectedCalls` (sequence), `summary`

The message is exactly the summaries joined with a blank line — both surfaces are built from one list, there is no path where they disagree. For tooling acting on a failure rather than printing it (adapters, IDE plugins, aggregators).

**Frozen from v0.1.0**: the readonly fields of `VerificationFailure`/`FailureKind`. Renaming/removing/retyping one is a major change; new kinds and newly-populated fields are additive. Declared in README ×2, llms.txt, and on the class docblock. Every throw site now builds records; a field-per-kind table lives in the docblock.

### Golden files for rendered reports

Multi-line failure messages moved to `tests/fixtures/messages/*.txt` read through `Support\GoldenMessage::read()` — a wording review reads a `.txt` diff instead of PHP concatenation. Convention recorded in AGENTS.md: single-line stays inline; a message grows a golden file when it starts rendering calls.

### Mockery migration table

README ×2 (synced): rosetta table, no aliases and no converter by policy. The two ⚠ rows carry the dogfooding lessons — a spy counter counted every call while `expect()` counts only its own arguments (migrated counters need `nothingElse()`), and incidental setup becomes `when()`, not `expect()`.

### AGENTS.md

Module boundaries stated as policy (a matcher depends on nothing but leaf formatting; only `Runtime` and the facade see everything) + the four-file walkthrough for adding an `Arg::*` matcher.

## Verification

```
PASS: composer build (1211 lines)
744 tests · 10935 assertions — 744 passed
```
New: `VerificationFailureTest` (9 scenarios — every kind's fields, message parity). Fixed a latent Risky on `aForgottenDoubleIsInvisibleToStrictStubs` with `#[ExpectNoAssertions]`.