### PR TITLE
Read tentative return types when unifying a contract

### DIFF
--- a/src/Codegen/TargetUnifier.php
+++ b/src/Codegen/TargetUnifier.php
@@ -80,9 +80,9 @@ final class TargetUnifier
                     throw UnsupportedTarget::signatureConflict(
                         $name,
                         self::describe($classStatic) . ' declares `: '
-                        . TypeRenderer::returnType($classStatic->getReturnType()) . '`',
+                        . TypeRenderer::returnType(self::declaredReturnType($classStatic)) . '`',
                         self::describe($interfaceDeclaration) . ' declares `: '
-                        . TypeRenderer::returnType($interfaceDeclaration->getReturnType()) . '`',
+                        . TypeRenderer::returnType(self::declaredReturnType($interfaceDeclaration)) . '`',
                     );
                 }
 
@@ -349,6 +349,33 @@ final class TargetUnifier
     }
 
     /**
+     * The return type a method declares, tentative ones included.
+     *
+     * PHP's own interfaces carry TENTATIVE return types — `Countable::count()`
+     * is declared `: int`, and `getReturnType()` answers null for it, because
+     * an implementation is still allowed to omit or widen the type until the
+     * grace period ends. Reading only `getReturnType()` therefore made every
+     * built-in contract look untyped, and the generated override declared
+     * `mixed`: legal for `ArrayAccess::offsetGet` (tentatively `mixed` too),
+     * and a deprecation notice for `Countable::count`, on a call as ordinary
+     * as `Understudy::for(Repo::class, Countable::class)`. A future PHP turns
+     * that notice into an error.
+     *
+     * Declaring the tentative type satisfies the contract exactly, so no
+     * `#[\ReturnTypeWillChange]` is needed anywhere.
+     */
+    private static function declaredReturnType(\ReflectionMethod $method): ?\ReflectionType
+    {
+        // hasReturnType() rather than a `??` over the two getters: the two are
+        // mutually exclusive — a method with a tentative type has no declared
+        // one — so either order of a coalesce behaves identically and the
+        // swap is an equivalent mutant nothing can kill.
+        return $method->hasReturnType()
+            ? $method->getReturnType()
+            : $method->getTentativeReturnType();
+    }
+
+    /**
      * Return types are covariant, so an implementation must satisfy all of
      * them at once. `int` and `string` have no common subtype: no class can
      * implement both, and PHP rejects the attempt at compile time.
@@ -372,7 +399,7 @@ final class TargetUnifier
             }
 
             if ($satisfiesAll) {
-                return TypeRenderer::returnType($candidate->getReturnType(), $candidate->getDeclaringClass());
+                return TypeRenderer::returnType(self::declaredReturnType($candidate), $candidate->getDeclaringClass());
             }
         }
 
@@ -386,8 +413,8 @@ final class TargetUnifier
 
         throw UnsupportedTarget::signatureConflict(
             $name,
-            self::describe($left) . ' declares `: ' . TypeRenderer::returnType($left->getReturnType()) . '`',
-            self::describe($right) . ' declares `: ' . TypeRenderer::returnType($right->getReturnType()) . '`',
+            self::describe($left) . ' declares `: ' . TypeRenderer::returnType(self::declaredReturnType($left)) . '`',
+            self::describe($right) . ' declares `: ' . TypeRenderer::returnType(self::declaredReturnType($right)) . '`',
         );
     }
 
@@ -403,11 +430,11 @@ final class TargetUnifier
     private static function intersectReturnTypes(array $declarations): ?string
     {
         $first = $declarations[0];
-        $branches = self::returnTypeBranches($first->getReturnType(), $first->getDeclaringClass());
+        $branches = self::returnTypeBranches(self::declaredReturnType($first), $first->getDeclaringClass());
 
         foreach (array_slice($declarations, 1) as $declaration) {
             $requiredBranches = self::returnTypeBranches(
-                $declaration->getReturnType(),
+                self::declaredReturnType($declaration),
                 $declaration->getDeclaringClass(),
             );
             $intersections = [];
@@ -561,8 +588,8 @@ final class TargetUnifier
 
     private static function returnTypeSatisfies(\ReflectionMethod $candidate, \ReflectionMethod $required): bool
     {
-        $candidateBranches = self::returnTypeBranches($candidate->getReturnType(), $candidate->getDeclaringClass());
-        $requiredBranches = self::returnTypeBranches($required->getReturnType(), $required->getDeclaringClass());
+        $candidateBranches = self::returnTypeBranches(self::declaredReturnType($candidate), $candidate->getDeclaringClass());
+        $requiredBranches = self::returnTypeBranches(self::declaredReturnType($required), $required->getDeclaringClass());
 
         foreach ($candidateBranches as $candidateBranch) {
             $accepted = false;

--- a/tests/Codegen/TargetUnifierTest.php
+++ b/tests/Codegen/TargetUnifierTest.php
@@ -239,6 +239,42 @@ final class TargetUnifierTest
         Assert::true(array_key_exists('write', $signatures));
     }
 
+    public function aBuiltInInterfaceKeepsItsTentativeReturnType(): void
+    {
+        // PHP's own interfaces declare TENTATIVE return types, and
+        // getReturnType() answers null for one — an implementation may still
+        // omit or widen it until the grace period ends. Reading only that made
+        // every built-in contract look untyped, so the override was generated
+        // `: mixed`, and PHP answered `Understudy::for(Repo::class,
+        // Countable::class)` with a deprecation notice. A future PHP turns
+        // that into an error.
+        $signatures = TargetUnifier::unify([new \ReflectionClass(\Countable::class)]);
+
+        Assert::same($signatures['count']->returnType, 'int');
+    }
+
+    public function aTentativeMixedStaysMixed(): void
+    {
+        // The other half of the same rule: ArrayAccess::offsetGet is
+        // tentatively `mixed`, and declaring `mixed` is what satisfies it.
+        // The old behaviour was right here by accident, which is why the bug
+        // survived — it only showed on a contract whose tentative type is
+        // narrower than `mixed`.
+        $signatures = TargetUnifier::unify([new \ReflectionClass(\ArrayAccess::class)]);
+
+        Assert::same($signatures['offsetGet']->returnType, 'mixed');
+    }
+
+    public function aBuiltInContractCombinesWithAnInterfaceOfOurOwn(): void
+    {
+        $signatures = TargetUnifier::unify([
+            new \ReflectionClass(ArityOne::class),
+            new \ReflectionClass(\Countable::class),
+        ]);
+
+        Assert::same($signatures['count']->returnType, 'int');
+    }
+
     public function everyContractMethodIsUnified(): void
     {
         $signatures = TargetUnifier::unify([new \ReflectionClass(ArityOne::class)]);


### PR DESCRIPTION
Fixes #78

`Understudy::for(BookRepository::class, Countable::class)` — the shape the README uses to introduce combined contracts — emitted a PHP deprecation:

```
Return type of …::count(): mixed should either be compatible with Countable::count(): int,
or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

PHP's own interfaces carry tentative return types, and `getReturnType()` answers `null` for one: an implementation is still allowed to omit or widen the type until the grace period ends. Every read in `TargetUnifier` used only that, so a built-in contract looked untyped and the override was generated `mixed`.

## Why it survived

It is right by accident for most of them. `ArrayAccess::offsetGet` and `JsonSerializable::jsonSerialize` are tentatively `mixed` too, so `mixed` satisfies them; only a contract whose tentative type is narrower — `Countable::count` as `int`, `IteratorAggregate::getIterator` as `Traversable` — produced the notice. A userland interface declaring the same method was always unified correctly, which is what made the failure look like it was about combining contracts rather than about internal ones.

## What changed

`declaredReturnType()` falls back to `getTentativeReturnType()`, and all nine reads go through it. Declaring the tentative type satisfies the contract exactly, so no `#[\ReturnTypeWillChange]` is needed anywhere.

It is written over `hasReturnType()` rather than a `??` between the two getters on purpose: a method with a tentative type has no declared one, so either order of a coalesce behaves identically and the swap would be an equivalent mutant nothing can kill.

## Tests

Three, in `TargetUnifierTest`:

- `aBuiltInInterfaceKeepsItsTentativeReturnType` — the narrower case.
- `aTentativeMixedStaysMixed` — the case that was already passing, so a future change cannot regress it while looking green.
- `aBuiltInContractCombinesWithAnInterfaceOfOurOwn`.

## Verification

- `composer build` green.
- `make mutation-diff`: 100% MSI, no escaped mutants.
- Full `make mutation`: 94% against a gate of 92, unchanged.

Found while checking the documentation site's claims against the engine.