### PR TITLE
Correct the times() mapping in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ here. Two rows are traps, marked ⚠.
 | `Mockery::mock(BookRepository::class)` | `Understudy::for(BookRepository::class)` | |
 | `$mock->shouldReceive('find')` | `when(fn () => $mock->find(...))` | a real call; no method-name string |
 | `->once()` / `->twice()` / `->times(3)` | `expect(fn () => ...)->times(3)` | an `expect()` is checked by `verifyAll()` / the adapter |
-| `->atLeast()->once()` | `expect(...)->times(minimum: 1)` | |
+| `->atLeast()->once()` | `expect(...)->times(1, null)` | |
 | `->andReturn($book)` | `->returns($book)` | |
 | `->andReturnUsing(fn ...)` | `->answers(fn (Invocation $i) => ...)` | arguments come from `$i->args` |
 | `->andThrow(new NotFound())` | `->throws(new NotFound())` | |
@@ -344,10 +344,17 @@ drop them, and the captor object is then simply empty again.
 use function Rasuvaeff\Understudy\expect;
 
 expect(fn () => $repository->save($book));            // exactly once
+expect(fn () => $repository->count())->times(3);      // exactly three times
+expect(fn () => $repository->count())->times(0);      // not at all
 expect(fn () => $repository->count())->times(1, 3);   // a range
+expect(fn () => $repository->count())->times(2, null); // at least twice
 
 Understudy::verifyAll();
 ```
+
+`times()` reads the number of arguments it was **given**, so one argument is an
+exact count however it is spelled: `times(minimum: 2)` is `times(2)`, not an
+open range. Write the second argument for that.
 
 `expect()` states how often a call must happen and `verifyAll()` checks it. A
 `when()` stub is permission rather than a claim — `->times(2)` turns it into

--- a/README.ru.md
+++ b/README.ru.md
@@ -47,7 +47,7 @@ when(fn () => $repository->find(123))->returns($book);
 | `Mockery::mock(BookRepository::class)` | `Understudy::for(BookRepository::class)` | |
 | `$mock->shouldReceive('find')` | `when(fn () => $mock->find(...))` | настоящий вызов; без строки с именем метода |
 | `->once()` / `->twice()` / `->times(3)` | `expect(fn () => ...)->times(3)` | `expect()` проверяется `verifyAll()` или адаптером |
-| `->atLeast()->once()` | `expect(...)->times(minimum: 1)` | |
+| `->atLeast()->once()` | `expect(...)->times(1, null)` | |
 | `->andReturn($book)` | `->returns($book)` | |
 | `->andReturnUsing(fn ...)` | `->answers(fn (Invocation $i) => ...)` | аргументы — из `$i->args` |
 | `->andThrow(new NotFound())` | `->throws(new NotFound())` | |
@@ -341,10 +341,17 @@ $options->all();                  // list<DeliveryOptions>, в порядке в
 use function Rasuvaeff\Understudy\expect;
 
 expect(fn () => $repository->save($book));            // ровно один раз
+expect(fn () => $repository->count())->times(3);      // ровно три раза
+expect(fn () => $repository->count())->times(0);      // ни разу
 expect(fn () => $repository->count())->times(1, 3);   // диапазон
+expect(fn () => $repository->count())->times(2, null); // не меньше двух
 
 Understudy::verifyAll();
 ```
+
+`times()` смотрит на **число переданных** аргументов, поэтому один аргумент —
+всегда точный счёт, как бы он ни был написан: `times(minimum: 2)` — это
+`times(2)`, а не открытый диапазон. Для диапазона пишите второй аргумент.
 
 `expect()` заявляет, сколько раз вызов обязан произойти, а `verifyAll()` это
 проверяет. Стаб `when()` — разрешение, а не заявление; `->times(2)` делает его


### PR DESCRIPTION
Documentation only, so no issue first per the monorepo's `AGENTS.md`.

The Mockery table offered `expect(...)->times(minimum: 1)` as the equivalent of `->atLeast()->once()`. It is not:

```php
public function times(int $minimum, ?int $maximum = null): static
{
    $this->expectation->setCardinality(
        func_num_args() === 1
            ? Cardinality::exactly($minimum)
            : Cardinality::between($minimum, $maximum),
    );
```

`times()` branches on the number of arguments it was **given**, so one argument is an exact count however it is spelled. That line promised an open range while producing "exactly once".

Verified rather than read:

```
times(minimum: 2) with 2 calls: PASS
times(minimum: 2) with 5 calls: FAIL — expected exactly 2 times, but it was called 5 times
times(2, null)    with 5 calls: PASS
```

## What changed

- The Mockery row maps to `times(1, null)`.
- The `expect()` section shows all four forms — `times(3)`, `times(0)`, `times(1, 3)`, `times(2, null)` — and states why the named-argument spelling does not do what it looks like.

Both READMEs in the same commit, as the bilingual rule requires.