### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 — 2026-08-27
 
 - **A `when()` stub and an `expect()` for the exact same call are refused at
   registration** with the new `ConflictingExpectation` (rasuvaeff/understudy#59).


### PR DESCRIPTION
Dates the changelog for 0.3.0: the `ConflictingExpectation` refusal of a `when()`/`expect()` pair naming the exact same call (#59, #64).

A minor rather than a patch, same reasoning as 0.2.0: a new public exception class, and configurations that previously degraded silently now throw — on 0.x that is the boundary Composer's caret already treats as breaking.

## Perf A/B before the tag (per AGENTS.md)

Re-measured `make perf` at `442da10` (the commit the recorded figures were taken from) and at the candidate (`bf0f98c`), three interleaved runs a side, same machine, quiet:

- Per-scenario `current` filtered means moved within ±2.4% by medians, sign in both directions — inside the noise floor the competitors' own movement set in the same runs.
- The harness's built-in "current is fastest" verdicts **fail at `442da10`** (PHPUnit stub up to 22.9% faster, consistently in all three runs) and **pass on the candidate** in all three: master got faster since the recorded figures via #58's lazy matcher indexes, and the #64 registration guard did not spend those gains.
- `perf/README.md` figures stay as recorded — they are dated and attributed to `442da10`; a full re-record (including cold-start and memory) can ride a later PR.