### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.2 — 2026-08-26
 
 - Recorded why eleven `FileWrapper` methods are excluded from mutation, next to
   the exclusion itself. The text is the one written when the list was


### PR DESCRIPTION
Four changes, all additive or internal. No API was removed or retyped.

- **`Arg::allOf()` / `Arg::anyOf()`** (#42) — the matcher algebra had negation
  and nothing to negate against; two conditions on one argument now compose,
  and describe themselves in a failure message instead of collapsing to
  `satisfies(…)`. An empty combinator, and one holding a tail matcher, are
  refused with the reason.
- **The release workflow waits for the matrix build** (#40) — a tag pushed
  right after the merge read a `null` conclusion as a failure, which is how
  `v0.1.1`'s GitHub Release had to be created by hand.
- **Why eleven `FileWrapper` methods are excluded from mutation** (#41),
  recorded next to the exclusion. The text is the one written when the list was
  introduced and dropped later; a silent exclusion cannot be told apart from
  one made to get the gate green.
- **The perf ritual in `AGENTS.md`** (#41) — nothing in CI defends the figures
  in `perf/README.md`, so a release-bound change now meets the instruction to
  re-measure the old commit rather than trust the number.

`composer build` is green locally; every change landed through its own green
PR, and #42 carried a full run including mutation and BC.

This is the first tag whose Release is created by the fixed guard.