### PR TITLE
Record what the mutation gate does not cover, and the perf ritual

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,3 +332,12 @@ make release-check
   `examples/` if usage changed); update `CHANGELOG.md` when releasing.
 - Re-run `composer build`; if the change affects public API or release safety,
   also run `make release-check`. Paste the output.
+- **Before a release tag, re-measure `perf/` on the commit the current numbers
+  were taken from, then on the candidate.** `perf/README.md` states figures —
+  cost per call, cost per double, memory per double — and nothing in CI
+  defends them: a regression is found only by somebody deciding to measure.
+  Comparing against a number in the file is not enough either, because the
+  environment moves; that is why `PERF` in the `Makefile` pins it, and why the
+  old commit is measured again rather than trusted. This is how the 350 -> 435
+  bytes per double was attributed to PR #9-#14 and #16 rather than to the
+  machine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Recorded why eleven `FileWrapper` methods are excluded from mutation, next to
+  the exclusion itself. The text is the one written when the list was
+  introduced and dropped later with the gate's rationale block; a silent
+  exclusion cannot be told apart from one made to get the gate green.
+- `AGENTS.md` now carries the perf ritual: re-measure `perf/` on the commit the
+  current figures came from before comparing a release candidate, because
+  nothing in CI defends those numbers.
+
 - **The release workflow waits for the matrix build instead of judging it
   mid-flight.** A tag pushed right after the merge arrived while master's own
   build was still running, and the guard read a `null` conclusion as a failed

--- a/infection.json5
+++ b/infection.json5
@@ -11,6 +11,18 @@
     "minMsi": 90,
     "mutators": {
         "@default": true,
+        // Raw-I/O passthroughs. Each of these forwards one call to the native
+        // filesystem and returns what it answered; a mutant either changes
+        // nothing observable or needs a real side effect on disk to see. The
+        // wrapper's decisions — what counts as PHP source, how the allow-list
+        // widens, which stat a flag asks for — are not here and stay under
+        // mutation.
+        //
+        // Written when the list was introduced (PR #13), dropped with the
+        // gate's own rationale block in PR #23, restored here: a silent
+        // exclusion cannot be told apart from one made to get the gate green.
+        // A method that stops being a passthrough leaves this list with the
+        // change that makes it decide something.
         "UnwrapArrayValues": false,
         "global-ignore": [
             "Rasuvaeff\\Understudy\\Bypass\\FileWrapper::stream_write",


### PR DESCRIPTION
Two pieces of knowledge the package holds but does not write down. No behaviour
changes; nothing in `src/` is touched.

## Why eleven `FileWrapper` methods are excluded from mutation

`infection.json5` carries a `global-ignore` list of eleven methods with no word
about why. The rationale was not missing — it was written when the list was
introduced in #13 and dropped in #23 along with the gate's own rationale block:

> Raw-I/O passthroughs. Each of these forwards one call to the native
> filesystem and returns what it answered; a mutant either changes nothing
> observable or needs a real side effect on disk to see. The wrapper's
> decisions — what counts as PHP source, how the allow-list widens, which stat
> a flag asks for — are not here and stay under mutation.

Restored next to the list, with a note on the boundary: a method that stops
being a passthrough leaves the list in the change that makes it decide
something. A silent exclusion cannot be told apart from one made to get the
gate green, and these eleven are the former.

The gate number itself keeps no rationale — that was a deliberate call in #23
and is left alone here. The rule applies to movements from now on.

Verified with the decoder Infection actually uses: `Json5Decoder::decode()`
reads the file, `minMsi=90`, `global-ignore` still holds 11 entries.

## The perf ritual

`perf/README.md` states cost per call, cost per double and memory per double.
Nothing in CI defends those figures — a regression is found only when somebody
decides to measure. Comparing a candidate against the number in the file is not
enough either, because the environment moves underneath it; that is why `PERF`
in the `Makefile` pins the environment, and why the old commit gets re-measured
rather than trusted. That is how the 350 -> 435 bytes per double was attributed
to #9-#14 and #16 rather than to the machine.

`AGENTS.md` now says so in "When you finish", where a release-bound change will
meet it.

## Related

Items A5 and A7 of the hardening plan.