### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,38 @@
 # Changelog
 
-## Unreleased
+## 0.4.1 — 2026-08-30
 
+- **`verifyAll()` renders the call log when an expectation goes unmet.** Two
+  code paths reported the same failure and only one showed the calls:
+  `verify()` rendered through `FailureReport`, while the verification sweep
+  had a `sprintf` of its own. Since `verifyAll()` is the path every runner
+  adapter takes, the alias table and the `*` argument marks — the part that
+  says WHICH call differed — were missing from almost every failure anyone
+  saw. Both paths now render the same report, the failure carries
+  `observedCalls`, and the sentence the two used to word differently ("but it
+  was called never") is settled. A test asserting the exact text of an unmet
+  expectation may need updating. (#77, #79)
+- **Doubling a built-in interface no longer emits a deprecation notice.**
+  PHP's own interfaces carry tentative return types, which
+  `ReflectionMethod::getReturnType()` reports as null, so
+  `Understudy::for(Repo::class, Countable::class)` generated `count(): mixed`
+  and PHP answered with `should either be compatible with
+  Countable::count(): int`. The unifier reads the tentative type, which
+  satisfies the contract exactly and needs no `#[\ReturnTypeWillChange]`. The
+  defect was invisible for `ArrayAccess` and `JsonSerializable`, whose
+  tentative type is `mixed` anyway. (#78, #80)
+- **A documentation site for the whole family**, at
+  <https://rasuvaeff.github.io/understudy/>: the guide, migration guides from
+  Mockery and PHPUnit, a cookbook of real incidents whose output the build
+  diffs against the scripts that produce it, and an API reference reflected
+  out of all five packages' `src/` — free functions and analyser rule
+  identifiers included, neither of which a class-only reference would show.
+  `MIGRATION.md` at the root is generated from the same pages. (#82)
+- **The README's Mockery table mapped `->atLeast()->once()` to
+  `times(minimum: 1)`, which is not what that does.** `times()` branches on
+  the number of arguments it was given, so one argument is an exact count
+  however it is spelled; the open range is `times(1, null)`. Both READMEs now
+  show all four forms and say why. (#81)
 - **The escaped-mutant hunt: 240 → 158, MSI 90.4% → 94.0%, gate raised to 92**
   (the full trajectory and the reason live next to the number in
   `infection.json5`). About sixty targeted tests and fixtures, each written
@@ -22,9 +53,6 @@
   manual arbitrations confirmed the remainder is dominated by genuine
   equivalents — redundant second guards, set-map values read through
   `array_keys()`, perf fastpaths, warning-only offsets.
-
-## Unreleased
-
 - **Honest-coverage sweep after 0.4.0.** Twelve targeted tests kill the
   escaped mutants the new code left behind (hooked-property collection and
   rendering, cross-Fiber property routing, forwarding write-through, captor

--- a/perf/README.md
+++ b/perf/README.md
@@ -118,6 +118,17 @@ judged by an A/B of the full harness on a quiet machine, three runs a side,
 with the competitors' movement as the noise floor — never by an isolated
 micro-benchmark, which cannot see a cost that was moved.
 
+**Re-validated before 0.4.1 (2026-08-30) without re-taking the figures.** The
+harness was run three times at `442da10` — the commit these numbers come from —
+and three times at the release candidate, on the same machine in one session,
+with Mockery 1.6.15, Prophecy 1.26.1 and PHPUnit 12.5.34. Understudy moved
++3.5% on creation, +3.2% on the mock scenario and +2.9% on the stub scenario;
+the competitors moved between -1.4% and +3.8% in the same runs, so the movement
+is inside the noise floor those establish and nothing is attributable to the
+change. The absolutes on that machine read about 2.3x the figures below, which
+is exactly the reason the ratio is what gets quoted and why the numbers here
+were not replaced with the ones it produced.
+
 Every in-process table below was run three times; medians move by 0.2-3.5%
 between runs. Figures are **filtered means** — testo's `Mean*`, after outlier
 rejection — and the relative deviation of that filtered set is under 5%


### PR DESCRIPTION
## What is in it

Two user-facing bug fixes, both found by checking the documentation's claims against the engine rather than by a bug report:

- **#77 / #79** — `verifyAll()` reported an unmet expectation without the call log. That is the path every runner adapter takes, so the alias table and the `*` argument marks were missing from almost every failure anyone actually saw.
- **#78 / #80** — doubling a built-in interface emitted a PHP deprecation, because tentative return types are reported by a different reflection method and only `getReturnType()` was read.

Plus the family documentation site (#82), the README correction to the `times()` mapping (#81), and the test-quality work that had accumulated since 0.4.0.

## CHANGELOG

The file carried **two** `## Unreleased` headings — one from each of the two post-0.4.0 test-quality passes. They are merged into a single `## 0.4.1 — 2026-08-30`, with the four new entries above it.

## One note for upgraders

`verifyAll()`'s message for an unmet expectation changed: it now renders the call log, and the summary sentence reads "but it was never called" where it used to read "but it was called never". A test asserting that exact text needs updating. The CHANGELOG says so.

## perf

Re-validated as `AGENTS.md` requires before a release tag — the harness run three times at `442da10`, the commit the recorded figures come from, and three times at this candidate, same machine, one session, identical competitor versions (Mockery 1.6.15, Prophecy 1.26.1, PHPUnit 12.5.34).

| | understudy | Mockery | PHPUnit | Prophecy |
|---|---|---|---|---|
| Create | +3.5% | −0.9% | −1.4% | −1.2% |
| Mock | +3.2% | +1.4% | +0.6% | −0.6% |
| Stub | +2.9% | +3.8% | −0.0% | +0.2% |

The competitors moved between −1.4% and +3.8% in the same runs, so understudy's ~3% is inside the noise floor they establish and nothing is attributable to the change.

The figures in `perf/README.md` were **not** replaced. The absolutes on this machine read about 2.3× the recorded ones — the exact situation that file warns about — so re-taking them would have recorded the machine rather than the library. A note records the validation instead; the `Taken` stamp still names the run the figures come from.