### PR TITLE
Model the nested scope in the engine lifecycle property

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,11 @@ functions `when()`/`verify()` in `src/functions.php`, `Arg`, `Invocation`,
 under `Codegen\`, `Runtime\`, `Expectation\`, `Defaults\` and `Matcher\` is
 `@internal`.
 
-The design and its milestones live in the monorepo at
-`_plans/UNDERSTUDY-PLAN.md`. `spikes/` holds the executable feasibility
-fixtures the design rests on — they are not tests of this package's API, and
-they must keep passing on PHP 8.3/8.4/8.5.
+The design plan that drove milestones 0-7 shipped in full and was retired
+from the monorepo on 2026-08-28; what it decided lives in this file, the
+READMEs and the tests. `spikes/` holds the executable feasibility fixtures
+the design rests on — they are not tests of this package's API, and they must
+keep passing on PHP 8.3/8.4/8.5.
 
 ## Golden rules
 

--- a/tests/EngineLifecyclePropertyTest.php
+++ b/tests/EngineLifecyclePropertyTest.php
@@ -24,6 +24,7 @@ use Rasuvaeff\Understudy\Tests\Support\DispatchFindCommand;
 use Rasuvaeff\Understudy\Tests\Support\EngineHarness;
 use Rasuvaeff\Understudy\Tests\Support\EngineState;
 use Rasuvaeff\Understudy\Tests\Support\RequireNothingElseCommand;
+use Rasuvaeff\Understudy\Tests\Support\ScopeInterludeCommand;
 use Rasuvaeff\Understudy\Tests\Support\SettleCheckpointCommand;
 use Rasuvaeff\Understudy\Tests\Support\VerifyCallsCommand;
 use Rasuvaeff\Understudy\Tests\Support\VerifyEverythingCommand;
@@ -35,7 +36,7 @@ use Testo\Test;
 
 /**
  * Model-based test for the ledger lifecycle the plan calls the engine's
- * core loop: stub/expect → dispatch → verify → checkpoint. Any sequence of
+ * core loop: stub/expect → dispatch → verify → checkpoint → scope. Any sequence of
  * configuration, dispatch and verification commands must keep the real
  * double's answers, its call log and its accounting in lock-step with the
  * pure {@see EngineState} model — most-recent-first matching, claim
@@ -87,6 +88,12 @@ final class EngineLifecyclePropertyTest
         Classify::cover($harness->verifiesFailed > 0, 'an explicit verify failed', 5);
         Classify::cover($harness->settledCheckpoints > 0, 'a checkpoint settled', 5);
         Classify::cover($harness->refusedRegistrations > 0, 'a colliding registration was refused', 5);
+        // The scope interlude runs whenever its command is drawn; which way
+        // its close goes depends on the outer ledger at that instant, so the
+        // two outcomes are labelled without a floor and pinned by examples.
+        Classify::cover($harness->cleanScopeCloses + $harness->refusedScopeCloses > 0, 'a nested scope lived and died', 5);
+        Classify::when($harness->cleanScopeCloses > 0, 'scope: closed clean');
+        Classify::when($harness->refusedScopeCloses > 0, 'scope: close refused by an outer claim');
 
         // The runner advanced its own copy of the model; folding the same
         // pure transitions here gives the end state the real log must have
@@ -184,6 +191,33 @@ final class EngineLifecyclePropertyTest
                 new RequireNothingElseCommand(),
             ],
         )];
+
+        // The two ways a nested scope can close, pinned deterministically:
+        // over a clean outer ledger the close verifies and passes; over a
+        // violated outer claim it throws, because the close's verify sweeps
+        // every live context. Either way the inner double dies with its
+        // context and the outer ledger is untouched — a scope checks, it
+        // never settles, which the trailing dispatch and verify prove.
+        yield 'a scope closes clean over a clean outer ledger' => [new CommandSequence(
+            new EngineState(),
+            [
+                new ConfigureStubCommand(anyArgument: false, literalId: 2),
+                new ScopeInterludeCommand(),
+                new DispatchFindCommand(id: 2),
+                new VerifyCallsCommand(anyArgument: false, literalId: 2, minimum: 1, maximum: 1),
+            ],
+        )];
+
+        yield 'a scope close is refused by a violated outer claim' => [new CommandSequence(
+            new EngineState(),
+            [
+                new ConfigureExpectCommand(anyArgument: false, literalId: 1, minimum: 1, maximum: 1),
+                new ScopeInterludeCommand(),
+                new DispatchFindCommand(id: 1),
+                new ScopeInterludeCommand(),
+                new VerifyEverythingCommand(),
+            ],
+        )];
     }
 
     /**
@@ -246,6 +280,7 @@ final class EngineLifecyclePropertyTest
             Gen::constant(new VerifyEverythingCommand()),
             Gen::constant(new SettleCheckpointCommand()),
             Gen::constant(new RequireNothingElseCommand()),
+            Gen::constant(new ScopeInterludeCommand()),
         ];
     }
 

--- a/tests/Support/EngineHarness.php
+++ b/tests/Support/EngineHarness.php
@@ -21,6 +21,8 @@ final class EngineHarness
     public int $verifiesFailed = 0;
     public int $settledCheckpoints = 0;
     public int $refusedRegistrations = 0;
+    public int $cleanScopeCloses = 0;
+    public int $refusedScopeCloses = 0;
 
     public function __construct(public readonly BookRepository $double) {}
 }

--- a/tests/Support/ScopeInterludeCommand.php
+++ b/tests/Support/ScopeInterludeCommand.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Support;
+
+use Rasuvaeff\PropertyTesting\StateMachine\Command;
+use Rasuvaeff\Understudy\Exception\ForgottenDouble;
+use Rasuvaeff\Understudy\Exception\VerificationFailed;
+use Rasuvaeff\Understudy\Tests\Fixture\Book;
+use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
+use Rasuvaeff\Understudy\Understudy;
+
+/**
+ * Runs a whole nested `scope()` life — build an inner double, claim a call on
+ * it, satisfy the claim, close — in the middle of the outer sequence.
+ *
+ * Two things the model predicts, and only a random interleaving exercises:
+ *
+ * - closing a scope verifies EVERY live context, the outer one included, so
+ *   the close throws exactly when the outer ledger's claims are violated at
+ *   that moment — accounting is wider than isolation;
+ * - whether the close threw or not, the inner double dies with its context
+ *   (a later call meets `ForgottenDouble`) and the outer model is untouched:
+ *   a scope checks, it never settles.
+ */
+final readonly class ScopeInterludeCommand implements Command
+{
+    #[\Override]
+    public function preCondition(mixed $model): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function nextState(mixed $model): EngineState
+    {
+        \assert($model instanceof EngineState);
+
+        return $model;
+    }
+
+    /**
+     * @return array{threw: bool, innerRetired: bool, innerAnswer: ?Book}
+     */
+    #[\Override]
+    public function run(mixed $model, mixed $system): array
+    {
+        \assert($system instanceof EngineHarness);
+
+        $inner = null;
+        $answer = null;
+        $threw = false;
+
+        try {
+            Understudy::scope(static function () use (&$inner, &$answer): void {
+                /** @var BookRepository $inner */
+                $inner = Understudy::for(BookRepository::class);
+                Understudy::expect(static fn(): ?Book => $inner->find(9))->returns(null);
+                $answer = $inner->find(9);
+            });
+        } catch (VerificationFailed) {
+            $threw = true;
+        }
+
+        \assert($inner instanceof BookRepository);
+
+        $retired = false;
+
+        try {
+            $inner->find(9);
+        } catch (ForgottenDouble) {
+            $retired = true;
+        }
+
+        if ($threw) {
+            ++$system->refusedScopeCloses;
+        } else {
+            ++$system->cleanScopeCloses;
+        }
+
+        return ['threw' => $threw, 'innerRetired' => $retired, 'innerAnswer' => $answer];
+    }
+
+    #[\Override]
+    public function postCondition(mixed $model, mixed $result): bool
+    {
+        \assert($model instanceof EngineState);
+        \assert(\is_array($result));
+
+        // The inner cast is self-contained and satisfied, so the close throws
+        // for exactly one reason: the OUTER ledger's claims were violated when
+        // the scope's verify swept every live context.
+        return $result['threw'] === $model->claimsViolated()
+            && $result['innerRetired'] === true
+            && $result['innerAnswer'] === null;
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return 'scope(inner cast)';
+    }
+}


### PR DESCRIPTION
Closes the last gap of the design plan's §8: the stateful model over the engine loop (`stub/expect → dispatch → verify → checkpoint → scope`) covered everything but `scope`.

`ScopeInterludeCommand` runs a complete nested `scope()` life in the middle of the outer sequence — inner double, a claim satisfied inside, close — and the model predicts what only a random interleaving exercises:

- **the close throws exactly when the outer ledger's claims are violated at that instant** — `scope()`'s verify sweeps every live context, the same predicate `VerifyEverythingCommand` already models;
- either way **the inner double dies with its context** (`ForgottenDouble` on a later call) and **the outer model is untouched** — a scope checks, it never settles, proven by the trailing dispatch/verify in the examples.

Both close outcomes are pinned by deterministic `Examples` before the random phase; the command's reachability is `Classify::cover`-gated at 5% with the two outcomes labelled via `Classify::when` (a floor on the branch split would gate on the outer ledger's distribution — the AGENTS trap about flaky cover thresholds). Property run is stable across six fresh seeds; full `composer build` green.

Test-strengthening only (no engine change, honest-coverage exemption from issue-first). Also retires the AGENTS.md pointer to `_plans/UNDERSTUDY-PLAN.md` — milestones 0–7 shipped in full and the plan file is being removed from the monorepo.