### PR TITLE
Golden messages: normalize CRLF so the comparison holds on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@
 /perf export-ignore
 /build export-ignore
 /Makefile export-ignore
+tests/fixtures/messages/*.txt text eol=lf

--- a/tests/Support/GoldenMessage.php
+++ b/tests/Support/GoldenMessage.php
@@ -13,8 +13,9 @@ namespace Rasuvaeff\Understudy\Tests\Support;
  * not PHP concatenation. Single-line messages stay inline; a message grows a
  * golden file when it starts rendering calls.
  *
- * A single trailing newline is trimmed on read, so the file can carry the
- * final newline editors add.
+ * Line endings are normalized to LF and a single trailing newline is
+ * trimmed on read: git may check the file out with CRLF on Windows, and the
+ * comparison must hold on every platform.
  */
 final class GoldenMessage
 {
@@ -29,6 +30,6 @@ final class GoldenMessage
         /** @var string $content */
         $content = file_get_contents($path);
 
-        return rtrim($content, "\n");
+        return rtrim(str_replace("\r\n", "\n", $content), "\n");
     }
 }


### PR DESCRIPTION
## What

The Windows job failed on exactly the two golden-file tests: git checked the
`.txt` fixtures out with CRLF, `rtrim($content, "\n")` trimmed the LF but
left the trailing `\r`, and the byte comparison diverged.

Fix, both layers:

- `GoldenMessage::read()` normalizes `\r\n` → `\n` before comparing — the
  assertion holds regardless of how git checked the file out;
- `.gitattributes` pins `tests/fixtures/messages/*.txt` to `text eol=lf`, so
  the working tree is stable in the first place.

## Verification

Local suite PASS. Merging only after the Windows job is green.