### PR TITLE
Render the call log when verifyAll() reports an unmet expectation

### DIFF
--- a/src/Understudy.php
+++ b/src/Understudy.php
@@ -352,20 +352,37 @@ final class Understudy
             return null;
         }
 
+        // The same renderer verify() uses, rather than a sprintf of its own.
+        // Two paths reported the same failure and only one of them showed the
+        // call log — so an unmet expectation reported by verifyAll(), which is
+        // what every runner adapter calls, said "expected 2, got 1" and left
+        // the reader to find out which call differed. That log is where the
+        // alias table and the argument marks live, and it is the whole reason
+        // they exist. The paths also disagreed on wording: this one produced
+        // "but it was called never".
+        $sameMethod = array_values(array_filter(
+            $state->callLog(),
+            static fn(Invocation $invocation): bool => $invocation->method === $expectation->method,
+        ));
+
         return ArgumentFormatter::scope(static fn(): VerificationFailure => new VerificationFailure(
             kind: FailureKind::UnmetExpectation,
-            summary: sprintf(
-                'Understudy `%s` expected `%s` to be called %s, but it was called %s.',
-                $state->label(),
-                $expectation->describe(),
-                $cardinality->describe(),
-                $count === 0 ? 'never' : ($count === 1 ? '1 time' : $count . ' times'),
+            summary: FailureReport::render(
+                label: $state->label(),
+                expectation: $expectation->describe(),
+                expectedLow: $cardinality->minimum,
+                expectedHigh: $cardinality->maximum,
+                actual: $count,
+                callLog: $state->callLog(),
+                method: $expectation->method,
+                expectedArgs: $expectation->args,
             ),
             double: $state->label(),
             expectation: $expectation->describe(),
             expectedMinimum: $cardinality->minimum,
             expectedMaximum: $cardinality->maximum,
             actualCount: $count,
+            observedCalls: $sameMethod,
         ));
     }
 

--- a/tests/UnderstudyTest.php
+++ b/tests/UnderstudyTest.php
@@ -866,6 +866,72 @@ final class UnderstudyTest
         verify(fn() => $repository->tag('gamma'));
     }
 
+    public function verifyAllListsTheCallsThatDidNotMatchTheExpectation(): void
+    {
+        // The same report verify() renders, from the path a runner adapter
+        // actually takes. These two rendered different messages for one
+        // failure: verifyAll() had a sprintf of its own and showed the summary
+        // line alone, so the alias table and the argument marks — the only
+        // things that say WHICH call differed — were missing from every
+        // adapter-reported failure.
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->tag('gamma'));
+
+        $repository->tag('alpha');
+        $repository->tag('beta');
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            GoldenMessage::read('verify-all-lists-same-method-calls-with-marked-argument'),
+        );
+
+        Understudy::verifyAll();
+    }
+
+    public function verifyAllCarriesTheSameMethodCallsAsData(): void
+    {
+        // `observedCalls` is documented as "the calls to the same method", and
+        // it is the path a reporter takes instead of parsing the message. The
+        // filter that makes it true is invisible to a test that only reads the
+        // rendered text — FailureReport filters again on its own way in.
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->tag('gamma'));
+
+        $repository->tag('alpha');
+        $repository->count();
+
+        try {
+            Understudy::verifyAll();
+        } catch (VerificationFailed $failure) {
+            $observed = $failure->failures()[0]->observedCalls;
+
+            Assert::same(array_map(
+                static fn(Invocation $invocation): string => $invocation->method,
+                $observed ?? [],
+            ), ['tag']);
+
+            return;
+        }
+
+        Assert::fail('verifyAll() passed with an unmet expectation');
+    }
+
+    public function verifyAllSpellsAnUncalledExpectationTheSameWayVerifyDoes(): void
+    {
+        // "but it was never called", not "but it was called never" — the two
+        // paths disagreed on the wording of the same sentence.
+        $repository = Understudy::for(BookRepository::class);
+
+        expect(fn() => $repository->count());
+
+        Expect::exception(VerificationFailed::class)->withMessage(
+            'Understudy `BookRepository` expected `count()` to be called exactly 1 time, but it was never called.',
+        );
+
+        Understudy::verifyAll();
+    }
+
     public function anObjectKeepsOneNameAcrossTheExpectationAndTheCallLog(): void
     {
         // The `*` marks a difference the report has to be able to show: both

--- a/tests/fixtures/messages/verify-all-lists-same-method-calls-with-marked-argument.txt
+++ b/tests/fixtures/messages/verify-all-lists-same-method-calls-with-marked-argument.txt
@@ -1,0 +1,5 @@
+Understudy `BookRepository` expected `tag('gamma', 1)` to be called exactly 1 time, but it was never called.
+
+The following calls to `tag` were made during this test:
+    tag(*'alpha'*, 1)
+    tag(*'beta'*, 1)

--- a/tests/fixtures/messages/verify-all-two-unmet-expectations-in-declaration-order.txt
+++ b/tests/fixtures/messages/verify-all-two-unmet-expectations-in-declaration-order.txt
@@ -1,3 +1,3 @@
-Understudy `BookRepository` expected `count()` to be called exactly 1 time, but it was called never.
+Understudy `BookRepository` expected `count()` to be called exactly 1 time, but it was never called.
 
-Understudy `BookRepository` expected `titles()` to be called exactly 1 time, but it was called never.
+Understudy `BookRepository` expected `titles()` to be called exactly 1 time, but it was never called.


### PR DESCRIPTION
Fixes #77

Two code paths reported the same failure and only one of them showed the calls. `verify()` rendered through `FailureReport`; `checkExpectation()` had a `sprintf` of its own, so an unmet expectation reported by `verifyAll()` — the path every runner adapter takes — said "expected 2 times, but it was called 1 time" and stopped there.

What was missing is the part that answers the reader's question. The call log carries the alias table and the `*` marks, and those exist precisely to distinguish a rebuilt copy from the instance the expectation named. Both are documented as how understudy reports a failure; neither appeared unless the test happened to use `verify()`.

The same `sprintf` also disagreed with `FailureReport` on wording and produced `but it was called never`.

## What changed

- `checkExpectation()` renders through `FailureReport::render()`, the same call `verify()` makes.
- The failure carries `observedCalls`, filtered to the failing method, as the `verify()` path already did.

## Tests

- One golden fixture changed wording.
- `verifyAllListsTheCallsThatDidNotMatchTheExpectation` — a new golden covering the log.
- `verifyAllSpellsAnUncalledExpectationTheSameWayVerifyDoes` — pins the sentence the two paths disagreed on.
- `verifyAllCarriesTheSameMethodCallsAsData` — reads `observedCalls` back, because the rendered message cannot catch a change there: `FailureReport` filters again on its own way in.

## Verification

- `composer build` green.
- `make mutation-diff`: 100% MSI, no escaped mutants.
- Full `make mutation`: 94% against a gate of 92, unchanged.

Found while checking the documentation site's claims against the engine.