### PR TITLE
Reuse the coverage image instead of rebuilding it every run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,10 @@ make mutation
 make release-check
 ```
 
-`make test-coverage` and `make mutation` bootstrap `pcov` inside the
-`composer:2` container because the base image has no coverage driver.
+`make test-coverage` and `make mutation` run in `composer-pcov:local`, built
+once from `composer:2` by `make pcov-image` because the base image carries no
+coverage driver. `make mutation-diff` mutates only what the branch changed —
+seconds instead of the full run's minute — and the full run stays the gate.
 
 ## Invariants & gotchas
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,27 @@
 DOCKER := docker run --rm -v "$(PWD)":/app -w /app composer:2
 DOCKER_HOST := docker run --rm --network host -v "$(PWD)":/app -w /app
-PCOV_BOOTSTRAP := apk add --no-cache $$PHPIZE_DEPS >/dev/null && pecl install pcov >/dev/null && docker-php-ext-enable pcov
 
-.PHONY: bench build cs cs-fix psalm test mutation rector rector-fix install normalize require-checker \
-       test-coverage test-coverage-ci update-deps release-check bc-check audit-package help \
-       perf perf-install perf-cold perf-memory
+# `composer:2` ships no coverage driver, so anything measuring coverage needs
+# one installed. Installing it per run — apk add $$PHPIZE_DEPS, then pecl
+# install pcov, compiled from source — cost three to five minutes before the
+# first mutant, every time, and was also the most fragile step in the file: a
+# transient apk extraction error took the whole target down without a single
+# test having run. The full mutation run itself is about a minute, so the
+# bootstrap was the cost.
+#
+# Nothing in the image is package-specific, so every package in the monorepo
+# shares this one tag. It pins the PHP that coverage runs use — after a
+# `composer:2` bump, `make pcov-image-refresh`.
+PCOV_IMAGE := composer-pcov:local
+DOCKER_PCOV := docker run --rm -v "$(PWD)":/app -w /app --entrypoint sh $(PCOV_IMAGE) -lc
+
+# What `mutation-diff` measures against. A branch is compared to the trunk it
+# will merge into; override for a stacked branch.
+MUTATION_BASE ?= origin/master
+
+.PHONY: bench build cs cs-fix psalm test mutation mutation-diff rector rector-fix install normalize \
+       require-checker test-coverage test-coverage-ci update-deps release-check bc-check audit-package \
+       help perf perf-install perf-cold perf-memory pcov-image pcov-image-refresh
 
 install:
 	$(DOCKER) composer install --no-interaction --no-progress --prefer-dist
@@ -53,14 +70,33 @@ test-integration:
 examples:
 	$(DOCKER) composer examples
 
-test-coverage:
-	$(DOCKER) sh -lc '$(PCOV_BOOTSTRAP) && composer test:coverage'
+# Built once and then reused; the recipe is a no-op when the image is there.
+pcov-image:
+	@docker image inspect $(PCOV_IMAGE) >/dev/null 2>&1 || $(MAKE) pcov-image-refresh
 
-test-coverage-ci:
-	$(DOCKER) sh -lc '$(PCOV_BOOTSTRAP) && composer test:coverage:ci'
+pcov-image-refresh:
+	@echo "Building $(PCOV_IMAGE) from composer:2 ..."
+	@printf 'FROM composer:2\nRUN apk add --no-cache $$PHPIZE_DEPS >/dev/null \\\n && pecl install pcov >/dev/null \\\n && docker-php-ext-enable pcov\n' \
+	  | docker build -t $(PCOV_IMAGE) - >/dev/null
 
-mutation:
-	$(DOCKER) sh -lc '$(PCOV_BOOTSTRAP) && composer mutation'
+test-coverage: pcov-image
+	$(DOCKER_PCOV) 'composer test:coverage'
+
+test-coverage-ci: pcov-image
+	$(DOCKER_PCOV) 'composer test:coverage:ci'
+
+mutation: pcov-image
+	$(DOCKER_PCOV) 'composer mutation'
+
+# Only the mutants the branch moved. The gate is still the full run — this is
+# the loop to iterate in while a change is still being written, and it answers
+# in seconds where the whole suite answers in about a minute.
+#
+# git needs safe.directory: the repository is bind-mounted and owned by another
+# uid inside the container, and Infection shells out to git to resolve the diff.
+mutation-diff: pcov-image
+	$(DOCKER_PCOV) 'git config --global --add safe.directory /app; \
+	  composer mutation -- --git-diff-lines --git-diff-base=$(MUTATION_BASE)'
 
 rector:
 	$(DOCKER) composer rector
@@ -124,6 +160,8 @@ help:
 	@echo "  test-coverage    run testo with coverage"
 	@echo "  test-coverage-ci run testo coverage for CI artifacts"
 	@echo "  mutation         mutation testing"
+	@echo "  mutation-diff    mutate only what this branch changed"
+	@echo "  pcov-image       build the coverage image if it is missing"
 	@echo "  rector           check rector (dry-run)"
 	@echo "  rector-fix       apply rector fixes"
 	@echo "  normalize        normalize composer.json"


### PR DESCRIPTION
Local tooling only — no CI file, no source, no test is touched.

## The measurement

Every coverage-measuring target installed a driver first: `apk add
$PHPIZE_DEPS`, then `pecl install pcov` compiled from source, inside a `--rm`
container that then threw it away.

| Step | Time |
|---|---|
| Building the driver | **491 s** |
| The full mutation run it enables (2582 mutants, 13 threads) | **66 s** |

The bootstrap was the cost of mutation testing. It was also the most fragile
line in the file: it failed here with `gcc-15.2.0-r2: failed to extract
usr/bin/lto-dump: I/O error`, taking the whole target down before a single test
ran, on a machine with 665G free.

## What changes

- `make pcov-image` builds `composer-pcov:local` once and is a no-op when the
  image is present; `mutation`, `test-coverage` and `test-coverage-ci` depend on
  it. `make pcov-image-refresh` rebuilds after a `composer:2` bump — the image
  pins the PHP that coverage runs use.
- The tag is deliberately shared rather than package-scoped. This machine had
  six hand-built variations of the same thing — `composer-pcov:2`,
  `composer-pcov-tmp`, `retry-pcov`, `duration-pcov`, `bh-pcov:8.4`,
  `composer-apcu-pcov` — one per package that ever needed coverage locally.
- `make mutation-diff` mutates only the lines the branch changed
  (`--git-diff-lines --git-diff-base`, defaulting to `origin/master`, overridable
  via `MUTATION_BASE` for a stacked branch). **8 s** against the full run's 66 on
  the object-rendering branch. The full run stays the gate; this is the loop to
  iterate in while a change is still being written.

## Verification

The pre-existing image was deleted and rebuilt from this recipe rather than
trusted: 772MB, built in 491 s by `make pcov-image` alone. Then, on that fresh
image, `make mutation` green at 2582 mutants in 66 s, and `make mutation-diff`
correct in both directions — 8 s and a real verdict on a branch that changes
source, and `[OK] Could not find any modified files` with exit 0 on one that
does not.

`--only-covering-test-cases` was considered and left out: Infection documents it
in terms of PHPUnit's `--filter`, and this package runs under the testo bridge.
That needs its own check, not a flag flipped on a hunch.

`AGENTS.md`'s Commands section is updated in the same commit, since it described
the bootstrap that no longer exists.
