### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 — 2026-09-04
+
+A minor rather than a patch: a pair of targets the unifier used to accept is
+now refused. Composer's caret treats that as breaking on 0.x, and it is —
+though what those targets produced was a double that logged an argument value
+neither contract declares.
+
 
 - **Conflicting parameter defaults across unified contracts rejected the
   target instead of quietly becoming `null`.** `Understudy::for(A::class,
@@ -24,7 +30,6 @@
   random phase: both signed zeros, `0` against `0.0` and `'0'`, `''` against
   `null` and `false`, `1` against `true`, and `NAN`, which matches no call
   including itself.
-
 - **The parity matrix gained `ForeignCapture`**: somebody else's zero-argument
   `capture()` written inside a specification. Both analysers must report it,
   and one of them did not — `understudy-psalm` decided a capture by the method


### PR DESCRIPTION
A minor rather than a patch: a pair of targets the unifier used to accept is now refused. Composer's caret treats that as breaking on 0.x, and it is — though what those targets produced was a double that logged an argument value neither contract declares.

Contents, all already merged:

- Conflicting parameter defaults across unified contracts reject the target instead of quietly becoming `null` (#91).
- A stub armed with `-0.0` is found by a call made with `0.0`: the dispatch index keys a literal the way `===` compares it (#92).
- `DispatchIndexPropertyTest` gains a second property, about identity rather than order, over literals of every scalar type.
- The analyser parity matrix gained `ForeignCapture`, and `perf/README.md` records the v0.5.0 re-check.

The version heading is `## 0.6.0 — 2026-09-04` rather than `## Unreleased` on purpose: the `Backward compatibility` job tolerates a non-zero report only when the top heading declares the boundary, and on 0.x a minor above the last tag is that boundary.