### PR TITLE
Hunt the escaped mutants: 240 → 158, MSI 90.4 → 94.0, gate to 92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- **The escaped-mutant hunt: 240 → 158, MSI 90.4% → 94.0%, gate raised to 92**
+  (the full trajectory and the reason live next to the number in
+  `infection.json5`). About sixty targeted tests and fixtures, each written
+  from an escaped mutant's diff rather than from the line it sits on:
+  constant defaults now assert their rendered SOURCE (`\Cfg::LIMIT`, uppercase
+  `SELF::`/`PARENT::` resolved through the declaring hierarchy) where the old
+  tests compared values a mutant renders identically; static satisfaction
+  gets its satisfied complements (a type-distinct variadic tail, untyped and
+  union return contracts); by-reference detection is asserted at every
+  parameter position; `FinalStripper` pins the glued-comment and bare
+  `final const` boundaries; settle() is pinned to drop satisfied claims and
+  keep every stub; Fiber routing is pinned for by-reference returns,
+  `callOriginal()` and ordering claims; the structured failure fields
+  (`actualCount`, both bounds of `unused()`, `observedCalls` filtering,
+  `expectedCalls` as strings, both halves of `allVerified()`) are asserted
+  exactly, as are six refusal messages formerly checked by fragments. Three
+  more test classes attribute `#[Covers]` they exercised all along. Three
+  manual arbitrations confirmed the remainder is dominated by genuine
+  equivalents — redundant second guards, set-map values read through
+  `array_keys()`, perf fastpaths, warning-only offsets.
+
+## Unreleased
+
 - **Honest-coverage sweep after 0.4.0.** Twelve targeted tests kill the
   escaped mutants the new code left behind (hooked-property collection and
   rendering, cross-Fiber property routing, forwarding write-through, captor

--- a/infection.json5
+++ b/infection.json5
@@ -8,7 +8,14 @@
         "summary": "build/infection-summary.log"
     },
     "testFramework": "testo",
-    "minMsi": 90,
+    // 90 -> 92 on 2026-08-28: the escaped-mutant hunt took the local full run
+    // from 240 escaped / 90.4% to 158 / 94.0% (three manual arbitrations
+    // confirmed the remainder is dominated by genuine equivalents: redundant
+    // second guards, set-map values read through array_keys, perf fastpaths,
+    // warning-only offsets). Two points of headroom stay because the CI
+    // mutant count differs from the local one by dozens and a pair of
+    // SELF-case mutants flip between runs.
+    "minMsi": 92,
     "mutators": {
         "@default": true,
         // Raw-I/O passthroughs. Each of these forwards one call to the native

--- a/tests/Bypass/FinalStripperTest.php
+++ b/tests/Bypass/FinalStripperTest.php
@@ -84,6 +84,58 @@ final class FinalStripperTest
             '<?php namespace App; readonly class Money {}',
         ];
 
+        // The strip removes the `final` token and the ONE space after it —
+        // never a newline, whose loss would shift every line below, and never
+        // more than one space. A comment or a tab is whitespace enough for
+        // the lookahead but is not the single space the strip may eat.
+        yield 'a newline after final is kept' => [
+            "<?php namespace App; final\nclass Gate {}",
+            [['namespace' => 'App', 'class' => 'Gate']],
+            "<?php namespace App; \nclass Gate {}",
+        ];
+
+        yield 'a double space loses only what the token rule says' => [
+            '<?php namespace App; final  class Gate {}',
+            [['namespace' => 'App', 'class' => 'Gate']],
+            '<?php namespace App; class Gate {}',
+        ];
+
+        yield 'a comment between final and class survives' => [
+            '<?php namespace App; final /* sealed */ class Gate {}',
+            [['namespace' => 'App', 'class' => 'Gate']],
+            '<?php namespace App; /* sealed */ class Gate {}',
+        ];
+
+        yield 'a tab after final' => [
+            "<?php namespace App; final\tclass Gate {}",
+            [['namespace' => 'App', 'class' => 'Gate']],
+            '<?php namespace App; class Gate {}',
+        ];
+
+        yield 'a comment glued to final is not the one space the strip may eat' => [
+            '<?php namespace App; final/* sealed */class Gate {}',
+            [['namespace' => 'App', 'class' => 'Gate']],
+            '<?php namespace App; /* sealed */class Gate {}',
+        ];
+
+        yield 'a bare final const is a member, not a class' => [
+            '<?php namespace App; class Gate { final const KEY = 1; }',
+            null,
+            '<?php namespace App; class Gate { final const KEY = 1; }',
+        ];
+
+        yield 'a string literal naming the class is untouched' => [
+            '<?php namespace App; $x = "final class Gate"; final class Gate {}',
+            [['namespace' => 'App', 'class' => 'Gate']],
+            '<?php namespace App; $x = "final class Gate"; class Gate {}',
+        ];
+
+        yield 'a name the target merely prefixes keeps its final' => [
+            '<?php namespace App; final class Gate {} final class GateKeeper {}',
+            [['namespace' => 'App', 'class' => 'Gate']],
+            '<?php namespace App; class Gate {} final class GateKeeper {}',
+        ];
+
         yield 'the keyword is case-insensitive, like PHP' => [
             '<?php namespace App; FINAL class Gate {}',
             [['namespace' => 'App', 'class' => 'Gate']],

--- a/tests/CaptorTest.php
+++ b/tests/CaptorTest.php
@@ -240,6 +240,24 @@ final class CaptorTest
         Assert::same($options->all(), []);
     }
 
+    /**
+     * The verify-side capture registers with the context the same way the
+     * dispatch-side one does: a reset leaves the captor empty.
+     */
+    public function resetDropsWhatAVerifyCaptured(): void
+    {
+        $this->store->temporaryUrl('a.pdf', new \DateTimeImmutable(), new DeliveryOptions('claimed.pdf'));
+
+        $options = Arg::captor(DeliveryOptions::class);
+        verify(fn(): ?string => $this->store->temporaryUrl(Arg::any(), Arg::any(), $options->capture()), times: 1);
+
+        Assert::same(count($options->all()), 1);
+
+        Understudy::reset();
+
+        Assert::same($options->all(), []);
+    }
+
     public function aClosingScopeDropsWhatItCaptured(): void
     {
         $options = Arg::captor(DeliveryOptions::class);

--- a/tests/ClassDoubleTest.php
+++ b/tests/ClassDoubleTest.php
@@ -42,6 +42,7 @@ use function Rasuvaeff\Understudy\when;
 
 #[Test]
 #[Covers(DoubleFactory::class)]
+#[Covers(Understudy::class)]
 #[Covers(PropertyDefaults::class)]
 #[Covers(TargetUnifier::class)]
 #[Covers(Blueprint::class)]
@@ -353,6 +354,48 @@ final class ClassDoubleTest
     }
 
     // --- Rejections ---------------------------------------------------------
+
+    /**
+     * `final` on a STATIC method rejects nothing: statics are not intercepted,
+     * so there is nothing a final one could hide from the double.
+     */
+    public function aFinalStaticMethodDoesNotRejectTheTarget(): void
+    {
+        $class = 'FinalStaticHost_' . PHP_VERSION_ID;
+        eval(sprintf(
+            'namespace %s; class %s { final public static function seal(): int { return 1; } public function plain(): int { return 2; } }',
+            __NAMESPACE__,
+            $class,
+        ));
+
+        /** @var class-string $fqcn */
+        $fqcn = __NAMESPACE__ . '\\' . $class;
+        $double = Understudy::for($fqcn);
+
+        Assert::same($double->plain(), 0);
+    }
+
+    /**
+     * The final-member walk reads EVERY method: a final instance method after
+     * a perfectly ordinary one still rejects the target.
+     */
+    public function aFinalMethodAfterAPlainOneStillRejects(): void
+    {
+        $class = 'LateFinalHost_' . PHP_VERSION_ID;
+        eval(sprintf(
+            'namespace %s; class %s { public function plain(): int { return 1; } final public function sealed(): int { return 2; } }',
+            __NAMESPACE__,
+            $class,
+        ));
+
+        /** @var class-string $fqcn */
+        $fqcn = __NAMESPACE__ . '\\' . $class;
+
+        Expect::exception(UnsupportedTarget::class)
+            ->withMessageContaining('::sealed()` is final and cannot be overridden');
+
+        Understudy::for($fqcn);
+    }
 
     public function aFinalClassIsRejected(): void
     {

--- a/tests/Codegen/TargetUnifierTest.php
+++ b/tests/Codegen/TargetUnifierTest.php
@@ -22,6 +22,9 @@ use Rasuvaeff\Understudy\Tests\Fixture\Unify\BothIterableCountable;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\CallableFactory;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ClassUnionFirst;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ClosureFactory;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ConstantDefaultBase;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ConstantDefaults;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ConstantsInterface;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\CountableValue;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\DnfParam;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\DnfParamToo;
@@ -39,6 +42,7 @@ use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntersectionBeta;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntReturn;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\IntTailPlain;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\IterableAll;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\KnownConstants;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\MixedTail;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\MixedValue;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\MixedWriter;
@@ -54,6 +58,7 @@ use Rasuvaeff\Understudy\Tests\Fixture\Unify\PrimaryNamed;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderInt;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderString;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderStringy;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\ReaderUntyped;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SecondaryNamed;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SelfReturn;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SelfValue;
@@ -61,6 +66,7 @@ use Rasuvaeff\Understudy\Tests\Fixture\Unify\Showcase;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\Sibling;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SlotsByRef;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\SlotsByValue;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticIntPartsContract;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticMixedPartsContract;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticOptionalContract;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPartsContract;
@@ -71,12 +77,14 @@ use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingContract;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingExtraRequired;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingFixedInsteadOfTail;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingFixedThenTail;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingIntThenTail;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingNarrowerParameter;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingOptional;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingOptionalInsteadOfTail;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingProtected;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingRequiredParameter;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingTooFewParameters;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingTypedReturn;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingVariadicTail;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticPingWiderParameter;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticReferenceReturnContract;
@@ -84,6 +92,8 @@ use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticReturn;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticSlotContract;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticStringReturnContract;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticTailContract;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticUnionReturnContract;
+use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticUntypedReturnContract;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StaticValue;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StdClassAll;
 use Rasuvaeff\Understudy\Tests\Fixture\Unify\StdClassFactory;
@@ -938,6 +948,104 @@ final class TargetUnifierTest
             $signature->returnType,
             '\Stringable&\\' . BothIterableCountable::class . '&\JsonSerializable',
         );
+    }
+
+    // --- Constant defaults render as their declared form ---------------------
+
+    /**
+     * The value alone cannot tell `= \\Cfg::LIMIT` from `= 5`, so the rendered
+     * SOURCE is asserted: a constant default keeps its name, resolved through
+     * the class that declares it — `SELF`/`PARENT` (case included) never
+     * follow the double into a class that never had the constant.
+     */
+    #[DataProvider('constantDefaultProvider')]
+    public function rendersAConstantDefaultByItsDeclaredName(string $method, string $expected): void
+    {
+        $signature = TargetUnifier::unify([new \ReflectionClass(ConstantDefaults::class)])[$method];
+
+        Assert::same($signature->parameters, $expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function constantDefaultProvider(): iterable
+    {
+        $m = self::MATCHER;
+
+        yield "another class's constant" => [
+            'viaClass',
+            "int|{$m} \$a = \\" . KnownConstants::class . '::LIMIT',
+        ];
+        yield 'SELF resolves to the declaring class, whatever the case' => [
+            'viaSelfUpper',
+            "int|{$m} \$a = \\" . ConstantDefaults::class . '::MINE',
+        ];
+        yield 'PARENT resolves to the parent class, not the declaring one' => [
+            'viaParentUpper',
+            "int|{$m} \$a = \\" . ConstantDefaultBase::class . '::FROM_PARENT',
+        ];
+        yield 'an interface constant' => [
+            'viaInterfaceConstant',
+            "string|{$m} \$a = \\" . ConstantsInterface::class . '::MODE',
+        ];
+    }
+
+    // --- Reference detection -------------------------------------------------
+
+    /**
+     * `hasReferenceParameters` gates the by-reference snapshots, so it must
+     * fold across every position — a `&` anywhere makes it true, none makes
+     * it false, whichever side of the parameter list it sits on.
+     */
+    public function referenceDetectionFoldsAcrossEveryPosition(): void
+    {
+        Assert::false($this->showcase('scalar')->hasReferenceParameters);
+        Assert::true($this->showcase('byReference')->hasReferenceParameters);
+        Assert::true($this->showcase('refFirst')->hasReferenceParameters);
+        Assert::true($this->showcase('refSecond')->hasReferenceParameters);
+    }
+
+    // --- Static satisfaction: the variadic tail and the return branches ------
+
+    /**
+     * The satisfied complement of the misalignment tests above: the tail is
+     * the LAST declared parameter, and it is that parameter — not the first —
+     * that stretches over the contract's remaining ones. `$first` is `int`
+     * and the tail is `string` precisely so that reading the wrong end is a
+     * type mismatch rather than a coincidence.
+     */
+    public function aStaticVariadicTailSatisfiesTypeDistinctRemainingParameters(): void
+    {
+        Assert::false(
+            array_key_exists('ping', $this->unify(StaticPingIntThenTail::class, StaticIntPartsContract::class)),
+        );
+    }
+
+    public function aTypedStaticImplementationSatisfiesAnUntypedContract(): void
+    {
+        Assert::false(
+            array_key_exists('ping', $this->unify(StaticPingTypedReturn::class, StaticUntypedReturnContract::class)),
+        );
+    }
+
+    public function aStaticBranchOfAUnionReturnSatisfiesTheContract(): void
+    {
+        Assert::false(
+            array_key_exists('ping', $this->unify(StaticPingTypedReturn::class, StaticUnionReturnContract::class)),
+        );
+    }
+
+    // --- Untyped returns unify with typed ones -------------------------------
+
+    /**
+     * A declaration with no return type allows anything, so the typed
+     * declaration is the one every target satisfies — the unified return is
+     * `int`, not a refusal and not `mixed`.
+     */
+    public function anUntypedReturnIsAbsorbedByTheTypedOne(): void
+    {
+        Assert::same($this->unify(ReaderUntyped::class, ReaderInt::class)['read']->returnType, 'int');
     }
 
     /**

--- a/tests/ConflictingExpectationTest.php
+++ b/tests/ConflictingExpectationTest.php
@@ -110,8 +110,11 @@ final class ConflictingExpectationTest
 
         // times() turned the stub into a claim about counts, so a later stub
         // for the same call would starve it exactly like an expect().
-        Expect::exception(ConflictingExpectation::class)->withMessageContaining(
-            'Give the expectation its behaviour instead',
+        Expect::exception(ConflictingExpectation::class)->withMessage(
+            'Understudy `BookRepository` already counts `count()`, and a later stub for the same call would '
+            . 'not compose with it: the stub would take the dispatch and starve the count, which verifyAll() '
+            . 'then reports as "called never" about a call that did happen. Give the expectation its '
+            . 'behaviour instead: expect(...)->returns(...).',
         );
 
         when(fn() => $repository->count());

--- a/tests/DefaultFactoriesTest.php
+++ b/tests/DefaultFactoriesTest.php
@@ -29,6 +29,7 @@ use Testo\Test;
 
 #[Test]
 #[Covers(DefaultFactories::class)]
+#[Covers(\Rasuvaeff\Understudy\Runtime\Runtime::class)]
 #[Covers(ForgottenDouble::class)]
 #[Covers(TypeDefaultResolver::class)]
 final class DefaultFactoriesTest
@@ -365,10 +366,94 @@ final class DefaultFactoriesTest
         Understudy::defaults(Logger::class, static fn(): Logger => $forgotten);
         $workspace = Understudy::for(Workspace::class);
 
-        Expect::exception(ForgottenDouble::class)
-            ->withMessageContaining('register the factory inside the test that uses it');
+        Expect::exception(ForgottenDouble::class)->withMessage(
+            'The default factory for `' . Logger::class . "` answered with an understudy that is no longer known to Understudy.\n"
+            . 'It was created before a reset(); register the factory inside the test that uses it '
+            . 'rather than sharing one double across tests.',
+        );
 
         $workspace->logger();
+    }
+
+    /**
+     * `AuditedLogger` is two steps from `Logger` (through `Audited`), so a
+     * registration for the grandparent alone is found by the second level of
+     * the walk — the one that has to flatten an interface's own parents.
+     */
+    public function aGrandparentRegistrationAloneIsStillFound(): void
+    {
+        $pinned = new AuditedLogger();
+        Understudy::defaults(Logger::class, static fn(): AuditedLogger => $pinned);
+
+        $workspace = Understudy::for(Workspace::class);
+
+        Assert::same($workspace->auditor(), $pinned);
+    }
+
+    /**
+     * The registry consulted is the OWNER's, not the one of whichever Fiber
+     * happens to be running: a call made from a Fiber still answers with what
+     * the owning test registered.
+     */
+    public function aCallFromAFiberAnswersWithTheOwnersRegistration(): void
+    {
+        $pinned = new AuditedLogger();
+        Understudy::defaults(Logger::class, static fn(): AuditedLogger => $pinned);
+        $workspace = Understudy::for(Workspace::class);
+
+        $answered = null;
+        $fiber = new \Fiber(static function () use ($workspace, &$answered): void {
+            $answered = $workspace->logger();
+        });
+        $fiber->start();
+
+        Assert::same($answered, $pinned);
+    }
+
+    /**
+     * A nested double is a full citizen of the owner's context: calling a
+     * method ON it answers the loose default, and a call made from a Fiber is
+     * routed back to the owner that adopted it.
+     */
+    public function aNestedDoubleAnswersItsOwnCallsFromAnyFiber(): void
+    {
+        $workspace = Understudy::for(Workspace::class);
+        $chained = $workspace->chained();
+
+        Assert::same($chained->name(), '');
+
+        $named = null;
+        $fiber = new \Fiber(static function () use ($chained, &$named): void {
+            $named = $chained->name();
+        });
+        $fiber->start();
+
+        Assert::same($named, '');
+    }
+
+    /**
+     * A registration outranks `null` on BOTH spellings of a nullable return:
+     * the `?Logger` shorthand and the written `Logger|null` union resolve the
+     * same registered instance, and `null` stays the answer only when nobody
+     * said anything better.
+     */
+    public function aRegistrationOutranksNullOnEitherNullableSpelling(): void
+    {
+        $pinned = new AuditedLogger();
+        Understudy::defaults(Logger::class, static fn(): AuditedLogger => $pinned);
+
+        $workspace = Understudy::for(Workspace::class);
+
+        Assert::same($workspace->maybe(), $pinned);
+        Assert::same($workspace->optionalLogger(), $pinned);
+    }
+
+    public function bothNullableSpellingsAnswerNullWithoutARegistration(): void
+    {
+        $workspace = Understudy::for(Workspace::class);
+
+        Assert::null($workspace->maybe());
+        Assert::null($workspace->optionalLogger());
     }
 
     public function resetDropsTheRegistry(): void

--- a/tests/Fixture/Def/Workspace.php
+++ b/tests/Fixture/Def/Workspace.php
@@ -20,6 +20,10 @@ interface Workspace
 
     public function counted(): int;
 
+    public function maybe(): ?Logger;
+
+    public function optionalLogger(): ?Logger;
+
     /** Neither branch can be doubled and neither has a builtin default. */
     public function hopeless(): NullLogger|Sealed;
 

--- a/tests/Fixture/Unify/ConstantDefaultBase.php
+++ b/tests/Fixture/Unify/ConstantDefaultBase.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+abstract class ConstantDefaultBase
+{
+    public const int FROM_PARENT = 9;
+}

--- a/tests/Fixture/Unify/ConstantDefaults.php
+++ b/tests/Fixture/Unify/ConstantDefaults.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+/**
+ * Every spelling of a constant default whose rendered SOURCE matters — the
+ * value alone cannot tell `= \Cfg::LIMIT` from `= 5`, and faithfulness to the
+ * declared form is what the renderer promises. `SELF`/`PARENT` are uppercase
+ * on purpose: Reflection preserves the case, and the resolver must not.
+ */
+class ConstantDefaults extends ConstantDefaultBase
+{
+    public const int MINE = 2;
+
+    public function viaClass(int $a = KnownConstants::LIMIT): void {}
+
+    public function viaSelfUpper(int $a = self::MINE): void {}
+
+    public function viaParentUpper(int $a = parent::FROM_PARENT): void {}
+
+    public function viaInterfaceConstant(string $a = ConstantsInterface::MODE): void {}
+}

--- a/tests/Fixture/Unify/ConstantsInterface.php
+++ b/tests/Fixture/Unify/ConstantsInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ConstantsInterface
+{
+    public const string MODE = 'on';
+}

--- a/tests/Fixture/Unify/KnownConstants.php
+++ b/tests/Fixture/Unify/KnownConstants.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+class KnownConstants
+{
+    public const int LIMIT = 5;
+}

--- a/tests/Fixture/Unify/ReaderUntyped.php
+++ b/tests/Fixture/Unify/ReaderUntyped.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface ReaderUntyped
+{
+    /** @return mixed */
+    public function read();
+}

--- a/tests/Fixture/Unify/Showcase.php
+++ b/tests/Fixture/Unify/Showcase.php
@@ -22,6 +22,10 @@ interface Showcase
 
     public function byReference(array &$slot): void;
 
+    public function refFirst(array &$slot, int $extra): void;
+
+    public function refSecond(int $extra, array &$slot): void;
+
     public function untyped($a): void;
 
     public function intersection(ReaderInt&ReaderStringy $a): void;

--- a/tests/Fixture/Unify/StaticIntPartsContract.php
+++ b/tests/Fixture/Unify/StaticIntPartsContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface StaticIntPartsContract
+{
+    public static function ping(int $first, string $second, string $third): int;
+}

--- a/tests/Fixture/Unify/StaticPingIntThenTail.php
+++ b/tests/Fixture/Unify/StaticPingIntThenTail.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+class StaticPingIntThenTail
+{
+    public static function ping(int $first, string ...$rest): int
+    {
+        return $first + count($rest);
+    }
+}

--- a/tests/Fixture/Unify/StaticPingTypedReturn.php
+++ b/tests/Fixture/Unify/StaticPingTypedReturn.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+class StaticPingTypedReturn
+{
+    public static function ping(): int
+    {
+        return 1;
+    }
+}

--- a/tests/Fixture/Unify/StaticUnionReturnContract.php
+++ b/tests/Fixture/Unify/StaticUnionReturnContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface StaticUnionReturnContract
+{
+    public static function ping(): int|string;
+}

--- a/tests/Fixture/Unify/StaticUntypedReturnContract.php
+++ b/tests/Fixture/Unify/StaticUntypedReturnContract.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Unify;
+
+interface StaticUntypedReturnContract
+{
+    /** @return mixed */
+    public static function ping();
+}

--- a/tests/LastCallAndForgetTest.php
+++ b/tests/LastCallAndForgetTest.php
@@ -127,8 +127,11 @@ final class LastCallAndForgetTest
         // Asking anything about a retired double — its calls, its accounting —
         // is a question about an object the test replaced; say so rather than
         // silently passing or reporting a closure problem that is not there.
-        Expect::exception(ForgottenDouble::class)
-            ->withMessageContaining('retired with Understudy::forget()');
+        Expect::exception(ForgottenDouble::class)->withMessage(
+            'This understudy was retired with Understudy::forget() and can no longer be asked '
+            . 'anything — not calls, not verification. A replacement built afterwards is a '
+            . 'different object; ask that one.',
+        );
 
         Understudy::nothingElse($replaced);
     }
@@ -139,16 +142,20 @@ final class LastCallAndForgetTest
         when(fn() => $repository->find(Arg::any()))->returns(new Book('title'));
         Understudy::forget($repository);
 
-        Expect::exception(ForgottenDouble::class)
-            ->withMessageContaining('retired with Understudy::forget()');
+        Expect::exception(ForgottenDouble::class)->withMessage(
+            "This understudy was retired with Understudy::forget(), but `find()` was called on it.\n"
+            . 'A forgotten double is gone for good; build a new one instead of calling this one.',
+        );
 
         $repository->find(1);
     }
 
     public function forgettingANonDoubleIsRefusedByName(): void
     {
-        Expect::exception(InvalidCallSpecification::class)
-            ->withMessageContaining('expects an understudy created by Understudy::for()');
+        Expect::exception(InvalidCallSpecification::class)->withMessage(
+            'Understudy::forget() expects an understudy created by Understudy::for(). '
+            . 'This object is not one.',
+        );
 
         Understudy::forget(new \stdClass());
     }

--- a/tests/LedgerTest.php
+++ b/tests/LedgerTest.php
@@ -20,6 +20,9 @@ use Rasuvaeff\Understudy\Runtime\RuntimeContext;
 use Rasuvaeff\Understudy\Tests\Fixture\Book;
 use Rasuvaeff\Understudy\Tests\Fixture\BookRepository;
 use Rasuvaeff\Understudy\Tests\Fixture\Clock;
+use Rasuvaeff\Understudy\Tests\Fixture\Fwd\Chainable;
+use Rasuvaeff\Understudy\Tests\Fixture\Fwd\RealChain;
+use Rasuvaeff\Understudy\Tests\Fixture\Ref\Registry;
 use Rasuvaeff\Understudy\Tests\Support\GoldenMessage;
 use Rasuvaeff\Understudy\Understudy;
 use Rasuvaeff\Understudy\VerificationFailure;
@@ -935,6 +938,216 @@ final class LedgerTest
         $repository->count();
 
         Understudy::verifyAll();
+    }
+
+    // --- What settle() keeps and what it drops --------------------------------
+
+    /**
+     * A satisfied claim is DONE and settle drops it: a call after the
+     * checkpoint must not be counted against the old cardinality, or a phase
+     * boundary would turn a clean second phase into "called 2 times".
+     */
+    #[ExpectNoAssertions]
+    public function aSettledClaimDoesNotCountTheNextPhasesCalls(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        expect(fn() => $repository->count())->returns(1);
+
+        $repository->count();
+        Understudy::checkpoint();
+
+        $repository->count();
+        Understudy::verifyAll();
+    }
+
+    /**
+     * Settle rebuilds the per-method map by APPENDING: two surviving stubs of
+     * one method must both come through, or the older fallback silently
+     * vanishes at every phase boundary.
+     */
+    public function settleKeepsEveryStubOfAMethod(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        when(fn() => $repository->find(1))->returns(new Book('one'));
+        when(fn() => $repository->find(2))->returns(new Book('two'));
+
+        Understudy::checkpoint();
+
+        Assert::same($repository->find(1)?->title, 'one');
+        Assert::same($repository->find(2)?->title, 'two');
+    }
+
+    // --- The literal index keeps the walked fallbacks reachable ---------------
+
+    /**
+     * A matcher-first specification has no literal key and must stay in the
+     * walked list: once a second expectation puts the method under the index,
+     * the wildcard still answers the calls the literal one does not.
+     */
+    public function aWildcardStubStaysReachableUnderTheLiteralIndex(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        when(fn() => $repository->find(Arg::any()))->returns(new Book('fallback'));
+        when(fn() => $repository->find(2))->returns(new Book('exact'));
+
+        Assert::same($repository->find(2)?->title, 'exact');
+        Assert::same($repository->find(3)?->title, 'fallback');
+    }
+
+    // --- Fiber routing beyond plain dispatch ----------------------------------
+
+    /**
+     * A by-reference return from another Fiber still finds the OWNER's slot:
+     * both lookups on that path route by owner first, and a context that only
+     * exists inside the Fiber knows nothing about the double.
+     */
+    public function aByReferenceReturnFromAnotherFiberUsesTheOwnersSlot(): void
+    {
+        $registry = Understudy::for(Registry::class);
+
+        $fiber = new \Fiber(static function () use ($registry): void {
+            $slot = &$registry->values();
+            $slot[] = 'written in the fiber';
+        });
+        $fiber->start();
+
+        Assert::same($registry->values(), ['written in the fiber']);
+    }
+
+    /**
+     * `callOriginal()` inside an answer, reached from another Fiber, delegates
+     * through the owner's state — the running Fiber's empty context is not
+     * where the forwarding target lives.
+     */
+    public function callOriginalFromAnotherFiberFindsTheOwnersTarget(): void
+    {
+        $real = new RealChain();
+        $double = Understudy::for(Chainable::class);
+        Understudy::forwarding($double, $real);
+        when(fn(): string => $double->label())
+            ->answers(static fn(Invocation $call): string => strtoupper((string) $call->callOriginal()));
+
+        $answered = null;
+        $fiber = new \Fiber(static function () use ($double, &$answered): void {
+            $answered = $double->label();
+        });
+        $fiber->start();
+
+        Assert::same($answered, 'REAL');
+    }
+
+    /**
+     * A forgotten double's by-reference method fails with the same
+     * `ForgottenDouble` a plain call gets — not with a type error from the
+     * lookup that ran before dispatch could say it properly.
+     */
+    public function aByReferenceCallOnAForgottenDoubleSaysForgotten(): void
+    {
+        $registry = Understudy::for(Registry::class);
+        Understudy::reset();
+
+        Expect::exception(ForgottenDouble::class);
+
+        $registry->values();
+    }
+
+    /**
+     * Ordering claims of a Fiber-owned context are judged against THAT
+     * context's own counting: two ordered expectations satisfied in reverse
+     * inside a Fiber must fail `verifyAll()` called from the main flow.
+     */
+    public function orderingInsideAFiberIsJudgedByItsOwnContext(): void
+    {
+        $fiber = new \Fiber(static function (): void {
+            $repository = Understudy::for(BookRepository::class);
+            expect(fn() => $repository->count())->ordered()->returns(1);
+            expect(fn() => $repository->titles())->ordered()->returns([]);
+
+            $repository->titles();
+            $repository->count();
+            \Fiber::suspend();
+        });
+        $fiber->start();
+
+        Expect::exception(VerificationFailed::class)
+            ->withMessageContaining('to be called after');
+
+        try {
+            Understudy::verifyAll();
+        } finally {
+            $fiber->resume();
+        }
+    }
+
+    // --- Outcome recording is first-writer-wins ------------------------------
+
+    /**
+     * An invocation's outcome is written once, by whoever answers first, and
+     * every later writer is a no-op — including the lean discard, and
+     * including the legacy Outcome wrapper, in both directions.
+     */
+    public function anOutcomeIsRecordedExactlyOnce(): void
+    {
+        $returned = new Invocation('m', [], 1);
+        $returned->recordReturned('first');
+        $returned->recordThrown(new \DomainException('late'));
+        $returned->recordDiscardedReturn();
+
+        Assert::true($returned->didReturn());
+        Assert::false($returned->didThrow());
+        Assert::same($returned->returned(), 'first');
+
+        $threw = new Invocation('m', [], 2);
+        $threw->recordThrown(new \DomainException('kept'));
+        $threw->recordReturned('late');
+
+        Assert::true($threw->didThrow());
+        Assert::instanceOf($threw->thrown(), \DomainException::class);
+
+        $legacy = new Invocation('m', [], 3);
+        $legacy->recordOutcome(Outcome::returnedValue('wrapped'));
+        $legacy->recordReturned('late');
+
+        Assert::true($legacy->didReturn());
+        Assert::false($legacy->didThrow());
+        Assert::same($legacy->returned(), 'wrapped');
+
+        $legacyThrew = new Invocation('m', [], 4);
+        $legacyThrew->recordOutcome(Outcome::thrownError(new \DomainException('wrapped')));
+
+        Assert::false($legacyThrew->didReturn());
+        Assert::true($legacyThrew->didThrow());
+    }
+
+    // --- The context answers plainly for its own state ------------------------
+
+    public function aFreshContextIsNotRecordingAndHoldsNoCaptors(): void
+    {
+        $context = new RuntimeContext();
+
+        Assert::false($context->isRecording());
+        Assert::same($context->captors(), []);
+    }
+
+    /**
+     * Retirement walks EVERY double the context held: after a reset, both are
+     * forgotten, not just the first one the storage yielded.
+     */
+    public function aResetRetiresEveryDoubleOfTheContext(): void
+    {
+        $first = Understudy::for(BookRepository::class);
+        $second = Understudy::for(BookRepository::class);
+
+        Understudy::reset();
+
+        foreach ([$first, $second] as $double) {
+            try {
+                $double->count();
+                Assert::true(false);
+            } catch (ForgottenDouble) {
+                Assert::true(true);
+            }
+        }
     }
 
     // --- scope and checkpoint ------------------------------------------------

--- a/tests/PropertyHooksTest.php
+++ b/tests/PropertyHooksTest.php
@@ -323,6 +323,44 @@ final class PropertyHooksTest
         Assert::same($double->tag, 'both');
     }
 
+    /**
+     * The union folds each hook independently: a get-only and a set-only
+     * declaration of one property meet in a double that can do both.
+     */
+    public function aGetOnlyAndASetOnlyDeclarationUnionIntoBoth(): void
+    {
+        if ($this->onOldPhp()) {
+            return;
+        }
+
+        $reader = $this->declare('UnionGetHalf', 'namespace %s; interface %s { public string $tag { get; } }');
+        $writer = $this->declare('UnionSetHalf', 'namespace %s; interface %s { public string $tag { set; } }');
+
+        $double = Understudy::for($reader, $writer);
+        $double->tag = 'both halves';
+
+        Assert::same($double->tag, 'both halves');
+    }
+
+    /**
+     * And when both targets declare both hooks, both survive — a fold that
+     * needed agreement instead of presence would quietly drop one.
+     */
+    public function twoFullDeclarationsKeepBothHooks(): void
+    {
+        if ($this->onOldPhp()) {
+            return;
+        }
+
+        $one = $this->declare('UnionFullOne', 'namespace %s; interface %s { public string $tag { get; set; } }');
+        $two = $this->declare('UnionFullTwo', 'namespace %s; interface %s { public string $tag { get; set; } }');
+
+        $double = Understudy::for($one, $two);
+        $double->tag = 'kept';
+
+        Assert::same($double->tag, 'kept');
+    }
+
     // --- Forwarding ----------------------------------------------------------
 
     public function aForwardingDoubleDelegatesReadsAndWritesToTheRealInstance(): void
@@ -393,8 +431,11 @@ final class PropertyHooksTest
         $stringy = $this->declare('TypeString', 'namespace %s; interface %s { public string $tag { get; } }');
         $inty = $this->declare('TypeInt', 'namespace %s; interface %s { public int $tag { get; } }');
 
-        Expect::exception(UnsupportedTarget::class)
-            ->withMessageContaining('property `$tag` is declared `int` here and `string` by another target');
+        Expect::exception(UnsupportedTarget::class)->withMessage(
+            'Cannot create an understudy for `' . $inty . '`: property `$tag` is declared `int` here and '
+            . '`string` by another target. Property types are invariant, so no single declaration '
+            . 'satisfies both.',
+        );
 
         Understudy::for($stringy, $inty);
     }
@@ -425,8 +466,11 @@ final class PropertyHooksTest
 
         Understudy::reset();
 
-        Expect::exception(ForgottenDouble::class)
-            ->withMessageContaining('its property `$name` was touched');
+        Expect::exception(ForgottenDouble::class)->withMessage(
+            "This understudy is no longer known to Understudy, but its property `\$name` was touched.\n"
+            . 'It was created before a reset(); create doubles inside the test that uses them '
+            . 'rather than sharing one across tests.',
+        );
 
         $double->name;
     }

--- a/tests/VerificationFailureTest.php
+++ b/tests/VerificationFailureTest.php
@@ -28,6 +28,7 @@ use function Rasuvaeff\Understudy\when;
  */
 #[Test]
 #[Covers(VerificationFailed::class)]
+#[Covers(Understudy::class)]
 #[Covers(VerificationFailure::class)]
 #[Covers(FailureKind::class)]
 final class VerificationFailureTest
@@ -222,5 +223,114 @@ final class VerificationFailureTest
     private function firstFailureOf(callable $body): VerificationFailure
     {
         return $this->catch($body)->failures()[0];
+    }
+
+    // --- The structured fields say exactly what happened ----------------------
+
+    /**
+     * A strict-stub failure is a claim about ZERO use: the record carries
+     * `actualCount: 0`, and the message is asserted whole — every half of a
+     * concatenation in one is a mutant `contains()` cannot see.
+     */
+    public function aStrictStubFailureCarriesZeroAndSaysItWhole(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        Understudy::label($repository, 'catalogue');
+        when(fn() => $repository->count())->returns(1);
+
+        try {
+            Understudy::verifyAll(strictStubs: true);
+            Assert::true(false);
+        } catch (VerificationFailed $failed) {
+            $failure = $failed->failures()[0];
+
+            Assert::same($failure->actualCount, 0);
+            Assert::same(
+                $failure->summary,
+                "Understudy `catalogue` has a stub for `count()` that was never used.\n"
+                . 'Remove it, or drop strictStubs if the call is genuinely optional.',
+            );
+        }
+    }
+
+    /**
+     * `unused()` claims a closed interval of exactly zero: both bounds are 0,
+     * and the observed calls are the ones that broke the claim.
+     */
+    public function anUnusedFailureClaimsExactlyZero(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $repository->count();
+
+        try {
+            Understudy::unused($repository);
+            Assert::true(false);
+        } catch (VerificationFailed $failed) {
+            $failure = $failed->failures()[0];
+
+            Assert::same($failure->expectedMinimum, 0);
+            Assert::same($failure->expectedMaximum, 0);
+            Assert::same($failure->actualCount, 1);
+        }
+    }
+
+    /**
+     * A failed `verify()` reports the calls of THE method it asked about:
+     * calls to other methods are noise the reader should not wade through.
+     */
+    public function aVerifyFailureObservesOnlyTheAskedMethod(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $repository->count();
+        $repository->titles();
+
+        try {
+            verify(fn() => $repository->count(), times: 5);
+            Assert::true(false);
+        } catch (VerificationFailed $failed) {
+            $observed = $failed->failures()[0]->observedCalls;
+
+            Assert::same(count($observed), 1);
+            Assert::same($observed[0]->method, 'count');
+        }
+    }
+
+    /**
+     * `allVerified()` reports BOTH halves when both are broken — the unmet
+     * claim and the unaccounted call — not whichever it met first.
+     */
+    public function allVerifiedReportsEveryBrokenHalf(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        expect(fn() => $repository->count());
+
+        $repository->titles();
+
+        try {
+            Understudy::allVerified($repository);
+            Assert::true(false);
+        } catch (VerificationFailed $failed) {
+            Assert::same(count($failed->failures()), 2);
+        }
+    }
+
+    /**
+     * A sequence mismatch renders its protocol as DESCRIPTIONS — strings a
+     * reporter can print — not as the probe machinery that produced them.
+     */
+    public function aSequenceFailureDescribesTheExpectedCallsAsStrings(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+        $repository->count();
+
+        try {
+            Understudy::verifySequence(
+                fn() => $repository->count(),
+                fn() => $repository->titles(),
+            );
+            Assert::true(false);
+        } catch (VerificationFailed $failed) {
+            Assert::same($failed->failures()[0]->expectedCalls, ['count()', 'titles()']);
+        }
     }
 }

--- a/tests/WireTest.php
+++ b/tests/WireTest.php
@@ -370,9 +370,11 @@ final class WireTest
 
     public function aByReferenceConstructorParameterIsRefused(): void
     {
-        Expect::exception(CannotWire::class)
-            ->withMessageContaining('`$sink` is taken by reference')
-            ->withMessageContaining('Overrides are values');
+        Expect::exception(CannotWire::class)->withMessage(
+            'Cannot wire `' . ReferenceConstructor::class . "`: `\$sink` is taken by reference.\n"
+            . 'Overrides are values, and passing one would quietly promise a reference semantics wire() does '
+            . 'not have. Build the subject yourself.',
+        );
 
         Understudy::wire(ReferenceConstructor::class);
     }


### PR DESCRIPTION
The debt A4 named, paid down as far as it honestly goes. Full-run trajectory: **2410/2666 killed (90.4%, 240 escaped) → 2516/2679 (94.0%, 158 escaped)**; the gate rises 90 → 92 with the rationale written next to the number, keeping two points of headroom for the CI-vs-local mutant-count variance and a pair of SELF-case mutants that flip between runs.

**Method.** Every killing test was designed from the escaped mutant's *diff* (extracted via `--show-mutations=max`), not from the line it sits on; where a diff refused to die as predicted, the mutant was applied by hand and the suite run against it — three arbitrations (`FinalStripper` glued-comment, resolver `ltrim`, resolver union-throw) turned "should die" into either a working kill or a confirmed equivalent.

**Kills, by cluster:**
- `TargetUnifier` 68 → 39: constant defaults asserted by rendered SOURCE (the value-comparing tests a rendering mutant passes verbatim), uppercase `SELF::`/`PARENT::` resolution, static satisfaction's satisfied complements (type-distinct variadic tail, untyped/union return contracts), by-ref detection at every position.
- `Runtime` 33 → 26 and `Understudy` 16 → 2: Fiber routing for by-ref returns, `callOriginal()` and ordering; nested doubles answering their own calls from any Fiber; retirement walking every double; structured failure fields (`actualCount`, `unused()` bounds, `observedCalls` filtering, `expectedCalls` as strings, both halves of `allVerified()`) asserted exactly.
- `DoubleState`: settle() pinned to drop satisfied claims and keep every stub of a method.
- `FinalStripper` 14 → 12 → the glued-comment and bare `final const` boundaries (oracles captured empirically, pinning current behaviour).
- Six refusal messages upgraded from fragment-`contains` to whole-message asserts — every concatenation half is a mutant `contains()` cannot see.
- Three more honest `#[Covers]` attributions (`DefaultFactoriesTest`→Runtime, `ClassDoubleTest`→Understudy, `VerificationFailureTest`→Understudy) — the same mapping gap that hid the verify-captor mutant in #75.

**What stays, and why it may:** the residue is dominated by confirmed equivalents — redundant second guards (a fastpath whose removal routes to a slower path with the same answer), set-map values read only through `array_keys()`, perf-only caches, warning-only index offsets, and unreachable defensive belts. The handful of genuinely-killable stragglers left (`Wire` resolution internals, the snapshot depth-cap boundary family) are noted here rather than force-fed with tests that would assert incidental structure.

Test-strengthening only; no engine change. 913 tests green, `composer build` green.