### PR TITLE
README: the family table

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,15 @@ It is a development dependency. Do not install it in production.
 
 Runnable scripts live in [examples/](examples/).
 
+## The understudy family
+
+| Package | What it is |
+|---|---|
+| **rasuvaeff/understudy** *(this package)* | The engine: doubles, matchers, expectations, verification. |
+| [rasuvaeff/understudy-testo](https://github.com/rasuvaeff/understudy-testo) | Testo adapter — verification and reset around every test. |
+| [rasuvaeff/understudy-phpunit](https://github.com/rasuvaeff/understudy-phpunit) | PHPUnit and Pest adapter — the same, through a trait. |
+| [rasuvaeff/understudy-psalm](https://github.com/rasuvaeff/understudy-psalm) | Psalm plugin — matcher-aware specifications and misuse diagnostics. |
+
 ## Development
 
 ```bash

--- a/README.ru.md
+++ b/README.ru.md
@@ -583,6 +583,15 @@ Understudy генерирует по классу на набор контрак
 
 Исполняемые скрипты — в [examples/](examples/).
 
+## Семейство understudy
+
+| Пакет | Что это |
+|---|---|
+| **rasuvaeff/understudy** *(этот пакет)* | Движок: дубли, матчеры, ожидания, верификация. |
+| [rasuvaeff/understudy-testo](https://github.com/rasuvaeff/understudy-testo) | Testo-адаптер — верификация и сброс вокруг каждого теста. |
+| [rasuvaeff/understudy-phpunit](https://github.com/rasuvaeff/understudy-phpunit) | Адаптер для PHPUnit и Pest — то же самое, через трейт. |
+| [rasuvaeff/understudy-psalm](https://github.com/rasuvaeff/understudy-psalm) | Psalm-плагин — спецификации с матчерами и диагностики ошибок. |
+
 ## Разработка
 
 ```bash


### PR DESCRIPTION
Adds a family table to `README.md` and `README.ru.md`: the engine, both runner adapters and the Psalm plugin, each linked, with this package marked.

A reader who lands on one repository currently has no way to discover the rest.

Documentation only.