### PR TITLE
perf: state the decision on the pre-0.1.0 creation regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **The pre-0.1.0 double-creation regression is now a stated decision, not an
+  open question** (rasuvaeff/understudy#56). `perf/README.md` records that the
+  ~0.3µs per double bisected to #23 bought bounded registration/reset/verify
+  accounting and closed the Fiber hole where an unmet `expect()` in a Fiber
+  passed silently — a false pass, the one failure mode a verification library
+  must not have. The trade is accepted; reopening it requires the full-harness
+  A/B the file describes. No code change.
+
 - **`Arg::captor()`: a typed argument captor** (rasuvaeff/understudy#62). The
   typed replacement for reading `args[N]` out of the call log:
   `$options = Arg::captor(DeliveryOptions::class)`, `$options->capture()` in

--- a/perf/README.md
+++ b/perf/README.md
@@ -99,6 +99,18 @@ see the invariant in the package's `AGENTS.md`: the per-double loop in
 `Runtime::retire()` looks removable and is not, and replacing it moved the cost
 onto creation instead, 13-23% worse in this harness.
 
+**Decision (closes #56): the cost is accepted.** #23 is the core review round
+that made registration, reset, `idle()` and aggregate verification bounded and
+predictable, and closed the Fiber accounting hole — a test body run in a Fiber
+could leave an unmet `expect()` and the suite stayed green. That is a false
+*pass*, the one failure mode a verification library must not have, and it is
+worth ~0.3µs on every double built. The figures in this file describe the
+library as shipped, with that trade in it. Reopening the trade takes what the
+attempt above took: a change that removes the cost without reopening the hole,
+judged by an A/B of the full harness on a quiet machine, three runs a side,
+with the competitors' movement as the noise floor — never by an isolated
+micro-benchmark, which cannot see a cost that was moved.
+
 Every in-process table below was run three times; medians move by 0.2-3.5%
 between runs. Figures are **filtered means** — testo's `Mean*`, after outlier
 rejection — and the relative deviation of that filtered set is under 5%


### PR DESCRIPTION
Fixes #56

The issue offered two ways to close: a change that removes the cost and survives the full-harness A/B, or a documented decision that #23 bought correctness worth ~0.3µs per double. This takes the second, because the first was already attempted honestly and failed: #52 replaced the retire() loop, the A/B showed the cost had moved onto creation (13–23% worse), and #53 reverted it — the invariant lives in AGENTS.md.

What the decision says, now in `perf/README.md` next to the bisect it concludes: #23 made registration/reset/`idle()`/aggregate verification bounded and predictable and closed the Fiber accounting hole — an unmet `expect()` in a Fiber-run body passed silently. A false pass is the one failure mode a verification library must not have, and it is worth 0.3µs per double. The published figures describe the library as shipped, with that trade in it; reopening it requires the same A/B discipline, never an isolated micro-benchmark.

Docs only, no code change. CHANGELOG under Unreleased.