### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.1 — 2026-08-25
 
 - **The distributed archive no longer carries the feasibility spikes.**
   `.gitattributes` listed every other development directory as


### PR DESCRIPTION
Two fixes, both to what 0.1.0 already shipped. No API change, so this is a
patch.

- **#34** — a target declaring an abstract property hook (an interface
  property, or an `abstract` one on a class, PHP 8.4+) produced an uncatchable
  fatal error out of `eval()` instead of a refusal. It is now an
  `UnsupportedTarget` naming the property and its hooks, alongside the other
  targets this generator declines before generating a line.
- **#38** — `.gitattributes` never marked `spikes/` as `export-ignore`, so 24
  milestone-0 feasibility scripts travelled into every install of 0.1.0. The
  archive is now source, `resources/` and the top-level documents. 0.1.0's
  published archive cannot be changed, so this tag is the first clean one.

`composer build` is green locally, and both changes landed through their own
green PRs.