### PR TITLE
Undo the lazy context retirement: it moved a cost rather than removing one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,23 @@ seconds instead of the full run's minute — and the full run stays the gate.
   `final` properties and asymmetric visibility are a parse error on 8.3 — a file
   carrying them takes the whole suite down there rather than skipping a test.
 
+- **The per-double loop in `Runtime::retire()` is load-bearing, and it looks
+  like the opposite.** Teardown runs after every test and walks every double the
+  context held, stamping it forgotten and dropping its owner — an obvious thing
+  to replace with a flag on the context that `ownerOf()` reads. That was built,
+  and it made teardown cheaper in an isolated loop and double creation **13-23%
+  slower** in the benchmark: the owner entries then live until collection, and
+  the map they sit in grows across the whole suite. The work was not removed,
+  it was moved somewhere it costs more. Reverted, measured back to parity.
+  Before touching it again, read the next bullet.
+- **An isolated micro-benchmark cannot see a cost you moved.** It times an
+  operation; the regression above was in the system around it, and only showed
+  up in a run that had already built ten thousand doubles. The full harness is
+  the one that sees it — and it reads 0.415 normalised where three filtered runs
+  read 0.307 if the machine is busy. What is trustworthy is neither on its own:
+  an A/B of the full harness on a quiet machine, three runs per side, with the
+  competitors' movement in the same runs used as the noise floor. If Mockery and
+  PHPUnit moved as much as we did, nothing was measured.
 - **A perf figure that cannot be reproduced from the repository is not a
   figure.** The recorded environment said "pinned to six cores"; the `make perf`
   target did no pinning, so the numbers depended on flags in someone's shell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Reverted the lazy context retirement from the previous entry.** Marking a
+  context retired instead of walking its doubles made teardown cheaper in an
+  isolated loop and double creation 13-23% slower in the benchmark: the owner
+  entries then live until collection and the map they sit in grows across the
+  suite. The work was not removed, it was moved somewhere it costs more. No
+  behaviour changes either way; the other three costs taken off the hot paths
+  stay.
+
 - **`Understudy::expectSequence()` / `expectSequence()`: a protocol armed before
   the subject runs.** `ordered()` and `verifySequence()` both answer in
   teardown, where the stack trace points at `verifyAll()` rather than at the

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -309,20 +309,7 @@ final class Runtime
     {
         $owners = self::owners();
 
-        if (!$owners->offsetExists($double)) {
-            return null;
-        }
-
-        // WeakMap::offsetGet() is typed as nullable regardless of the value
-        // type, and offsetExists() above has already ruled that out.
-        /** @var RuntimeContext $owner */
-        $owner = $owners->offsetGet($double);
-
-        // A retired context owns nothing any more. Answering null here is what
-        // unsetting every one of its doubles used to do, at one write instead
-        // of one per double — and it leaves a context still on a Fiber's stack
-        // answering for its own, which is the behaviour reset() has.
-        return $owner->isRetired() ? null : $owner;
+        return $owners->offsetExists($double) ? $owners->offsetGet($double) : null;
     }
 
     /**
@@ -334,16 +321,7 @@ final class Runtime
      */
     public static function isForgotten(object $double): bool
     {
-        // The raw map, not `ownerOf()`: that one hides a retired context,
-        // which is exactly the case this question is about.
-        if (self::$owners === null || !self::$owners->offsetExists($double)) {
-            return false;
-        }
-
-        /** @var RuntimeContext $owner */
-        $owner = self::$owners->offsetGet($double);
-
-        return $owner->isRetired();
+        return self::$forgotten?->offsetExists($double) ?? false;
     }
 
     /**
@@ -975,17 +953,26 @@ final class Runtime
     }
 
     /**
-     * Marks a context dead, in two writes rather than one per double.
+     * Stamps every double the context held as forgotten and drops its owner.
      *
-     * The doubles keep pointing at it through `$owners`; `ownerOf()` reads the
-     * flag and answers null, which is what walking every double to unset its
-     * owner used to achieve. Teardown runs after every test, so a loop there
-     * is paid by the whole suite — to answer a question (`isForgotten()`) that
-     * one cold path asks.
+     * The loop looks like something to remove — teardown runs after every test
+     * — and removing it was measured. Marking the context instead and having
+     * `ownerOf()` read the flag made teardown cheaper in isolation and double
+     * creation 13-23% slower in the benchmark, because the owner entries then
+     * live until collection and the map they sit in keeps growing. Eager
+     * removal here is what keeps that map the size of one test.
      */
     private static function retire(RuntimeContext $context): void
     {
         self::unremember($context);
-        $context->retire();
+
+        if (self::$owners === null) {
+            return;
+        }
+
+        foreach ($context->allDoubles() as $double) {
+            self::forgotten()[$double] = true;
+            unset(self::$owners[$double]);
+        }
     }
 }

--- a/src/Runtime/RuntimeContext.php
+++ b/src/Runtime/RuntimeContext.php
@@ -40,8 +40,6 @@ final class RuntimeContext
      */
     public ?ArmedSequence $armed = null;
 
-    private bool $retired = false;
-
     private readonly DefaultFactories $defaultFactories;
 
     public function __construct()
@@ -87,30 +85,6 @@ final class RuntimeContext
         if ($this->recordingDepth > 0) {
             $this->recordingDepth--;
         }
-    }
-
-    /**
-     * Whether this context was torn down. A retired context keeps answering
-     * "I owned this double" so that a call on a stale one can say what
-     * happened to it, and answers nothing else.
-     */
-    public function isRetired(): bool
-    {
-        return $this->retired;
-    }
-
-    /**
-     * One write, rather than one per double it holds. Teardown runs after
-     * every test, and what it costs is paid by every test in the suite.
-     *
-     * What it does NOT do is drop the registry: a context still on a Fiber's
-     * stack keeps answering for its own doubles, and only cross-context
-     * lookups stop finding it. Clearing here killed a sibling Fiber's doubles
-     * when the main flow reset.
-     */
-    public function retire(): void
-    {
-        $this->retired = true;
     }
 
     public function register(object $double, DoubleState $state): void


### PR DESCRIPTION
#52 replaced the per-double loop in `Runtime::retire()` with a flag on the
context that `ownerOf()` reads. Teardown got measurably cheaper in an isolated
loop, and **double creation got 13–23% slower** in the benchmark: the owner
entries then live until collection, and the map they sit in grows across the
whole suite. The work was not removed, it was moved somewhere it costs more.

A/B of the full harness on a quiet machine, three runs a side, with the
competitors in the same runs as the noise floor:

| | `7c1aeee` | with #52 | this branch | peers moved |
|---|---|---|---|---|
| `narrowUnderstudy` | 2.01µs | 2.47 | **2.04** | −1.8% |
| `wideUnderstudy` | 2.06µs | 2.33 | **2.04** | −1.7% |
| `verifiedUnderstudy` | 12.74µs | 13.46 | **12.87** | −1.9% |
| `onceUnderstudy` | 9.74µs | 9.47 | 9.74 | −2.9% |

The isolated measurement was not wrong about what it timed. It could not see the
cost being moved: it builds one double at a time, and the regression only appears
in a run that has already built ten thousand.

## What this settles

The older regression from #23, which #52 set out to remove, **cannot be removed
this way**. That loop is load-bearing — it keeps the owner map the size of one
test. The only change that appeared to recover the figures was the one that broke
creation.

Both the finding and the method that produced it are now in `AGENTS.md`, so the
next attempt starts from the measurement rather than from the same idea.

## What stays from #52

The other three costs stay, and measure neutral in this A/B while removing work
that is genuinely redundant:

- the armed-protocol check behind one null check instead of an accessor, a `??`
  and two enum comparisons per call;
- the context recorded live once where it is created, not once per double
  adopted into it;
- one `ReflectionClass` per generated class, not per double.

## Verification

`composer build` green. Mutation: 2722 mutants, **232 escaped** against 239
before this line of work began. No behaviour changes in either direction — the
revert restores the previous implementation of a private teardown path.
