### PR TITLE
Refuse a matcher that could never match, at construction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,11 +195,15 @@ seconds instead of the full run's minute — and the full run stays the gate.
   class')` matched the words "final classes" in a fixture's own docblock and
   turned three passing tests red for the wrong reason.
 
-- **The mutation gate is 90, and it does not move without a reason written
-  next to the number.** 85 -> 95 -> 94 -> 92 -> 93 -> 92 -> 90 is the whole
-  trajectory; the reasons for the older moves are in commit messages, which is
-  exactly why the rule exists — nobody reads a commit message while looking at
-  the number. `TargetUnifier` still carries most of the surviving mutants: it is
+- **The mutation gate is 92, and it does not move without a reason written
+  next to the number.** 85 -> 95 -> 94 -> 92 -> 93 -> 92 -> 90 -> 92 is the
+  whole trajectory; the reason for the last move is beside the number in
+  `infection.json5` (the escaped-mutant hunt of #76), and the reasons for the
+  older ones are in commit messages, which is exactly why the rule exists —
+  nobody reads a commit message while looking at the number. This file and
+  both READMEs quote the gate, and they went stale the moment the number moved
+  without them: quote it or leave it to `infection.json5`, never both silently.
+  `TargetUnifier` still carries most of the surviving mutants: it is
   reflection glue whose branches are combinations of what a signature can be,
   so honest `#[Covers]` attribution grows the denominator about as fast as new
   tests grow the numerator. Read the reasons before moving the number, and add

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@
   `verifyAll()`, `checkpoint()` and the runner adapter's teardown still report
   the enclosing claims. A test that relied on a scope surfacing an outer
   failure earlier will now see it at the end of the test instead. (#84)
+- **A matcher that could never match is refused where it is written.**
+  `Arg::int(min: 5, max: 1)` — and the same shape in `Arg::float()` and
+  `Arg::count()` — describes an empty range, and `Arg::string('/[unclosed')` is
+  not a pattern PCRE compiles. Both built a matcher that answered "no" to every
+  argument, so a typo surfaced as an expectation never met with nothing
+  pointing at its cause; the broken pattern also raised PHP's own warning on
+  every call from inside the code under test, which is the one thing a matcher
+  must not do. Both now raise `InvalidCallSpecification`, and the pattern's
+  message carries PCRE's own reason. (#86)
+- **Two decisions written down rather than changed.** A predicate handed to
+  `Arg::satisfies()` is the test's own code, so an exception in it travels
+  instead of being read as a mismatch — unlike `Arg::which()`, which reaches
+  into the argument. And `verifySequence()` with no calls asserts that nothing
+  happened, where `expectSequence()` refuses an empty protocol; both are now
+  stated in the docblocks and pinned by tests.
+- The mutation gate quoted in `README.md`, `README.ru.md` and `AGENTS.md` says
+  92, which is what `infection.json5` has required since #76.
 
 ## 0.4.1 — 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ The type matchers are deliberately strict: `Arg::int()` rejects `'5'`, and
 `Arg::float()` rejects `1`. A matcher pins the declared type as much as the
 value, which is the point in a codebase that runs with `strict_types`.
 
+A matcher that could never match anything is refused where it is written, not
+left to fail an expectation in teardown: `Arg::int(min: 5, max: 1)` and its
+`float`/`count` siblings describe an empty range, and `Arg::string('/[unclosed')`
+is not a pattern PCRE compiles — the latter would also raise a warning inside
+the code under test on every call.
+
 `Arg::which()` calls only a public, non-static method that needs no arguments.
 A getter that throws counts as a mismatch, never as an error — matching runs
 while the code under test is executing, and a matcher must not be the thing
@@ -849,7 +855,7 @@ make build          # validate, normalize, require-checker, cs, psalm, test
 make cs-fix
 make psalm
 make test
-make mutation       # infection, gate at 85% MSI
+make mutation       # infection, gate at 92% MSI
 make release-check
 
 make perf-install   # once: the comparative benchmark harness in perf/

--- a/README.ru.md
+++ b/README.ru.md
@@ -306,6 +306,12 @@ when(fn () => $storage->recordOutcome('svc', Arg::rest()))
 `Arg::float()` отвергает `1`. Матчер закрепляет объявленный тип не меньше, чем
 значение, — ради этого он и нужен в коде со `strict_types`.
 
+Матчер, который не смог бы совпасть ни с чем, отвергается там, где написан, а
+не проваливает ожидание в teardown: `Arg::int(min: 5, max: 1)` и его собратья
+`float`/`count` описывают пустой диапазон, а `Arg::string('/[unclosed')` — не
+компилируемый PCRE-паттерн, который вдобавок поднимал бы warning внутри
+тестируемого кода на каждом вызове.
+
 `Arg::which()` вызывает только публичный нестатический метод без обязательных
 аргументов. Геттер, бросивший исключение, считается несовпадением, а не
 ошибкой: сопоставление идёт во время работы тестируемого кода, и матчер не
@@ -848,7 +854,7 @@ make build          # validate, normalize, require-checker, cs, psalm, test
 make cs-fix
 make psalm
 make test
-make mutation       # infection, гейт 85% MSI
+make mutation       # infection, гейт 92% MSI
 make release-check
 
 make perf-install   # один раз: сравнительный харнесс в perf/

--- a/docs/scripts/api-snapshot.json
+++ b/docs/scripts/api-snapshot.json
@@ -93,7 +93,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 72
+                    "startLine": 74
                 },
                 {
                     "name": "string",
@@ -116,7 +116,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 82
+                    "startLine": 86
                 },
                 {
                     "name": "bool",
@@ -131,7 +131,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 87
+                    "startLine": 95
                 },
                 {
                     "name": "same",
@@ -154,7 +154,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 95
+                    "startLine": 103
                 },
                 {
                     "name": "not",
@@ -177,7 +177,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 103
+                    "startLine": 111
                 },
                 {
                     "name": "allOf",
@@ -200,7 +200,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 114
+                    "startLine": 122
                 },
                 {
                     "name": "anyOf",
@@ -223,7 +223,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 125
+                    "startLine": 133
                 },
                 {
                     "name": "instanceOf",
@@ -246,7 +246,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 133
+                    "startLine": 141
                 },
                 {
                     "name": "captor",
@@ -269,7 +269,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 165
+                    "startLine": 173
                 },
                 {
                     "name": "satisfies",
@@ -292,14 +292,14 @@
                     ],
                     "returnType": "mixed",
                     "summary": "Matches whatever the predicate accepts.",
-                    "description": "",
+                    "description": "A predicate that throws is not caught, and that is the decision rather\nthan an omission. `Arg::which()` swallows a throwing getter because the\ngetter belongs to the argument — foreign code, reached while the subject\nis running, where \"it threw\" can only mean \"not this one\". A predicate\nis the test's own code: an exception in it is a broken test, and turning\nthat into a quiet mismatch would report the symptom (an expectation\nnever met) instead of the cause.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 176
+                    "startLine": 192
                 },
                 {
                     "name": "containing",
@@ -322,7 +322,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 187
+                    "startLine": 203
                 },
                 {
                     "name": "count",
@@ -352,7 +352,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 198
+                    "startLine": 214
                 },
                 {
                     "name": "which",
@@ -382,7 +382,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 208
+                    "startLine": 226
                 },
                 {
                     "name": "none",
@@ -397,7 +397,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 246
+                    "startLine": 330
                 },
                 {
                     "name": "remaining",
@@ -412,7 +412,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 255
+                    "startLine": 339
                 },
                 {
                     "name": "rest",
@@ -427,7 +427,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 276
+                    "startLine": 360
                 }
             ],
             "constants": [],
@@ -3195,7 +3195,7 @@
             "isApi": true,
             "isAbstract": false,
             "isThrowable": true,
-            "summary": "The closure handed to when()/verify()/calls() did not describe one call the\nway a specification must: no direct call on an understudy, more than one, or\narguments that cannot form a valid specification.",
+            "summary": "The closure handed to when()/verify()/calls() did not describe one call the\nway a specification must: no direct call on an understudy, more than one, or\narguments that cannot form a valid specification — which includes a matcher\nconfigured so that it could never match anything.",
             "description": "",
             "deprecated": null,
             "see": [],
@@ -3223,7 +3223,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 16
+                    "startLine": 17
                 },
                 {
                     "name": "notADouble",
@@ -3238,7 +3238,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 25
+                    "startLine": 26
                 },
                 {
                     "name": "misplacedTailMatcher",
@@ -3275,7 +3275,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 37
+                    "startLine": 38
                 },
                 {
                     "name": "emptyCombinator",
@@ -3298,7 +3298,74 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 52
+                    "startLine": 53
+                },
+                {
+                    "name": "invertedBounds",
+                    "static": true,
+                    "params": [
+                        {
+                            "name": "matcher",
+                            "type": "non-empty-string",
+                            "description": "the factory that was called, without `Arg::`",
+                            "default": null,
+                            "variadic": false
+                        },
+                        {
+                            "name": "minimum",
+                            "type": "int|float",
+                            "description": "the lower bound as it was given",
+                            "default": null,
+                            "variadic": false
+                        },
+                        {
+                            "name": "maximum",
+                            "type": "int|float",
+                            "description": "the upper bound as it was given",
+                            "default": null,
+                            "variadic": false
+                        }
+                    ],
+                    "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
+                    "summary": "A range matcher whose maximum sits below its minimum, so it describes an\nempty range and could never match.",
+                    "description": "",
+                    "throws": [],
+                    "throwsInBody": false,
+                    "inheritedFrom": null,
+                    "see": [],
+                    "deprecated": null,
+                    "attributes": [],
+                    "startLine": 71
+                },
+                {
+                    "name": "invalidPattern",
+                    "static": true,
+                    "params": [
+                        {
+                            "name": "pattern",
+                            "type": "non-empty-string",
+                            "description": "the pattern as it was written",
+                            "default": null,
+                            "variadic": false
+                        },
+                        {
+                            "name": "reason",
+                            "type": "non-empty-string|null",
+                            "description": "what PCRE said, when it said anything",
+                            "default": null,
+                            "variadic": false
+                        }
+                    ],
+                    "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
+                    "summary": "A pattern handed to `Arg::string()` that PCRE cannot compile.",
+                    "description": "",
+                    "throws": [],
+                    "throwsInBody": false,
+                    "inheritedFrom": null,
+                    "see": [],
+                    "deprecated": null,
+                    "attributes": [],
+                    "startLine": 89
                 },
                 {
                     "name": "tailMatcherInCombinator",
@@ -3328,7 +3395,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 66
+                    "startLine": 104
                 },
                 {
                     "name": "emptySequence",
@@ -3343,7 +3410,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 77
+                    "startLine": 115
                 },
                 {
                     "name": "protocolAlreadyArmed",
@@ -3373,7 +3440,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 89
+                    "startLine": 127
                 },
                 {
                     "name": "incompleteSpecification",
@@ -3410,7 +3477,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 105
+                    "startLine": 143
                 },
                 {
                     "name": "omittedBeforeSpecified",
@@ -3447,7 +3514,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 121
+                    "startLine": 159
                 },
                 {
                     "name": "omittedTailNeedsRest",
@@ -3477,7 +3544,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 136
+                    "startLine": 174
                 },
                 {
                     "name": "closureFailed",
@@ -3500,7 +3567,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 147
+                    "startLine": 185
                 },
                 {
                     "name": "staticMethodCalled",
@@ -3523,12 +3590,12 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 159
+                    "startLine": 197
                 }
             ],
             "constants": [],
             "enumCases": [],
-            "sourceUrl": "https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidCallSpecification.php#L14",
+            "sourceUrl": "https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidCallSpecification.php#L15",
             "implementedBy": []
         },
         {
@@ -13262,7 +13329,7 @@
                     "summary": "Checks every expectation of the current context: the ones `expect()`\ndeclared, and the stubs that opted in through `times()`.",
                     "description": "With `strictStubs`, a stub that was never called fails too — the\nMockito reading of \"why did you configure it, then?\".",
                     "throws": [],
-                    "throwsInBody": false,
+                    "throwsInBody": true,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
@@ -13318,7 +13385,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 418
+                    "startLine": 397
                 },
                 {
                     "name": "calls",
@@ -13341,7 +13408,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 504
+                    "startLine": 483
                 },
                 {
                     "name": "lastCall",
@@ -13364,7 +13431,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 526
+                    "startLine": 505
                 },
                 {
                     "name": "strict",
@@ -13387,7 +13454,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 544
+                    "startLine": 523
                 },
                 {
                     "name": "lean",
@@ -13410,7 +13477,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 567
+                    "startLine": 546
                 },
                 {
                     "name": "forwarding",
@@ -13440,7 +13507,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 585
+                    "startLine": 564
                 },
                 {
                     "name": "delegate",
@@ -13470,7 +13537,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 636
+                    "startLine": 615
                 },
                 {
                     "name": "wire",
@@ -13500,7 +13567,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 668
+                    "startLine": 647
                 },
                 {
                     "name": "bypassFinals",
@@ -13528,7 +13595,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 705
+                    "startLine": 684
                 },
                 {
                     "name": "defaults",
@@ -13558,7 +13625,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 790
+                    "startLine": 769
                 },
                 {
                     "name": "label",
@@ -13588,7 +13655,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 801
+                    "startLine": 780
                 },
                 {
                     "name": "unused",
@@ -13611,7 +13678,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 809
+                    "startLine": 788
                 },
                 {
                     "name": "forget",
@@ -13634,7 +13701,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 849
+                    "startLine": 828
                 },
                 {
                     "name": "nothingElse",
@@ -13664,7 +13731,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 870
+                    "startLine": 849
                 },
                 {
                     "name": "allVerified",
@@ -13687,7 +13754,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 913
+                    "startLine": 892
                 },
                 {
                     "name": "expectSequence",
@@ -13710,7 +13777,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 998
+                    "startLine": 977
                 },
                 {
                     "name": "verifySequence",
@@ -13726,14 +13793,14 @@
                     ],
                     "returnType": "void",
                     "summary": "Asserts that these calls are exactly what happened in this context, in\nthis order, across every understudy — no more, no fewer.",
-                    "description": "",
+                    "description": "Called with nothing, it asserts that nothing happened, and that is not\nthe oversight it resembles: `expectSequence()` refuses an empty protocol\nbecause arming one would put every later call on trial with no step to\ntry it against, while this one reads the log that already exists, and\n\"the log is empty\" is a real question with a real answer. A call that\ndid happen is reported the same way any extra call is.",
                     "throws": [],
                     "throwsInBody": true,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 1031
+                    "startLine": 1017
                 },
                 {
                     "name": "transcript",
@@ -13756,7 +13823,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 1057
+                    "startLine": 1043
                 },
                 {
                     "name": "scope",
@@ -13779,14 +13846,14 @@
                     ],
                     "returnType": "mixed",
                     "summary": "Runs a callback in a nested context of its own.",
-                    "description": "On success the callback's expectations are verified; the context is then\ndropped either way. A failure inside the callback is never replaced by a\nteardown error — the original is what the reader needs.\n\nVerified is the context this call opened, and only it: the enclosing\ncontext is still running and its claims are none of a nested scope's\nbusiness. A scope is a local lifetime — the caller reaches for it to end\na few doubles early, often while its own expectations are deliberately\nunfinished — so answering for the whole test here would fail a\nself-contained scope for something the test has not got to yet. The\ntest as a whole is answered for by `verifyAll()`, `checkpoint()` and the\nrunner adapter's teardown, which are the calls that mean the test is\nover. A Fiber started inside the callback keeps a context of its own\nthat outlives the scope, so it stays for those to check.",
+                    "description": "On success the callback's expectations are verified; the context is then\ndropped either way. A failure inside the callback is never replaced by a\nteardown error — the original is what the reader needs.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 1193
+                    "startLine": 1168
                 },
                 {
                     "name": "checkpoint",
@@ -13809,7 +13876,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 1221
+                    "startLine": 1196
                 },
                 {
                     "name": "reset",
@@ -13824,7 +13891,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 1248
+                    "startLine": 1223
                 },
                 {
                     "name": "idle",
@@ -13839,7 +13906,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 1260
+                    "startLine": 1235
                 }
             ],
             "constants": [],

--- a/docs/scripts/check-claims.php
+++ b/docs/scripts/check-claims.php
@@ -32,6 +32,7 @@ if ($hasWorkspace) {
 }
 
 use Rasuvaeff\Understudy\Arg;
+use Rasuvaeff\Understudy\Exception\InvalidCallSpecification;
 use Rasuvaeff\Understudy\Exception\VerificationFailed;
 use Rasuvaeff\Understudy\Invocation;
 use Rasuvaeff\Understudy\Understudy;
@@ -343,6 +344,35 @@ claim('lifecycle/index', 'a scope closes clean over an unsatisfied outer claim',
     }
 
     return 'the outer claim was settled rather than left standing';
+});
+
+claim('stubbing/matchers', 'an inverted range is refused where it is written', function (): bool|string {
+    try {
+        Arg::int(min: 5, max: 1);
+    } catch (InvalidCallSpecification) {
+        return true;
+    }
+
+    return 'Arg::int(min: 5, max: 1) was accepted';
+});
+
+claim('stubbing/matchers', 'a pattern PCRE cannot compile is refused, quietly', function (): bool|string {
+    $raised = [];
+    set_error_handler(static function (int $severity, string $message) use (&$raised): bool {
+        $raised[] = $message;
+
+        return true;
+    });
+
+    try {
+        Arg::string('/[unclosed');
+
+        return 'Arg::string(\'/[unclosed\') was accepted';
+    } catch (InvalidCallSpecification) {
+        return $raised === [] ?: 'the refusal raised the warning it exists to prevent';
+    } finally {
+        restore_error_handler();
+    }
 });
 
 claim('lifecycle/retention', 'lean(): returned() raises OutcomeUnavailable', function (): bool|string {

--- a/docs/src/api/classes/Arg.md
+++ b/docs/src/api/classes/Arg.md
@@ -155,6 +155,14 @@ Matches whatever the predicate accepts.
 
 - `$description` — shown in failure messages
 
+A predicate that throws is not caught, and that is the decision rather
+than an omission. `Arg::which()` swallows a throwing getter because the
+getter belongs to the argument — foreign code, reached while the subject
+is running, where "it threw" can only mean "not this one". A predicate
+is the test's own code: an exception in it is a broken test, and turning
+that into a quiet mismatch would report the symptom (an expectation
+never met) instead of the cause.
+
 ### containing()
 
 ```php

--- a/docs/src/api/classes/Exception/InvalidCallSpecification.md
+++ b/docs/src/api/classes/Exception/InvalidCallSpecification.md
@@ -9,7 +9,7 @@ description: "The closure handed to when()/verify()/calls() did not describe one
 
 `Rasuvaeff\Understudy\Exception\InvalidCallSpecification`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidCallSpecification.php#L14) — **Version:** v0.4.1
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidCallSpecification.php#L15) — **Version:** v0.4.1
 
 **Extends:** `LogicException`
 
@@ -17,7 +17,8 @@ description: "The closure handed to when()/verify()/calls() did not describe one
 
 The closure handed to when()/verify()/calls() did not describe one call the
 way a specification must: no direct call on an understudy, more than one, or
-arguments that cannot form a valid specification.
+arguments that cannot form a valid specification — which includes a matcher
+configured so that it could never match anything.
 
 ## Methods
 
@@ -48,6 +49,37 @@ static misplacedTailMatcher(
 ```php
 static emptyCombinator(non-empty-string $matcher): Exception\InvalidCallSpecification
 ```
+
+### invertedBounds()
+
+```php
+static invertedBounds(
+    non-empty-string $matcher,
+    int|float $minimum,
+    int|float $maximum,
+): Exception\InvalidCallSpecification
+```
+
+A range matcher whose maximum sits below its minimum, so it describes an
+empty range and could never match.
+
+- `$matcher` — the factory that was called, without `Arg::`
+- `$minimum` — the lower bound as it was given
+- `$maximum` — the upper bound as it was given
+
+### invalidPattern()
+
+```php
+static invalidPattern(
+    non-empty-string $pattern,
+    non-empty-string|null $reason,
+): Exception\InvalidCallSpecification
+```
+
+A pattern handed to `Arg::string()` that PCRE cannot compile.
+
+- `$pattern` — the pattern as it was written
+- `$reason` — what PCRE said, when it said anything
 
 ### tailMatcherInCombinator()
 

--- a/docs/src/api/classes/Understudy.md
+++ b/docs/src/api/classes/Understudy.md
@@ -356,6 +356,13 @@ static verifySequence(callable $calls): void
 Asserts that these calls are exactly what happened in this context, in
 this order, across every understudy — no more, no fewer.
 
+Called with nothing, it asserts that nothing happened, and that is not
+the oversight it resembles: `expectSequence()` refuses an empty protocol
+because arming one would put every later call on trial with no step to
+try it against, while this one reads the log that already exists, and
+"the log is empty" is a real question with a real answer. A call that
+did happen is reported the same way any extra call is.
+
 ### transcript()
 
 ```php

--- a/docs/src/guide/stubbing/matchers.md
+++ b/docs/src/guide/stubbing/matchers.md
@@ -44,6 +44,19 @@ A matcher pins the declared type as much as the value, which is the point in a
 codebase running under `strict_types`. A matcher that quietly accepted the
 other type would hide exactly the bug the declaration exists to prevent.
 
+## A matcher that could never match is refused
+
+`Arg::int(min: 5, max: 1)` — and the same shape in `Arg::float()` and
+`Arg::count()` — describes an empty range, and `Arg::string('/[unclosed')` is
+not a pattern PCRE compiles. Both are typos, and both used to build a matcher
+that answered "no" to every argument, so the mistake surfaced as an
+expectation never met, with nothing pointing at its cause. They are refused
+with `InvalidCallSpecification` where they are written.
+
+The broken pattern had a second cost: `preg_match()` raises a warning on every
+call, from inside the code under test — which is the one thing a matcher must
+never do.
+
 ## `rest()` against `remaining()`
 
 They look similar and stand for different things:

--- a/llms.txt
+++ b/llms.txt
@@ -195,8 +195,11 @@ after it. Arguments match by `===`, or by matcher.
 Every `Arg::*` returns `mixed`, so passing one where the contract says `int`
 is not a type error in an IDE. `which()` calls only a public, non-static
 method needing no arguments; anything else, including a getter that throws, is
-a mismatch rather than an error. A matcher that reaches a real call raises
-`MatcherLeaked`.
+a mismatch rather than an error — but a predicate handed to `satisfies()` is
+the test's own code, so an exception in it travels. A matcher that could never
+match is refused at construction with `InvalidCallSpecification`: an inverted
+range (`int`/`float`/`count`) and a pattern PCRE cannot compile. A matcher that
+reaches a real call raises `MatcherLeaked`.
 
 `Arg::captor(?class-string $class = null): Captor` builds a typed argument
 captor — the replacement for reading `args[N]` out of the call log:

--- a/src/Arg.php
+++ b/src/Arg.php
@@ -63,6 +63,8 @@ final class Arg
      */
     public static function int(?int $min = null, ?int $max = null): mixed
     {
+        self::bounds('int', $min, $max);
+
         return new IntInRange($min, $max);
     }
 
@@ -71,6 +73,8 @@ final class Arg
      */
     public static function float(?float $min = null, ?float $max = null): mixed
     {
+        self::bounds('float', $min, $max);
+
         return new FloatInRange($min, $max);
     }
 
@@ -81,6 +85,10 @@ final class Arg
      */
     public static function string(?string $matches = null): mixed
     {
+        if ($matches !== null) {
+            self::pattern($matches);
+        }
+
         return new StringMatching($matches);
     }
 
@@ -170,6 +178,14 @@ final class Arg
     /**
      * Matches whatever the predicate accepts.
      *
+     * A predicate that throws is not caught, and that is the decision rather
+     * than an omission. `Arg::which()` swallows a throwing getter because the
+     * getter belongs to the argument — foreign code, reached while the subject
+     * is running, where "it threw" can only mean "not this one". A predicate
+     * is the test's own code: an exception in it is a broken test, and turning
+     * that into a quiet mismatch would report the symptom (an expectation
+     * never met) instead of the cause.
+     *
      * @param callable(mixed): bool $predicate
      * @param non-empty-string      $description shown in failure messages
      */
@@ -197,6 +213,8 @@ final class Arg
      */
     public static function count(?int $minimum = null, ?int $maximum = null): mixed
     {
+        self::bounds('count', $minimum, $maximum);
+
         return new CountBetween($minimum, $maximum);
     }
 
@@ -208,6 +226,72 @@ final class Arg
     public static function which(string $method, mixed $value): mixed
     {
         return new QueryEquals($method, $value);
+    }
+
+    /**
+     * A range refused rather than silently weakened: a maximum below the
+     * minimum describes an empty range, so the matcher would answer `false`
+     * to every argument and an `expect()` holding it could never be met. The
+     * same rule `Cardinality::between()` follows.
+     */
+    /**
+     * @param non-empty-string $matcher
+     */
+    private static function bounds(string $matcher, int|float|null $minimum, int|float|null $maximum): void
+    {
+        if ($minimum !== null && $maximum !== null && $maximum < $minimum) {
+            throw InvalidCallSpecification::invertedBounds($matcher, $minimum, $maximum);
+        }
+    }
+
+    /**
+     * A PCRE pattern compiled once, here, rather than on every call from
+     * inside the code under test — where a broken one raises PHP's own
+     * warning and answers `false` to every argument, which reads as "the
+     * argument was wrong" and is the one thing a matcher must never do.
+     *
+     * The compile runs under an error handler of our own so that the probe
+     * does not raise the very warning it exists to prevent, and so that
+     * PCRE's reason reaches the message instead of being thrown away. Nothing
+     * between the two handler calls can throw — `preg_match()` reports a bad
+     * pattern through the error channel our handler is holding — so there is
+     * no `finally` to unwind.
+     */
+    /**
+     * @param non-empty-string $pattern
+     */
+    private static function pattern(string $pattern): void
+    {
+        $reason = null;
+
+        set_error_handler(static function (int $severity, string $message) use (&$reason): bool {
+            $reason = $message;
+
+            return true;
+        });
+
+        $compiled = preg_match($pattern, '') !== false;
+        restore_error_handler();
+
+        if (!$compiled) {
+            throw InvalidCallSpecification::invalidPattern($pattern, self::reason($reason));
+        }
+    }
+
+    /**
+     * PCRE's own complaint, without the function name PHP prefixes it with.
+     *
+     * @return non-empty-string|null
+     */
+    private static function reason(?string $message): ?string
+    {
+        if ($message === null) {
+            return null;
+        }
+
+        $stripped = preg_replace('/^preg_match\(\):\s*/', '', $message) ?? $message;
+
+        return $stripped === '' ? null : $stripped;
     }
 
     /**

--- a/src/Exception/InvalidCallSpecification.php
+++ b/src/Exception/InvalidCallSpecification.php
@@ -7,7 +7,8 @@ namespace Rasuvaeff\Understudy\Exception;
 /**
  * The closure handed to when()/verify()/calls() did not describe one call the
  * way a specification must: no direct call on an understudy, more than one, or
- * arguments that cannot form a valid specification.
+ * arguments that cannot form a valid specification — which includes a matcher
+ * configured so that it could never match anything.
  *
  * @api
  */
@@ -56,6 +57,43 @@ final class InvalidCallSpecification extends \LogicException implements Understu
             . 'Pass what the argument has to satisfy, or use Arg::any() to accept anything.',
             $matcher,
             $matcher === 'allOf' ? 'every argument' : 'no argument at all',
+        ));
+    }
+
+    /**
+     * A range matcher whose maximum sits below its minimum, so it describes an
+     * empty range and could never match.
+     *
+     * @param non-empty-string $matcher the factory that was called, without `Arg::`
+     * @param int|float        $minimum the lower bound as it was given
+     * @param int|float        $maximum the upper bound as it was given
+     */
+    public static function invertedBounds(string $matcher, int|float $minimum, int|float $maximum): self
+    {
+        return new self(sprintf(
+            "`Arg::%s()` was given a minimum of %s and a maximum of %s, so it describes an empty "
+            . "range and would match no argument at all.\n"
+            . 'Order the bounds the other way, or leave one of them out to keep that side open.',
+            $matcher,
+            var_export($minimum, return: true),
+            var_export($maximum, return: true),
+        ));
+    }
+
+    /**
+     * A pattern handed to `Arg::string()` that PCRE cannot compile.
+     *
+     * @param non-empty-string      $pattern the pattern as it was written
+     * @param non-empty-string|null $reason  what PCRE said, when it said anything
+     */
+    public static function invalidPattern(string $pattern, ?string $reason): self
+    {
+        return new self(sprintf(
+            "`Arg::string()` was given `%s`, which is not a valid PCRE pattern%s\n"
+            . 'It would match no string and would raise a warning inside the code under test on '
+            . 'every call. Check the delimiters and the escaping.',
+            $pattern,
+            $reason === null ? '.' : ': ' . $reason . '.',
         ));
     }
 

--- a/src/Understudy.php
+++ b/src/Understudy.php
@@ -1026,6 +1026,13 @@ final class Understudy
      * Asserts that these calls are exactly what happened in this context, in
      * this order, across every understudy — no more, no fewer.
      *
+     * Called with nothing, it asserts that nothing happened, and that is not
+     * the oversight it resembles: `expectSequence()` refuses an empty protocol
+     * because arming one would put every later call on trial with no step to
+     * try it against, while this one reads the log that already exists, and
+     * "the log is empty" is a real question with a real answer. A call that
+     * did happen is reported the same way any extra call is.
+     *
      * @param callable(): mixed ...$calls
      */
     public static function verifySequence(callable ...$calls): void

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -353,6 +353,195 @@ final class ArgTest
         Assert::false($matcher->matches($target));
     }
 
+    /**
+     * A range whose maximum sits below its minimum matches nothing at all, so
+     * an `expect()` holding one could never be met and the mistake surfaces in
+     * teardown with nothing pointing at its cause. Refused where it is
+     * written, like an empty combinator.
+     *
+     * @param callable(): mixed $build
+     */
+    #[DataProvider('invertedBoundsProvider')]
+    public function anInvertedRangeIsRefusedWhereItIsWritten(callable $build, string $message): void
+    {
+        Expect::exception(InvalidCallSpecification::class)->withMessage($message);
+
+        $build();
+    }
+
+    public static function invertedBoundsProvider(): iterable
+    {
+        yield 'int' => [
+            static fn(): mixed => Arg::int(min: 5, max: 1),
+            "`Arg::int()` was given a minimum of 5 and a maximum of 1, so it describes an empty "
+            . "range and would match no argument at all.\n"
+            . 'Order the bounds the other way, or leave one of them out to keep that side open.',
+        ];
+
+        yield 'float' => [
+            static fn(): mixed => Arg::float(min: 1.5, max: 0.5),
+            "`Arg::float()` was given a minimum of 1.5 and a maximum of 0.5, so it describes an "
+            . "empty range and would match no argument at all.\n"
+            . 'Order the bounds the other way, or leave one of them out to keep that side open.',
+        ];
+
+        yield 'count' => [
+            static fn(): mixed => Arg::count(minimum: 3, maximum: 1),
+            "`Arg::count()` was given a minimum of 3 and a maximum of 1, so it describes an empty "
+            . "range and would match no argument at all.\n"
+            . 'Order the bounds the other way, or leave one of them out to keep that side open.',
+        ];
+    }
+
+    /**
+     * The bounds that are legitimate stay legitimate: equal ones pin one
+     * value, and either side may be left open.
+     *
+     * @param callable(): mixed $build
+     */
+    #[DataProvider('acceptedBoundsProvider')]
+    public function boundsThatDescribeARealRangeAreAccepted(callable $build, mixed $argument): void
+    {
+        $matcher = $build();
+        \assert($matcher instanceof ArgumentMatcher);
+
+        Assert::true($matcher->matches($argument));
+    }
+
+    public static function acceptedBoundsProvider(): iterable
+    {
+        yield 'int, equal bounds' => [static fn(): mixed => Arg::int(min: 5, max: 5), 5];
+        yield 'int, open above' => [static fn(): mixed => Arg::int(min: 5), 6];
+        yield 'int, open below' => [static fn(): mixed => Arg::int(max: 5), 4];
+        yield 'float, equal bounds' => [static fn(): mixed => Arg::float(min: 1.5, max: 1.5), 1.5];
+        yield 'count, equal bounds' => [static fn(): mixed => Arg::count(minimum: 2, maximum: 2), [1, 2]];
+    }
+
+    /**
+     * A pattern that does not compile answers `false` to every string — which
+     * reads as "the argument was wrong" — and raises PHP's own warning on
+     * every call from inside the code under test. Both are refused at the
+     * matcher's construction, and PCRE's reason is carried into the message
+     * because the delimiter or the escaping is what has to be fixed.
+     */
+    public function anInvalidPatternIsRefusedWithPcresOwnReason(): void
+    {
+        $caught = null;
+
+        try {
+            Arg::string('/[unclosed/');
+        } catch (InvalidCallSpecification $refusal) {
+            $caught = $refusal;
+        }
+
+        \assert($caught instanceof InvalidCallSpecification);
+        Assert::string($caught->getMessage())
+            ->contains('`Arg::string()` was given `/[unclosed/`, which is not a valid PCRE pattern')
+            ->contains('missing terminating ] for character class')
+            ->notContains('preg_match():');
+    }
+
+    /**
+     * The probe must not raise the warning it exists to prevent — the whole
+     * point is that nothing reaches the error channel because a matcher was
+     * built. Read through `error_get_last()` rather than a handler of the
+     * test's own: handlers do not chain, so an inner one that declined the
+     * error would be invisible to an outer one while PHP reported it anyway.
+     */
+    public function refusingAPatternRaisesNoWarningOfItsOwn(): void
+    {
+        error_clear_last();
+
+        try {
+            Arg::string('/[unclosed/');
+        } catch (InvalidCallSpecification) {
+            // The refusal is the subject of the test above; here only the
+            // error channel is on trial.
+        }
+
+        Assert::null(error_get_last());
+    }
+
+    /**
+     * And it must hand the error channel back. A probe that installed a
+     * handler and kept it would silence the rest of the test run — every
+     * warning the code under test raises from that point on.
+     */
+    public function refusingAPatternRestoresTheErrorHandler(): void
+    {
+        $sentinel = static fn(int $severity, string $message): bool => true;
+        set_error_handler($sentinel);
+
+        try {
+            Arg::string('/[unclosed/');
+        } catch (InvalidCallSpecification) {
+            // Same as above: the refusal itself is tested elsewhere.
+        }
+
+        // set_error_handler() answers with the handler that was active, which
+        // is the sentinel only if the probe popped its own.
+        $active = set_error_handler(static fn(int $severity, string $message): bool => true);
+        restore_error_handler();
+        restore_error_handler();
+
+        Assert::same($active, $sentinel);
+    }
+
+    /**
+     * The message is asserted whole here, on a reason of the test's own
+     * choosing: PCRE words its complaints differently between library
+     * versions, so pinning the sentence through a real compile failure would
+     * pin the PCRE build as well.
+     */
+    #[DataProvider('invalidPatternMessageProvider')]
+    public function theRefusalSpellsOutWhatWasGiven(?string $reason, string $expected): void
+    {
+        Assert::same(InvalidCallSpecification::invalidPattern('/[unclosed/', $reason)->getMessage(), $expected);
+    }
+
+    public static function invalidPatternMessageProvider(): iterable
+    {
+        yield 'with a reason' => [
+            'missing terminating ] for character class',
+            "`Arg::string()` was given `/[unclosed/`, which is not a valid PCRE pattern: "
+            . "missing terminating ] for character class.\n"
+            . 'It would match no string and would raise a warning inside the code under test on '
+            . 'every call. Check the delimiters and the escaping.',
+        ];
+
+        yield 'with none' => [
+            null,
+            "`Arg::string()` was given `/[unclosed/`, which is not a valid PCRE pattern.\n"
+            . 'It would match no string and would raise a warning inside the code under test on '
+            . 'every call. Check the delimiters and the escaping.',
+        ];
+    }
+
+    public function aPatternThatCompilesIsAccepted(): void
+    {
+        $matcher = Arg::string('/^ord-/');
+        \assert($matcher instanceof ArgumentMatcher);
+
+        Assert::true($matcher->matches('ord-1'));
+        Assert::false($matcher->matches('inv-1'));
+    }
+
+    /**
+     * `Arg::which()` swallows a throwing getter because the getter belongs to
+     * the argument. A predicate belongs to the test, so its exception travels:
+     * a broken predicate reported as "no match" would surface as an
+     * expectation never met, pointing at the subject instead of at itself.
+     */
+    public function aThrowingPredicateIsNotSwallowed(): void
+    {
+        $matcher = Arg::satisfies(static fn(mixed $value): bool => throw new \DomainException('predicate is broken'));
+        \assert($matcher instanceof ArgumentMatcher);
+
+        Expect::exception(\DomainException::class)->withMessage('predicate is broken');
+
+        $matcher->matches('anything');
+    }
+
     public function countAcceptsACountableObject(): void
     {
         $countable = new \ArrayObject([1, 2]);

--- a/tests/LedgerTest.php
+++ b/tests/LedgerTest.php
@@ -744,6 +744,32 @@ final class LedgerTest
         Understudy::verifySequence(fn() => $repository->count());
     }
 
+    /**
+     * An empty `verifySequence()` asserts that nothing happened, where an
+     * empty `expectSequence()` is refused. The asymmetry is the difference
+     * between reading a log that exists and arming a protocol that would put
+     * every later call on trial with no step to try it against — pinned here
+     * so the two are not "made consistent" by accident.
+     */
+    #[ExpectNoAssertions]
+    public function anEmptyVerifySequenceAssertsThatNothingHappened(): void
+    {
+        Understudy::for(BookRepository::class);
+
+        Understudy::verifySequence();
+    }
+
+    public function anEmptyVerifySequenceFailsOnACallThatDidHappen(): void
+    {
+        $repository = Understudy::for(BookRepository::class);
+
+        $repository->count();
+
+        Expect::exception(VerificationFailed::class)->withMessageContaining('exactly 0 call(s)');
+
+        Understudy::verifySequence();
+    }
+
     #[ExpectNoAssertions]
     public function verifySequenceAccountsForTheWholeLog(): void
     {


### PR DESCRIPTION
Fixes #86.

## What changed

`Arg::int(min: 5, max: 1)`, the same shape in `Arg::float()` and `Arg::count()`,
and `Arg::string('/[unclosed')` all built a matcher that answered "no" to every
argument. A typo therefore surfaced as an expectation never met, in teardown,
with nothing pointing at its cause — and the broken pattern additionally raised
PHP's own `preg_match(): Compilation failed` warning on **every call from
inside the code under test**, which is the one thing the package says a matcher
must never do.

Both are now refused with `InvalidCallSpecification` where they are written,
the way `Arg::operands()` already refuses an empty combinator. Validation sits
in `Arg`, not in the `@internal` matchers, so the analyser packages can
diagnose the same mistake statically later without reaching into them.

The pattern is compiled once, under an error handler of our own: the probe must
not raise the warning it exists to prevent, and PCRE's reason is what tells the
reader whether the delimiters or the escaping are wrong, so it goes into the
message.

## Two decisions written down rather than changed

- **`Arg::satisfies()` does not catch a throwing predicate.** `Arg::which()`
  does catch, because the getter belongs to the *argument* — foreign code, and
  "it threw" can only mean "not this one". A predicate is the test's own code:
  reading its exception as a mismatch would report an expectation never met and
  point at the subject instead of at the predicate.
- **An empty `verifySequence()` asserts that nothing happened**, where an empty
  `expectSequence()` is refused. Arming an empty protocol would put every later
  call on trial with no step to try it against; reading an empty log is a real
  question with a real answer, and a call that did happen is already reported.

Both are now in the docblocks and pinned by tests, so neither is "made
consistent" by a later reading of the pair.

## Also

The mutation gate quoted in `README.md`, `README.ru.md` and `AGENTS.md` said
85, 85 and 90 while `infection.json5` has required 92 since #76. All three now
say 92 and point at the reason recorded beside the number, and the AGENTS rule
says what to do about a gate quoted in more than one place.

## Verification

`composer build` green (938 unit + 26 integration). Full mutation run: MSI
94.5% against a gate of 92, and no escaped mutant in the new code — the
`try/finally` around the probe was dropped rather than left as an equivalent
mutant, since nothing between the two handler calls can throw. `make docs-api`,
`make docs-build`, `make docs-claims` (66 claims) and `make docs-vale` green.