### PR TITLE
Keep the feasibility spikes out of the distributed archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@
 /tests export-ignore
 /benchmarks export-ignore
 /perf export-ignore
+/spikes export-ignore
 /build export-ignore
 /Makefile export-ignore
 tests/fixtures/messages/*.txt text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **The distributed archive no longer carries the feasibility spikes.**
+  `.gitattributes` listed every other development directory as
+  `export-ignore` but not `spikes/`, so 24 scratch scripts from milestone 0
+  travelled into every install. They stay in the repository, where CI runs
+  them; they are simply no longer part of what `composer require` downloads.
+
 - **A target declaring an abstract property hook is refused, not fatal.** An
   interface property (`public string $name { get; }`, PHP 8.4+) or an
   `abstract` one on a class is an abstract member the generated class would


### PR DESCRIPTION
`.gitattributes` marks every development directory `export-ignore` —
`tests`, `benchmarks`, `perf`, `examples`, `build`, the workflows, the tool
configs — but never `spikes/`. So the milestone-0 feasibility scripts are part
of what Packagist serves.

Verified against the published tag, not this branch:

```
$ git archive v0.1.0 | tar -t | grep -c '^spikes/'
35
```

That is 24 files (~116K) plus their directory entries, in every install of
0.1.0. Nothing else is affected: `spikes/` exists only in the core package,
and the four satellites list the same 16 `export-ignore` entries with nothing
of their own to add.

After this change the archive is source, `resources/` (the skill the package
distributes) and the top-level documents:

```
$ git archive HEAD | tar -t | awk -F/ '{print $1}' | sort -u
CHANGELOG.md composer.json LICENSE.md llms.txt README.md README.ru.md resources src
```

The spikes stay in the repository and keep running in CI — the
`Spikes (PHP 8.3/8.4/8.5)` and `Spike 07` jobs are unaffected, because
`export-ignore` governs the dist archive and nothing else.

## Note on 0.1.0

A published tag cannot be moved, so 0.1.0's archive stays as it is. The first
clean distribution is the next tag.

## Related

Item A2 of the hardening plan. The blind spot it sits in is item A1:
`bin/understudy-consumer-smoke` installs the family from path repositories,
and its own header says what that cannot see — *"A path repository copies the
source tree, `tests/` included; only a dist archive from a tag would show
that."* Adding an archive-based leg to that script, and putting the script in
CI, is the fix for the class of defect rather than this instance.