### PR TITLE
tests: the Integration suite exists, and build runs it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,13 @@ jobs:
       - name: Test
         run: composer test
 
+      # The reason this job exists at all now lives in the Integration suite:
+      # `Bypass\FileWrapper` stands in front of `file://`, and paths,
+      # separators and symlink privileges are where the two platforms disagree.
+      # Running only `composer test` here would leave that unclaimed on Windows.
+      - name: Integration tests
+        run: composer test:integration
+
   bypass:
     name: Bypass acceptance
     needs: changes
@@ -237,7 +244,7 @@ jobs:
             || { echo "OPcache is off for the CLI: same problem"; exit 1; }
 
       - name: Bypass scenarios under a coverage driver and a warm opcode cache
-        run: composer test
+        run: composer test:integration
 
       # Composer resolves a class to a path out of a static map and includes it
       # without stat'ing first, which is a different route to the same read.
@@ -254,7 +261,7 @@ jobs:
             }
             fwrite(STDERR, "the autoloader is not authoritative: this step would prove nothing\n");
             exit(1);'
-          composer test
+          composer test:integration
 
   consumer-smoke:
     name: Consumer smoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ make build
 make cs-fix
 make psalm
 make test
+make test-integration
 make test-coverage
 make mutation
 make release-check
@@ -79,6 +80,15 @@ make release-check
   not throw on a hostile argument: matching runs inside the code under test,
   and a matcher that breaks is a test broken by its own tooling
   (`Arg::which()` catching a throwing getter is the precedent).
+- **`tests/Integration` is a suite of its own, and `composer build` runs it.**
+  What lives there spawns a process per claim (`BypassFinalsIntegrationTest`)
+  or runs a body inside a Fiber (`FiberIntegrationTest`) — neither is a unit of
+  code, and both cost more than the other 740 tests together. The Unit suite
+  excludes the directory by path, so a file added there is integration by
+  placement and nothing has to be registered twice. A suite outside `build` is
+  a suite that rots: the Windows and bypass-acceptance jobs run
+  `composer test:integration` explicitly, because the platform and driver
+  claims they exist for now live in that suite.
 - **Golden files for rendered reports.** A failure message that renders calls
   — a call log, an argument marked with `*` — belongs in
   `tests/fixtures/messages/<name>.txt`, read through

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ psalm:
 test:
 	$(DOCKER) composer test
 
+test-integration:
+	$(DOCKER) composer test:integration
+
 test-coverage:
 	$(DOCKER) sh -lc '$(PCOV_BOOTSTRAP) && composer test:coverage'
 
@@ -108,11 +111,12 @@ help:
 	@echo "  perf             benchmark against Mockery/Prophecy/PHPUnit"
 	@echo "  perf-cold        cold-start comparison (one process per double)"
 	@echo "  perf-memory      bytes retained per live double"
-	@echo "  build            full gate (validate + normalize + cs + psalm + test)"
+	@echo "  build            full gate (validate + normalize + cs + psalm + test + integration)"
 	@echo "  cs               check code style (dry-run)"
 	@echo "  cs-fix           fix code style"
 	@echo "  psalm            static analysis"
 	@echo "  test             run testo (Unit suite)"
+	@echo "  test-integration run testo (Integration suite)"
 	@echo "  test-coverage    run testo with coverage"
 	@echo "  test-coverage-ci run testo coverage for CI artifacts"
 	@echo "  mutation         mutation testing"

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,8 @@
             "@require-checker",
             "@cs",
             "@psalm",
-            "@test"
+            "@test",
+            "@test:integration"
         ],
         "cs": "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php",
         "cs:fix": "php-cs-fixer fix --diff --config=.php-cs-fixer.php",
@@ -95,6 +96,7 @@
         "require-checker": "composer-require-checker check composer.json",
         "test": "testo --suite=Unit",
         "test:coverage": "testo --suite=Unit --coverage --coverage-clover=build/coverage.xml",
-        "test:coverage:ci": "testo --suite=Unit --coverage-clover=build/coverage.xml"
+        "test:coverage:ci": "testo --suite=Unit --coverage-clover=build/coverage.xml",
+        "test:integration": "testo --suite=Integration"
     }
 }

--- a/testo.php
+++ b/testo.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Testo\Application\Config\ApplicationConfig;
+use Testo\Application\Config\FinderConfig;
 use Testo\Application\Config\SuiteConfig;
 
 return new ApplicationConfig(
@@ -10,7 +11,14 @@ return new ApplicationConfig(
     suites: [
         new SuiteConfig(
             name: 'Unit',
-            location: ['tests'],
+            // `tests/Integration` is excluded rather than listed file by file:
+            // what lives there spawns processes and runs bodies inside Fibers,
+            // and a unit run has to stay something you wait for.
+            location: new FinderConfig(include: ['tests'], exclude: ['tests/Integration']),
+        ),
+        new SuiteConfig(
+            name: 'Integration',
+            location: ['tests/Integration'],
         ),
         new SuiteConfig(
             name: 'Benchmarks',

--- a/tests/Bypass/FileWrapperTest.php
+++ b/tests/Bypass/FileWrapperTest.php
@@ -13,7 +13,7 @@ use Testo\Test;
 /**
  * The wrapper's own operations, driven directly.
  *
- * Registering it and letting PHP compile through it is what `BypassFinalsTest`
+ * Registering it and letting PHP compile through it is what `BypassFinalsIntegrationTest`
  * does, in a process per scenario — the only way to prove a load-order claim,
  * and invisible to coverage. Everything that is just a method taking a path can
  * be exercised here instead, where a mistake shows up as a failing assertion

--- a/tests/Bypass/FinalStripperTest.php
+++ b/tests/Bypass/FinalStripperTest.php
@@ -13,7 +13,7 @@ use Testo\Test;
 /**
  * The decisions the transform makes, on strings rather than through a process.
  *
- * The wrapper's end-to-end claims are made by `BypassFinalsTest`, which spawns a
+ * The wrapper's end-to-end claims are made by `BypassFinalsIntegrationTest`, which spawns a
  * process per scenario — necessary, because a class loads once, and invisible to
  * coverage for the same reason. What can be decided about a source file can be
  * decided here, where every branch is reachable and every mistake is visible.

--- a/tests/Fixture/Bypass/preload.php
+++ b/tests/Fixture/Bypass/preload.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  *
  * That is the whole point: a preloaded class is in memory before bypass could
  * have been asked for, so there is nothing left to lift and the refusal says
- * so. Started by `BypassFinalsTest`, never on its own.
+ * so. Started by `BypassFinalsIntegrationTest`, never on its own.
  */
 
 require __DIR__ . '/SealedGate.php';

--- a/tests/Fixture/Bypass/scenario.php
+++ b/tests/Fixture/Bypass/scenario.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * One scenario, one process. Started by `BypassFinalsTest`, never on its own.
+ * One scenario, one process. Started by `BypassFinalsIntegrationTest`, never on its own.
  *
  * A class is read from disk once per process, so every claim about lifting
  * `final` before that read has to be made in a process of its own. Running them

--- a/tests/Integration/BypassFinalsIntegrationTest.php
+++ b/tests/Integration/BypassFinalsIntegrationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rasuvaeff\Understudy\Tests;
+namespace Rasuvaeff\Understudy\Tests\Integration;
 
 use Testo\Assert;
 use Testo\Codecov\CoversNothing;
@@ -15,12 +15,12 @@ use Testo\Test;
  * A class is read from disk once per process and the transform happens as it is
  * read, so two scenarios in one process would prove only whichever ran first —
  * and coverage cannot see into a subprocess either, which is why
- * {@see Bypass\FinalStripperTest} exists beside this: the decisions are unit
+ * {@see \Rasuvaeff\Understudy\Tests\Bypass\FinalStripperTest} exists beside this: the decisions are unit
  * tested, the end-to-end claims are made here.
  */
 #[Test]
 #[CoversNothing]
-final class BypassFinalsTest
+final class BypassFinalsIntegrationTest
 {
     /**
      * @param list<string> $ini
@@ -90,7 +90,7 @@ final class BypassFinalsTest
     {
         $ini = [
             'opcache.enable_cli=1',
-            'opcache.preload=' . __DIR__ . '/Fixture/Bypass/preload.php',
+            'opcache.preload=' . dirname(__DIR__) . '/Fixture/Bypass/preload.php',
         ];
 
         if (\DIRECTORY_SEPARATOR === '\\') {
@@ -194,7 +194,7 @@ final class BypassFinalsTest
             '%s %s%s %s 2>&1',
             escapeshellarg(PHP_BINARY),
             $flags,
-            escapeshellarg(__DIR__ . '/Fixture/Bypass/scenario.php'),
+            escapeshellarg(dirname(__DIR__) . '/Fixture/Bypass/scenario.php'),
             escapeshellarg($scenario),
         );
 

--- a/tests/Integration/FiberIntegrationTest.php
+++ b/tests/Integration/FiberIntegrationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rasuvaeff\Understudy\Tests;
+namespace Rasuvaeff\Understudy\Tests\Integration;
 
 use Rasuvaeff\Understudy\Exception\VerificationFailed;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;


### PR DESCRIPTION
`tests/Integration` was an empty directory. Testo knew nothing about it,
`composer build` ran nothing from it, and two tests that are integration by
nature lived in `Unit`:

- `BypassFinalsIntegrationTest` (renamed from `BypassFinalsTest`) spawns a
  process per claim — a class is read from disk once per process, so each
  scenario needs its own;
- `FiberIntegrationTest` runs bodies inside Fibers and asks about them from
  outside.

Together they cost more than the other 740 tests combined: Unit is now 740
tests in 44ms, Integration 25 tests in 1.0s.

An empty directory there was also a landmine — testo refuses a finder path that
does not exist, and this one now has files in it.

## What changed

- `testo.php`: an `Integration` suite on `tests/Integration`, and `Unit`
  excludes that directory through `FinderConfig(include:, exclude:)`. A file
  added there is integration by placement; nothing has to be registered twice.
- `composer build` runs both suites; `composer test:integration` and
  `make test-integration` exist.
- **The Windows job and the bypass-acceptance job call
  `composer test:integration` explicitly.** The platform disagreements and the
  coverage-driver / warm-opcode-cache claims those jobs exist for are exactly
  what moved. Leaving them on `composer test` would have left those claims
  unmade — which is how the PHPUnit adapter's integration fixtures rotted.

## Mutation is unchanged, and that is measured

Two full runs, on this branch and on `master`, produced identical summaries:

```
Total: 2582 · killed 2093 · errored 246 · escaped 241 · timed out 2
MSI 90.66% (gate 90)
```

Both moved classes are `#[CoversNothing]`, so Infection's mapping never used
them, and the bridge invokes `testo run --type=!bench` with no `--suite` and
therefore runs every suite either way. Worth measuring rather than reasoning
about: the gate's margin is 17 mutants.

`bin/package-audit understudy`: 0 errors.