### PR TITLE
CI: wait for the matrix build before publishing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,40 @@ jobs:
             exit 1
           fi
 
-          conclusion=$(gh api "repos/$REPO/commits/$SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name | startswith("PHP "))] | if length == 0 then "missing" else (map(.conclusion) | unique | join(",")) end')
+          # The tag is pushed seconds after the merge, while master's own build
+          # is still queued or running. A `conclusion` of null means "not
+          # settled yet" and an empty list means "not dispatched yet" — neither
+          # is a verdict, and judging them as one failed every release tagged
+          # promptly (`matrix conclusion: ` — an empty string, because
+          # `join(",")` over nulls yields nothing). Both are waited on instead.
+          deadline=$(( SECONDS + 900 ))
 
-          if [ "$conclusion" != "success" ]; then
-            echo "::error::$SHA has no successful build (matrix conclusion: $conclusion)." \
+          while :; do
+            states=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.name | startswith("PHP ")) | .conclusion // "pending"]')
+
+            found=$(printf '%s' "$states" | jq 'length')
+            pending=$(printf '%s' "$states" | jq '[.[] | select(. == "pending")] | length')
+
+            if [ "$found" -gt 0 ] && [ "$pending" -eq 0 ]; then
+              break
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::$SHA has no settled matrix build after 15 minutes" \
+                "($found found, $pending still running). Re-run this workflow once the build" \
+                "on master has finished; the tag does not need to move."
+              exit 1
+            fi
+
+            echo "Waiting for the matrix build on $SHA ($found found, $pending still running)…"
+            sleep 20
+          done
+
+          verdicts=$(printf '%s' "$states" | jq -r '[.[] | select(. != "success")] | unique | join(",")')
+
+          if [ -n "$verdicts" ]; then
+            echo "::error::$SHA has no successful build (matrix conclusions: $verdicts)." \
               "A release must not be published for a commit whose CI did not pass."
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- **The release workflow waits for the matrix build instead of judging it
+  mid-flight.** A tag pushed right after the merge arrived while master's own
+  build was still running, and the guard read a `null` conclusion as a failed
+  one — so `v0.1.1` published to Packagist but its GitHub Release had to be
+  created by re-running the workflow. No effect on the package itself.
+
 ## 0.1.1 — 2026-08-25
 
 - **The distributed archive no longer carries the feasibility spikes.**


### PR DESCRIPTION
Hit for real while tagging `v0.1.1`.

The guard reads the check-runs of the tagged commit and requires every `PHP *`
run to be `success`. The tag is pushed seconds after the merge, so master's own
build is still queued or running — every `conclusion` is `null`, and

```
[.check_runs[] | select(.name | startswith("PHP "))] | map(.conclusion) | unique | join(",")
```

over nulls yields an **empty string**, which is not `"success"`. The step failed
with a message that named nothing:

```
::error::067bbbb… has no successful build (matrix conclusion: ).
```

The history was entirely valid; the build went green a minute later. Packagist
was unaffected — it publishes on its own webhook, so `v0.1.1` was already
installable — but the GitHub Release had to be created by re-running the
workflow by hand.

## What changes

`null` means "not settled yet" and an empty list means "not dispatched yet".
Neither is a verdict, so both are waited on: poll every 20s, deadline 15
minutes, then judge.

| API answers | Now |
|---|---|
| no `PHP *` runs | wait |
| any `PHP *` with `conclusion: null` | wait |
| all settled, all `success` | publish |
| all settled, anything else | refuse, naming the conclusions |
| deadline reached | refuse, and say the tag does not need to move |

A `skipped` or `cancelled` run is still a refusal — a skipped matrix job is not
a green build.

`per_page=100` comes along with it: the default page size is 30, and a commit
with more check-runs than that could hide the matrix on page two.

## Verification

The step is not reachable without pushing a tag, so the loop was exercised
locally against a stubbed `gh`, one run per branch:

| Scenario | Result |
|---|---|
| pending, then success | waits, then passes |
| never dispatched | times out, exit 1 |
| one `failure` | `matrix conclusions: failure`, exit 1 |
| `cancelled` + `skipped` | `matrix conclusions: cancelled,skipped`, exit 1 |

The first is exactly what broke the `v0.1.1` release.

## Provenance

Fixed in `templates/.github/workflows/release.yml` first; this brings the
package's copy in line. `release.yml` is not in `replicate/manifest.bash`, so
the other packages take it when a PR touches them anyway.