### PR TITLE
Take four per-call and per-double costs off the hot paths

### DIFF
--- a/src/Codegen/DoubleFactory.php
+++ b/src/Codegen/DoubleFactory.php
@@ -22,7 +22,23 @@ final class DoubleFactory
     /** @var array<class-string, Blueprint> */
     private static array $byGeneratedClass = [];
 
+    /** @var array<class-string, \ReflectionClass<object>> */
+    private static array $reflections = [];
+
     private function __construct() {}
+
+    /**
+     * One reflection per generated class rather than one per double: building
+     * it costs more the more members the class has, and every double of a
+     * contract is built from the same class.
+     */
+    public static function instantiate(Blueprint $blueprint): object
+    {
+        /** @var \ReflectionClass<object> $reflection */
+        $reflection = self::$reflections[$blueprint->generatedClass] ??= new \ReflectionClass($blueprint->generatedClass);
+
+        return $reflection->newInstanceWithoutConstructor();
+    }
 
     /**
      * @param non-empty-list<class-string> $contracts

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -514,19 +514,27 @@ final class Runtime
         // would mean deciding after `recordMatch()` counted it and
         // `performAction()` ran the test's own `returns()`/`answers()` — a
         // refused call would have already moved the double's state.
-        $sequence = $context->armedSequence();
-        $verdict = $sequence?->offer($double, $invocation) ?? SequenceVerdict::NotWatched;
+        //
+        // Cost is why this is one property read and a null check rather than
+        // an accessor and a verdict to compare: no protocol is armed in the
+        // overwhelming majority of calls, and everything on this path is paid
+        // by every call in every suite. `make perf` measures it.
+        $verdict = SequenceVerdict::NotWatched;
+        $sequence = $context->armed;
 
-        if ($verdict === SequenceVerdict::OutOfTurn) {
-            \assert($sequence !== null);
+        if ($sequence !== null) {
+            $verdict = $sequence->offer($double, $invocation);
 
-            throw VerificationFailed::of([self::outOfTurn($state, $sequence, $invocation)]);
-        }
+            if ($verdict === SequenceVerdict::OutOfTurn) {
+                throw VerificationFailed::of([self::outOfTurn($state, $sequence, $invocation)]);
+            }
 
-        if ($verdict === SequenceVerdict::Advanced) {
-            // A step is accounted for by the protocol that named it; without
-            // this, `nothingElse()` would report the protocol's own calls.
-            $invocation->markAccounted();
+            if ($verdict === SequenceVerdict::Advanced) {
+                // A step is accounted for by the protocol that named it;
+                // without this, `nothingElse()` would report the protocol's
+                // own calls.
+                $invocation->markAccounted();
+            }
         }
 
         foreach ($state->expectationsFor($method, $invocation->args) as $expectation) {

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -306,7 +306,20 @@ final class Runtime
     {
         $owners = self::owners();
 
-        return $owners->offsetExists($double) ? $owners->offsetGet($double) : null;
+        if (!$owners->offsetExists($double)) {
+            return null;
+        }
+
+        // WeakMap::offsetGet() is typed as nullable regardless of the value
+        // type, and offsetExists() above has already ruled that out.
+        /** @var RuntimeContext $owner */
+        $owner = $owners->offsetGet($double);
+
+        // A retired context owns nothing any more. Answering null here is what
+        // unsetting every one of its doubles used to do, at one write instead
+        // of one per double — and it leaves a context still on a Fiber's stack
+        // answering for its own, which is the behaviour reset() has.
+        return $owner->isRetired() ? null : $owner;
     }
 
     /**
@@ -318,7 +331,16 @@ final class Runtime
      */
     public static function isForgotten(object $double): bool
     {
-        return self::$forgotten?->offsetExists($double) ?? false;
+        // The raw map, not `ownerOf()`: that one hides a retired context,
+        // which is exactly the case this question is about.
+        if (self::$owners === null || !self::$owners->offsetExists($double)) {
+            return false;
+        }
+
+        /** @var RuntimeContext $owner */
+        $owner = self::$owners->offsetGet($double);
+
+        return $owner->isRetired();
     }
 
     /**
@@ -930,17 +952,18 @@ final class Runtime
         self::$live = [];
     }
 
+    /**
+     * Marks a context dead, in two writes rather than one per double.
+     *
+     * The doubles keep pointing at it through `$owners`; `ownerOf()` reads the
+     * flag and answers null, which is what walking every double to unset its
+     * owner used to achieve. Teardown runs after every test, so a loop there
+     * is paid by the whole suite — to answer a question (`isForgotten()`) that
+     * one cold path asks.
+     */
     private static function retire(RuntimeContext $context): void
     {
         self::unremember($context);
-
-        if (self::$owners === null) {
-            return;
-        }
-
-        foreach ($context->allDoubles() as $double) {
-            self::forgotten()[$double] = true;
-            unset(self::$owners[$double]);
-        }
+        $context->retire();
     }
 }

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -90,7 +90,7 @@ final class Runtime
         $stack = self::stack();
 
         if ($stack === []) {
-            $context = new RuntimeContext();
+            $context = self::freshContext();
             self::push($context);
 
             return $context;
@@ -112,7 +112,7 @@ final class Runtime
      */
     public static function pushScope(): RuntimeContext
     {
-        $context = new RuntimeContext();
+        $context = self::freshContext();
         self::push($context);
 
         return $context;
@@ -188,14 +188,19 @@ final class Runtime
     {
         $context = self::current();
         $context->register($double, $state);
-        self::remember($context);
-
         self::owners()->offsetSet($double, $context);
     }
 
     /**
      * Records a context as holding understudies, so accounting can reach it
      * from wherever the adapter stands.
+     */
+    /**
+     * Called where a context comes into being, not once per double adopted
+     * into it: the context is the same for every double a test builds, so
+     * doing it in `adopt()` rewrote the same key on the hottest creation path
+     * there is. A context that ends up holding nothing is harmless here —
+     * accounting walks its states, and it has none.
      */
     private static function remember(RuntimeContext $context): void
     {
@@ -256,7 +261,6 @@ final class Runtime
 
         $context = self::current();
         $context->register($clone, new DoubleState($blueprint));
-        self::remember($context);
 
         self::owners()->offsetSet($clone, $context);
     }
@@ -296,7 +300,6 @@ final class Runtime
         }
 
         $owner->register($double, new DoubleState($blueprint, nested: true));
-        self::remember($owner);
         self::owners()->offsetSet($double, $owner);
 
         return $double;
@@ -903,32 +906,51 @@ final class Runtime
         $fiber = \Fiber::getCurrent();
 
         if ($fiber === null) {
-            if (self::$main !== []) {
-                $position = count(self::$main) - 1;
-                self::retire(self::$main[$position]);
-                self::$main[$position] = new RuntimeContext();
-            }
+            $stack = self::$main;
+        } else {
+            $fibers = self::fibers();
+            /** @var list<RuntimeContext> $stack */
+            $stack = $fibers->offsetExists($fiber) ? $fibers->offsetGet($fiber) : [];
+        }
 
-            self::forgetOrphans();
+        // The sweep retires every live context, this one included — a context
+        // is recorded live where it is created, so there is nothing to retire
+        // separately here. It runs before the replacement is opened, because
+        // it would otherwise retire that one too.
+        self::forgetOrphans();
+
+        $position = count($stack) - 1;
+
+        if ($position < 0) {
+            return;
+        }
+
+        $stack[$position] = self::freshContext();
+        // Replacing one slot of a list keeps it a list; psalm widens it to a
+        // plain array because the offset is a variable.
+        /** @var list<RuntimeContext> $stack */
+
+        if ($fiber === null) {
+            self::$main = $stack;
 
             return;
         }
 
-        $fibers = self::fibers();
+        self::fibers()->offsetSet($fiber, $stack);
+    }
 
-        if ($fibers->offsetExists($fiber)) {
-            /** @var list<RuntimeContext> $stack */
-            $stack = $fibers->offsetGet($fiber);
+    /**
+     * The one place a context comes into being, and therefore the one place it
+     * is recorded as live. Recording it per double adopted into it rewrote the
+     * same key on the hottest creation path there is; recording it here happens
+     * once, and no context can be created without it.
+     */
+    private static function freshContext(): RuntimeContext
+    {
+        $context = new RuntimeContext();
+        self::remember($context);
 
-            if ($stack !== []) {
-                $position = count($stack) - 1;
-                self::retire($stack[$position]);
-                $stack[$position] = new RuntimeContext();
-                $fibers->offsetSet($fiber, $stack);
-            }
-        }
-
-        self::forgetOrphans();
+        return $context;
     }
 
     /**

--- a/src/Runtime/RuntimeContext.php
+++ b/src/Runtime/RuntimeContext.php
@@ -40,6 +40,8 @@ final class RuntimeContext
      */
     public ?ArmedSequence $armed = null;
 
+    private bool $retired = false;
+
     private readonly DefaultFactories $defaultFactories;
 
     public function __construct()
@@ -85,6 +87,30 @@ final class RuntimeContext
         if ($this->recordingDepth > 0) {
             $this->recordingDepth--;
         }
+    }
+
+    /**
+     * Whether this context was torn down. A retired context keeps answering
+     * "I owned this double" so that a call on a stale one can say what
+     * happened to it, and answers nothing else.
+     */
+    public function isRetired(): bool
+    {
+        return $this->retired;
+    }
+
+    /**
+     * One write, rather than one per double it holds. Teardown runs after
+     * every test, and what it costs is paid by every test in the suite.
+     *
+     * What it does NOT do is drop the registry: a context still on a Fiber's
+     * stack keeps answering for its own doubles, and only cross-context
+     * lookups stop finding it. Clearing here killed a sibling Fiber's doubles
+     * when the main flow reset.
+     */
+    public function retire(): void
+    {
+        $this->retired = true;
     }
 
     public function register(object $double, DoubleState $state): void

--- a/src/Runtime/RuntimeContext.php
+++ b/src/Runtime/RuntimeContext.php
@@ -38,7 +38,7 @@ final class RuntimeContext
      * naming the same double would each judge every call on it and could
      * disagree about the same call.
      */
-    private ?ArmedSequence $armed = null;
+    public ?ArmedSequence $armed = null;
 
     private readonly DefaultFactories $defaultFactories;
 
@@ -58,11 +58,6 @@ final class RuntimeContext
     public function defaultFactories(): DefaultFactories
     {
         return $this->defaultFactories;
-    }
-
-    public function armedSequence(): ?ArmedSequence
-    {
-        return $this->armed;
     }
 
     public function arm(ArmedSequence $sequence): void

--- a/src/Understudy.php
+++ b/src/Understudy.php
@@ -73,7 +73,7 @@ final class Understudy
         // statically known, and this is also the path a class double will need,
         // where the target's constructor must be skipped rather than run.
         /** @var T $double */
-        $double = (new \ReflectionClass($blueprint->generatedClass))->newInstanceWithoutConstructor();
+        $double = DoubleFactory::instantiate($blueprint);
 
         // The skipped constructor leaves every typed property uninitialized;
         // the ones that can hold an empty scalar or array get one, so that

--- a/src/Understudy.php
+++ b/src/Understudy.php
@@ -297,7 +297,7 @@ final class Understudy
 
     private static function checkArmedSequence(RuntimeContext $context): ?VerificationFailure
     {
-        $sequence = $context->armedSequence();
+        $sequence = $context->armed;
 
         if ($sequence === null || $sequence->isComplete()) {
             return null;
@@ -893,7 +893,7 @@ final class Understudy
         }
 
         $context = Runtime::current();
-        $armed = $context->armedSequence();
+        $armed = $context->armed;
 
         // Only a concurrent one is refused. A protocol that ran to completion
         // has nothing left to disagree about, and a two-phase test must be


### PR DESCRIPTION
Found by the release ritual in `AGENTS.md` — re-measure `perf/` on the commit the
recorded figures came from, then on the candidate — while preparing the 0.2.0
tag. Nothing in CI defends these numbers; a regression is found only because
somebody measures.

## Two findings, one of them already shipped

**Mine, from #51.** The armed-protocol check cost every call an accessor, a
null-coalesce and two enum comparisons whether or not a protocol existed. Arming
is rare; dispatch is not.

**Not mine.** Between `9837dfd` — the commit `perf/README.md` quotes — and this
branch there are 27 commits and two published releases. Bisected: `9837dfd`,
`0b9a547` and `bcf531f` measure clean, `7a364bd` (#23) carries the whole thing.
It shipped in 0.1.0, 0.1.1 and 0.1.2, which also means the recorded figures never
described a released version.

## What was costing what

| Change | Was |
|---|---|
| Retire a context by marking it | Two WeakMap operations **per double** on every `reset()`, to answer `isForgotten()` — one consumer, on a cold path |
| Record a context where it is created | `adopt()` rewrote the same key **per double**; the context is the same for every double a test builds |
| One `ReflectionClass` per generated class | Built **per double**; the cost grows with the class's member count |
| Armed-protocol check behind one null check | An accessor, a `??` and two enum comparisons **per call** |

`ownerOf()` reads the retired flag and answers null, which is what unsetting
every one of a context's doubles used to achieve. The registry is deliberately
*not* cleared: a context still on a Fiber's stack keeps answering for its own
doubles, and clearing killed a sibling Fiber's when the main flow reset —
`resetLeavesASiblingFiberContextIntact` caught it.

## Measurements

The benchmark harness turned out too noisy on a machine that had been running
Docker all session: it read `narrowUnderstudy` at 0.415 normalised where three
consecutive filtered runs gave 0.307–0.310. Everything below is instead a warmed
20000-iteration loop, timed with `hrtime()` in its own process, median of three,
compared only within a batch.

`for()+reset()`, three batches:

| | median |
|---|---|
| `bcf531f`, before the regression | 1.01µs |
| `7c1aeee`, before this branch | 1.27–1.33µs (**+26…29%**) |
| this branch | 1.15–1.24µs (**+14…20%**) |

About half the regression is back. The rest is diffuse: `blueprintFor`,
instantiation and `new DoubleState` time identically in both trees (0.029 /
0.086 / 0.129µs); what is left sits in `adopt()` and its surroundings at ~0.06µs
and is no longer attributable to a single call.

**The width of the contract never mattered.** 1.174 and 1.187µs for a one-method
and an eight-method interface here; 1.006 and 1.003 at the clean commit.
`wideUnderstudy` reading higher than `narrowUnderstudy` was the harness, not a
per-method cost.

One honest correction: the reflection cache was tried earlier, measured no
better, and dropped. That measurement was noisy. Measured properly it is worth
about 6% of creation, so it is here.

## Verification

`composer build` green. Mutation: 2721 mutants, **230 escaped against 239 on
master**. Two escapees sit on new lines: the cache's `??=`, which no behavioural
test can kill because only speed differs, and an off-by-one on the stack
position that reduces to the same observable state.

`perf/README.md` is deliberately **not** updated here. Its figures need three
runs on a quiet machine, and this one was not.
