### PR TITLE
README: the family table gains the PHPStan extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Runnable scripts live in [examples/](examples/).
 | [rasuvaeff/understudy-testo](https://github.com/rasuvaeff/understudy-testo) | Testo adapter — verification and reset around every test. |
 | [rasuvaeff/understudy-phpunit](https://github.com/rasuvaeff/understudy-phpunit) | PHPUnit and Pest adapter — the same, through a trait. |
 | [rasuvaeff/understudy-psalm](https://github.com/rasuvaeff/understudy-psalm) | Psalm plugin — matcher-aware specifications and misuse diagnostics. |
+| [rasuvaeff/understudy-phpstan](https://github.com/rasuvaeff/understudy-phpstan) | PHPStan extension — the same for PHPStan, plus its own rules. |
 
 ## Development
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -591,6 +591,7 @@ Understudy генерирует по классу на набор контрак
 | [rasuvaeff/understudy-testo](https://github.com/rasuvaeff/understudy-testo) | Testo-адаптер — верификация и сброс вокруг каждого теста. |
 | [rasuvaeff/understudy-phpunit](https://github.com/rasuvaeff/understudy-phpunit) | Адаптер для PHPUnit и Pest — то же самое, через трейт. |
 | [rasuvaeff/understudy-psalm](https://github.com/rasuvaeff/understudy-psalm) | Psalm-плагин — спецификации с матчерами и диагностики ошибок. |
+| [rasuvaeff/understudy-phpstan](https://github.com/rasuvaeff/understudy-phpstan) | PHPStan-расширение — то же самое для PHPStan, плюс свои правила. |
 
 ## Разработка
 


### PR DESCRIPTION
`rasuvaeff/understudy-phpstan` v0.1.0 is on Packagist, so the family table can carry it — the row was deliberately left out while the repository did not exist.

Both languages. Documentation only.