### PR TITLE
Pin a foreign capture() in the parity matrix, and record the perf re-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- **The parity matrix gained `ForeignCapture`**: somebody else's zero-argument
+  `capture()` written inside a specification. Both analysers must report it,
+  and one of them did not — `understudy-psalm` decided a capture by the method
+  name and an empty argument list, because its issue hook is handed no resolved
+  receiver, and swallowed the diagnostic. Fixed in that package (#18) and
+  pinned here, which is what the matrix exists for.
+- `perf/README.md` records that the figures were re-verified for the v0.5.0
+  tag and left unchanged: three runs a side at the commit they were taken from
+  and on the release candidate, with our movement inside the competitors'.
+
 ## 0.5.0 — 2026-09-03
 
 A minor rather than a patch: a closing `scope()` verifies less than it did, and

--- a/bin/consumer-smoke
+++ b/bin/consumer-smoke
@@ -527,11 +527,13 @@ PHP
 # where two copies would drift and neither would be wrong on its own.
 #
 # Each file carries exactly one idiom and is named for it, so an analyser's
-# output can be judged by file name alone. `Foreign*` are the two that matter
-# most: somebody else's class named `Arg`, which an answer read off the source
-# text gets wrong in both directions.
+# output can be judged by file name alone. `Foreign*` are the three that matter
+# most: somebody else's class named `Arg` and somebody else's `capture()`.
+# Both are shapes an analyser can only get right by resolving the class, and
+# both were got wrong by reading the source text instead — in Psalm, in two
+# separate places, each found only because the other analyser disagreed.
 PARITY_SILENT='OwnUnqualified OwnAliased OwnQualified StaticVerb RestShort CaptorSpec'
-PARITY_REPORTED='ForeignUnqualified ForeignAliased RealCall RestLeak CaptorLeak'
+PARITY_REPORTED='ForeignUnqualified ForeignAliased ForeignCapture RealCall RestLeak CaptorLeak'
 
 # Writes the matrix into a leg's `src/`, beside whatever that leg already has.
 parity_fixtures() { # dir
@@ -726,6 +728,51 @@ final class ForeignUnqualified
         $gate = Understudy::for(Gate::class);
 
         when(fn(): bool => $gate->open(Arg::int()));
+    }
+}
+PHP
+
+    cat > "$src/Other/Recorder.php" <<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace Consumer\Other;
+
+/**
+ * Somebody else's object with a zero-argument `capture()`. It is not a captor,
+ * and an analyser that reads the method name instead of resolving the class
+ * takes it for one.
+ */
+final class Recorder
+{
+    public function capture(): mixed
+    {
+        return 0;
+    }
+}
+PHP
+
+    cat > "$src/ForeignCapture.php" <<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace Consumer;
+
+use Consumer\Other\Recorder;
+use Rasuvaeff\Understudy\Understudy;
+
+use function Rasuvaeff\Understudy\when;
+
+final class ForeignCapture
+{
+    public function setUp(): void
+    {
+        $gate = Understudy::for(Gate::class);
+        $recorder = new Recorder();
+
+        when(fn(): bool => $gate->open($recorder->capture()));
     }
 }
 PHP

--- a/perf/README.md
+++ b/perf/README.md
@@ -97,6 +97,16 @@ variable in the root `Makefile`, not by flags typed at a prompt. Understudy at
 `442da10`, Mockery 1.6.15, Prophecy 1.26.1, PHPUnit 12.5.33. Taken 2026-08-27,
 before the 0.2.0 tag.
 
+**Re-verified for the v0.5.0 tag on 2026-09-03**, and left unchanged because
+there was nothing to change. Three runs of the full harness at `442da10` — the
+commit above — and three on the release candidate, same machine, same pinning,
+in one sitting. Understudy moved +0.7% to +3.3% across the six tables while
+Mockery, Prophecy and PHPUnit moved −4.3% to +4.2% in the same runs: the
+competitors' movement is the noise floor, and ours sits inside it, so nothing
+is attributable and the figures below still describe the library. This is the
+A/B the release rule asks for, and the reason it asks for the old commit to be
+re-run rather than compared against the number in this file.
+
 **The previous set was taken at `9837dfd` — a commit before 0.1.0**, so it
 described no released version at all. Between it and the first tag a regression
 landed that those figures did not show: double creation went from about 1.7µs to


### PR DESCRIPTION
Two findings of `UNDERSTUDY-PACKAGES-REVIEW.md`, from the core side.

## The matrix did its job

`ForeignCapture` — somebody else's zero-argument `capture()` written inside a
specification — joins `PARITY_REPORTED`. Both analysers must report it, and one
of them did not: `understudy-psalm` decided a capture by the method name and an
empty argument list, because its issue hook is handed no resolved receiver, so
it took a foreign method for a captor's and swallowed the diagnostic. PHPStan,
whose extension resolves the class, reported it all along.

That is exactly the shape the matrix was built for — a difference between two
implementations of one contract, found by comparing them rather than by
somebody noticing. Fixed in rasuvaeff/understudy-psalm#19; the fixture is what
keeps both sides honest from here.

Verified on both legs against local checkouts, in the form their CI uses:

```
ok    parity: 6 silent and 6 reported idioms agree with the table   (psalm)
ok    parity: 6 silent and 6 reported idioms agree with the table   (phpstan)
```

## The perf record

`perf/README.md` cited `442da10` and "before the 0.2.0 tag" while the current
tag is v0.5.0, which reads as figures nobody has checked since. The measurement
was made — three runs of the full harness at that commit and three on the
release candidate, same machine and pinning, on 2026-09-03 — and found our
movement (+0.7% to +3.3%) inside the competitors' movement (−4.3% to +4.2%) in
the same runs. So there was nothing to replace, and now the file says so.

`composer build` green.