### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 — 2026-08-27
 
-- **Reverted the lazy context retirement from the previous entry.** Marking a
-  context retired instead of walking its doubles made teardown cheaper in an
-  isolated loop and double creation 13-23% slower in the benchmark: the owner
-  entries then live until collection and the map they sit in grows across the
-  suite. The work was not removed, it was moved somewhere it costs more. No
-  behaviour changes either way; the other three costs taken off the hot paths
-  stay.
+New verbs and richer failure messages; nothing removed, nothing renamed. A
+minor rather than a patch because `expectSequence()` is new public API, and on
+0.x that is the boundary Composer's caret already treats as breaking.
 
 - **`Understudy::expectSequence()` / `expectSequence()`: a protocol armed before
   the subject runs.** `ordered()` and `verifySequence()` both answer in
@@ -39,6 +35,20 @@
   with its own exception.
 - Fixed a deprecation introduced with object rendering: `SplObjectStorage::contains()`
   is deprecated as of PHP 8.5, and every rendered object emitted a notice.
+
+- **Performance.** Four per-call and per-double costs came off the hot paths:
+  the armed-protocol check now sits behind one null check, a context is recorded
+  live once where it is created rather than once per double adopted into it, and
+  one `ReflectionClass` is built per generated class rather than per double. A
+  fifth change — retiring a context by marking it instead of walking its
+  doubles — was measured, found to move the cost onto creation (13-23% worse in
+  the benchmark) rather than remove it, and reverted; the finding is recorded in
+  `AGENTS.md`.
+- **`perf/README.md` re-measured on a quiet machine.** The previous figures were
+  taken at a commit before 0.1.0 and described no released version. They also
+  did not show a creation regression that landed before the first tag and
+  shipped in 0.1.0, 0.1.1 and 0.1.2; it is bisected, documented, and still
+  present.
 
 - **An object argument renders as an alias and its public state**, so the `*`
   that marks a differing argument points at something the reader can see:

--- a/perf/README.md
+++ b/perf/README.md
@@ -86,50 +86,66 @@ figure, is the only thing worth quoting.
 
 Environment: PHP 8.5.6, Linux x86_64, `composer:2` image, no OPcache, no Xdebug.
 The container is pinned to six cores with a raised CPU share — by the `PERF`
-variable in the root `Makefile`, not by flags typed at a prompt, which is what
-the previous set of figures depended on and why they are replaced here rather
-than compared against. Understudy at `9837dfd`, Mockery 1.6.15, Prophecy
-1.26.1, PHPUnit 12.5.33. Taken 2026-08-23, after the dispatch work in #16.
+variable in the root `Makefile`, not by flags typed at a prompt. Understudy at
+`442da10`, Mockery 1.6.15, Prophecy 1.26.1, PHPUnit 12.5.33. Taken 2026-08-27,
+before the 0.2.0 tag.
 
-Every in-process table below was run three times; all rows reproduce within 3%
-except Prophecy's twenty-call one, which is noted where it appears. Cold start
-was run three times too and does not reproduce that tightly — see its own
-section. Memory is deterministic: two runs, byte-identical.
+**The previous set was taken at `9837dfd` — a commit before 0.1.0**, so it
+described no released version at all. Between it and the first tag a regression
+landed that those figures did not show: double creation went from about 1.7µs to
+about 2.0µs in the same harness, and it shipped in 0.1.0, 0.1.1 and 0.1.2. It was
+bisected to #23 and is still present. Removing it was attempted and reverted —
+see the invariant in the package's `AGENTS.md`: the per-double loop in
+`Runtime::retire()` looks removable and is not, and replacing it moved the cost
+onto creation instead, 13-23% worse in this harness.
 
-Figures are **filtered means** — testo's `Mean*`, after outlier rejection —
-with the relative deviation of that filtered set under 5% everywhere quoted.
+Every in-process table below was run three times; medians move by 0.2-3.5%
+between runs. Figures are **filtered means** — testo's `Mean*`, after outlier
+rejection — and the relative deviation of that filtered set is under 5%
+everywhere quoted except the one-call stub row, where it reaches 7%: that
+scenario is short enough that process noise still shows through, and its
+medians are quoted because they reproduce to 0.2% across the three runs even
+though each run is internally noisier.
+
+**These runs were taken on an idle machine, and the difference matters.** The
+same harness, on a machine also running Docker builds, read double creation 35%
+higher and invented a gap between the one-method and eight-method contracts that
+does not exist. An A/B against another commit, three runs a side, with the other
+libraries' movement in the same runs as the noise floor, is the only comparison
+worth acting on.
 
 ### Building a double
 
 | Contract | understudy | Mockery | Prophecy | PHPUnit `createStub` | PHPUnit `createMock` |
 |---|---|---|---|---|---|
-| 1 method | **1.28µs** | +359% | +936% | +255% | +302% |
-| 8 methods | **1.29µs** | +354% | +919% | +254% | +298% |
+| 1 method | **2.06µs** | +216% | +683% | +155% | +159% |
+| 8 methods | **2.06µs** | +217% | +641% | +158% | +159% |
 
-The cost still does not move with the width of the contract — 1.28µs against
-1.29µs — because the generated class is compiled once and everything after that
-is instantiation.
+The cost still does not move with the width of the contract — 2.06µs either way
+— because the generated class is compiled once and everything after that is
+instantiation. A busy machine will suggest otherwise; it is wrong.
+
+Against the previous figures this row is 60% worse, and that is the #23
+regression described above, not a change since 0.1.2.
 
 ### A stub: build, stub, call, tear down
 
 | | understudy | Mockery | Prophecy | PHPUnit `createStub` |
 |---|---|---|---|---|
-| 1 call | 8.74µs | +30% | +81% | **−7%** |
-| 20 calls | 24.3µs | +75% | —¹ | **−11%** |
-| marginal cost of one call² | 0.82µs | 1.64µs | —¹ | **0.71µs** |
+| 1 call | 10.6µs | +17% | +76% | **−17%** |
+| 20 calls | 27.1µs | +59% | +75% | **−19%** |
+| marginal cost of one call² | 0.86µs | 1.61µs | 1.51µs | **0.69µs** |
 
-¹ Prophecy's twenty-call row still carries ±72% relative deviation after outlier
-filtering, and moves 13.9% between runs — its per-call path allocates enough to
-make garbage collection, not the call, the thing being measured. Neither the
-number nor a marginal cost derived from it is quotable.
+¹ Prophecy's twenty-call row was unquotable in the previous set — ±72% after
+filtering. On an idle machine it settles to ±3.7% and is quoted here.
 
 ² `(20 calls − 1 call) / 19`.
 
 **PHPUnit is ahead of understudy on the whole stub scenario, at both ends.** It
 builds the double more slowly and dispatches more cheaply, and in this
-environment the second effect wins from the first call onward: 8.14µs against
-8.74µs at one call, 0.71µs against 0.82µs per call after. There is no crossover
-at which understudy''s stub test becomes the cheaper one.
+environment the second effect wins from the first call onward: 8.77µs against
+10.6µs at one call, 0.69µs against 0.86µs per call after. There is no crossover
+at which understudy's stub test becomes the cheaper one.
 
 That is a change of conclusion, not only of numbers. The previous figures had
 understudy ahead by 27% on the one-call test and PHPUnit overtaking it at
@@ -142,8 +158,8 @@ PHPUnit from 1.62× to 1.15× — and it moved the build cost too, from 2.08µs 
 
 | | understudy | Mockery | Prophecy | PHPUnit `createMock` |
 |---|---|---|---|---|
-| plain expectation | 10.8µs | +19% | +159% | **−10%** |
-| with an argument matcher | **10.8µs** | +20% | +148% | —³ |
+| plain expectation | 12.8µs | +4% | +128% | **−27%** |
+| with an argument matcher | **12.2µs** | +5% | +115% | —³ |
 
 ³ see "What is deliberately absent" above.
 
@@ -153,19 +169,19 @@ expectation — 10.77µs either way.
 ### Cold start
 
 Medians of 25 processes, minus a baseline process that only loads the
-autoloader. **Quote the ratio, not the milliseconds:** understudy''s added time
-spans 1.95–2.52ms across three runs, a 29% spread, far outside the 2% testo
-calls stable. The ratios hold much better than the absolutes do.
+autoloader. **Quote the ratio, not the milliseconds:** the absolutes move far
+more between runs than testo calls stable, and the ratios hold much better.
 
 | library | added to process start | ×understudy |
 |---|---|---|
-| understudy | 1.95–2.52ms | **1.00×** |
-| Mockery | 2.97–3.49ms | 1.30–1.53× |
-| Prophecy | 8.50–9.12ms | 3.62–4.43× |
-| PHPUnit | 8.84–10.87ms | 3.86–4.94× |
+| understudy | 1.59ms | **1.00×** |
+| Mockery | 2.39ms | 1.50× |
+| Prophecy | 7.91ms | 4.96× |
+| PHPUnit | 8.58ms | 5.38× |
 
-Mockery''s ratio moved — it was 1.87× when these were last taken, and nothing in
-Mockery changed. Recorded as observed, without a cause.
+Mockery's ratio has been unstable across sets — 1.87×, then 1.30–1.53×, now
+1.50× — across commits that cannot touch Mockery. Recorded as observed, without
+a cause.
 
 ### Memory
 
@@ -175,10 +191,10 @@ Deterministic: two runs, identical to the byte.
 
 | library | first double of a contract | each further double |
 |---|---|---|
-| understudy | 4.0 KB (`Clock`), 13.1 KB (`Ledger`) | **435–450 B** |
-| Mockery | 190.3 KB, 140.8 KB | 513 B |
+| understudy | 4.5 KB (`Clock`), 13.6 KB (`Ledger`) | **467–482 B** |
+| Mockery | 126.3 KB, 140.8 KB | 513 B |
 | Prophecy | 13.5 KB, 35.5 KB | ~8.5 KB |
-| PHPUnit | 9.5 KB, 70.6 KB | ~1.25 KB |
+| PHPUnit | 9.5 KB, 134.6 KB | ~1.25 KB |
 
 **Per-double memory has grown, and it is ours.** The harness was re-run at the
 commit the previous figures were taken at and reproduced them exactly — 354 B
@@ -190,6 +206,10 @@ the movement is code:
 | #8, where the old figures were taken | 354 B | 339 B |
 | after #9–#14 (class doubles, forwarding, defaults, by-ref, bypass) | 418 B | 403 B |
 | after #16 (dispatch) | 450 B | 435 B |
+| at `442da10`, before 0.2.0 | 482 B | 467 B |
+
+The last row is another 32 bytes, over the same range that carries the #23
+creation regression. It has not been attributed to a single change.
 
 The last step is the price of the dispatch work: #16 keeps a second,
 reverse-ordered list of expectations so that matching does not rebuild one per

--- a/src/Codegen/DoubleFactory.php
+++ b/src/Codegen/DoubleFactory.php
@@ -140,7 +140,7 @@ final class DoubleFactory
         $getHooks = 'getHooks';
 
         foreach ($reflection->getProperties() as $property) {
-            if (!method_exists($property, $isAbstract) || $property->{$isAbstract}() !== true) {
+            if (!method_exists($property, $isAbstract) || !$property->{$isAbstract}()) {
                 continue;
             }
 

--- a/src/Runtime/ArmedSequence.php
+++ b/src/Runtime/ArmedSequence.php
@@ -99,7 +99,7 @@ final class ArmedSequence
         if (!$this->isComplete()) {
             [$owner, $step] = $this->steps[$this->cursor];
 
-            if ($owner === $double && self::accepts($step, $invocation)) {
+            if ($owner === $double && $this->accepts($step, $invocation)) {
                 ++$this->cursor;
 
                 return SequenceVerdict::Advanced;
@@ -119,7 +119,7 @@ final class ArmedSequence
     private function isAnyStep(object $double, Invocation $invocation): bool
     {
         foreach ($this->steps as [$owner, $step]) {
-            if ($owner === $double && self::accepts($step, $invocation)) {
+            if ($owner === $double && $this->accepts($step, $invocation)) {
                 return true;
             }
         }
@@ -133,7 +133,7 @@ final class ArmedSequence
      * counts as one that did not match, exactly as it does when a refusal is
      * being rendered.
      */
-    private static function accepts(Expectation $step, Invocation $invocation): bool
+    private function accepts(Expectation $step, Invocation $invocation): bool
     {
         try {
             return $step->matches($invocation->method, $invocation->args);


### PR DESCRIPTION
Cuts `## Unreleased` to `## 0.2.0 — 2026-08-27`, re-measures `perf/README.md`,
and takes the two changes `rector` asked for.

A **minor**, not a patch: `Understudy::expectSequence()` is new public API, and
on 0.x that is the boundary Composer's caret already treats as breaking. The
four satellites pin `rasuvaeff/understudy: ^0.1`, so each needs
`^0.1 || ^0.2` and a patch tag of its own after this one lands — widening a
constraint breaks nobody, and the existing consumer keeps resolving.

## What is in it

- `expectSequence()` — a protocol armed before the subject runs (#51, issue #33)
- a strict double says what it refused and what it compared the call against
  (#50, issue #47)
- an object argument renders as an alias and its public state (#48, issue #32)
- four per-call and per-double costs off the hot paths, and a fifth measured and
  reverted (#52, #53)

## Pre-flight

| Check | Result |
|---|---|
| `make release-check` | exit 0 — psalm clean, `Detected last version: v0.1.2`, MSI 91% |
| `bin/understudy-consumer-smoke` | clean across all five packages |
| `perf/README.md` | re-measured at `442da10` on an idle machine, three runs |

## About the perf figures

The previous set was taken at `9837dfd` — a commit **before 0.1.0** — so it
described no released version. It also did not show a creation regression that
landed before the first tag and shipped in 0.1.0, 0.1.1 and 0.1.2: double
creation about 1.7µs to about 2.0µs. It is bisected to #23, documented in
`AGENTS.md`, and still present. An attempt to remove it moved the cost onto
creation instead and was reverted in #53.

Double creation is therefore quoted at 2.06µs here against 1.28µs in the old
table. That is not a regression introduced by this release; it is the first
honest measurement of what has been shipping since 0.1.0.
