### PR TITLE
Match a bypass target the way PHP matches a class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- **`bypassFinals()` missed a target whose declaration is written in another
+  case.** `final class gate` in `namespace App` IS `App\Gate` to PHP —
+  `class_exists()` says so, and `bypassFinals(\App\Gate::class)` accepted the
+  name and installed the target — but the strip compared both halves with
+  `===` and walked past the very declaration it was installed for. The class
+  stayed final, with nothing said until `for()` refused it. Both halves are
+  compared the way PHP compares them now. Fixes #97.
+
 ## 0.7.0 — 2026-09-04
 
 A minor rather than a patch: `Invocation` loses two public properties,

--- a/src/Bypass/FinalStripper.php
+++ b/src/Bypass/FinalStripper.php
@@ -166,7 +166,14 @@ final class FinalStripper
             }
 
             foreach ($targets as $target) {
-                if ($target['class'] === $token[1] && $target['namespace'] === $namespace) {
+                // Case-insensitively, because that is what PHP does with
+                // these names: `final class gate` in `namespace App` IS
+                // `App\Gate`, and `class_exists()` says so. Comparing with
+                // `===` walked past the declaration the target was installed
+                // for and left the class final, with nothing said until
+                // `for()` refused it.
+                if (strcasecmp($target['class'], $token[1]) === 0
+                    && strcasecmp($target['namespace'], $namespace) === 0) {
                     return true;
                 }
             }

--- a/tests/Bypass/FinalStripperTest.php
+++ b/tests/Bypass/FinalStripperTest.php
@@ -82,16 +82,39 @@ final class FinalStripperTest
             '<?php namespace App; final class GateKeeper {}',
         ];
 
-        // The pre-filter is case-insensitive and the tokenizer's own name
-        // comparison is not, which is the safe direction for them to differ
-        // in: a looser filter only ever lets MORE files reach the decision.
-        // PHP would call this declaration `App\Gate`, so a target written in
-        // another case is not opened — pre-existing behaviour, pinned here
-        // because the filter is now the first thing that sees the name.
-        yield 'a declaration in another case reaches the tokenizer and is left alone' => [
+        // PHP calls this declaration `App\Gate` and so does `class_exists()`,
+        // so the strip has to as well. Comparing with `===` walked past the
+        // very declaration the target was installed for.
+        yield 'a class declared in another case is still the target' => [
             '<?php namespace App; final class gate {}',
             [['namespace' => 'App', 'class' => 'Gate']],
-            '<?php namespace App; final class gate {}',
+            '<?php namespace App; class gate {}',
+        ];
+
+        yield 'the namespace is case-insensitive too' => [
+            '<?php namespace app; final class Gate {}',
+            [['namespace' => 'App', 'class' => 'Gate']],
+            '<?php namespace app; class Gate {}',
+        ];
+
+        yield 'a target written in another case finds the declaration' => [
+            '<?php namespace App; final class Gate {}',
+            [['namespace' => 'APP', 'class' => 'GATE']],
+            '<?php namespace App; class Gate {}',
+        ];
+
+        // Case-insensitive is not name-insensitive: a different class in the
+        // same namespace keeps its `final` however either is spelled.
+        yield 'another class in the same namespace is untouched' => [
+            '<?php namespace App; final class Wall {}',
+            [['namespace' => 'app', 'class' => 'gate']],
+            '<?php namespace App; final class Wall {}',
+        ];
+
+        yield 'the right name in the wrong namespace is untouched' => [
+            '<?php namespace Other; final class Gate {}',
+            [['namespace' => 'app', 'class' => 'gate']],
+            '<?php namespace Other; final class Gate {}',
         ];
 
         yield 'an empty target list strips nothing' => [

--- a/tests/Fixture/Bypass/LowercaseGate.php
+++ b/tests/Fixture/Bypass/LowercaseGate.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rasuvaeff\Understudy\Tests\Fixture\Bypass;
+
+/**
+ * The declaration writes the class name in a case nobody references it by.
+ * PHP does not care — `class_exists()` resolves it under either spelling — and
+ * neither should the strip: comparing the name with `===` walked past this
+ * very declaration and left it final, with nothing said until `for()` refused
+ * it.
+ */
+final class lowercasegate {}

--- a/tests/Fixture/Bypass/scenario.php
+++ b/tests/Fixture/Bypass/scenario.php
@@ -34,8 +34,16 @@ echo match ($scenario) {
     // The name handed to `bypassFinals()` is the one this file writes; the
     // declaration writes it in another case. PHP calls them one class, and so
     // must the strip.
-    'case-insensitive-target' => (static function (): string {
+    //
+    // Required by hand rather than autoloaded, and not for convenience:
+    // Composer's classmap keys a class by the case it was DECLARED in, and
+    // under `--classmap-authoritative` the lookup is exact — so the very
+    // mismatch this scenario is about would make the autoloader miss the file
+    // before the stripper ever saw it. The require goes through the wrapper
+    // exactly as an autoloaded include would.
+    'case-insensitive-target' => (static function () use ($fixtures): string {
         Understudy::bypassFinals(LowercaseGate::class);
+        require $fixtures . '/LowercaseGate.php';
         $double = Understudy::for(LowercaseGate::class);
 
         return $double instanceof LowercaseGate ? 'doubled' : 'not a LowercaseGate';

--- a/tests/Fixture/Bypass/scenario.php
+++ b/tests/Fixture/Bypass/scenario.php
@@ -31,6 +31,16 @@ echo match ($scenario) {
         return $double instanceof SealedGate ? 'doubled' : 'not a SealedGate';
     })(),
 
+    // The name handed to `bypassFinals()` is the one this file writes; the
+    // declaration writes it in another case. PHP calls them one class, and so
+    // must the strip.
+    'case-insensitive-target' => (static function (): string {
+        Understudy::bypassFinals(LowercaseGate::class);
+        $double = Understudy::for(LowercaseGate::class);
+
+        return $double instanceof LowercaseGate ? 'doubled' : 'not a LowercaseGate';
+    })(),
+
     'without-bypass' => (static function (): string {
         try {
             Understudy::for(SealedGate::class);

--- a/tests/Integration/BypassFinalsIntegrationTest.php
+++ b/tests/Integration/BypassFinalsIntegrationTest.php
@@ -37,6 +37,7 @@ final class BypassFinalsIntegrationTest
     public static function scenarioProvider(): iterable
     {
         yield 'a bypassed final class can be doubled' => ['targeted', 'doubled'];
+        yield 'a target is matched however either name is cased' => ['case-insensitive-target', 'doubled'];
         yield 'without bypass the refusal names the recipe' => ['without-bypass', 'refused with the recipe'];
         yield 'only the named class in a file is opened' => ['sibling-untouched', 'opened/still final'];
         yield 'global mode opens every class in a file' => ['global', 'opened/opened'];


### PR DESCRIPTION
`final class gate` in `namespace App` **is** `App\Gate` to PHP. `class_exists()` says so, `bypassFinals(\App\Gate::class)` accepted the name and installed the target — and then the strip compared both halves with `===`, walked past the very declaration it was installed for, and left the class final.

Nothing reported it. The first thing to say so was `Understudy::for()`, refusing a class the caller believed was open.

## The fix

Both halves are compared with `strcasecmp()`, which is what PHP does with these names. The stored target keeps the case the caller wrote, so messages are unaffected.

The pre-filter added in 0.7.0 already was case-insensitive (`stripos`) — the safe direction for the two to differ in, since a looser filter only lets more files reach the decision — which left the decision as the only case-sensitive step in the path.

## How it is pinned

In the stripper, five cases that were one before:

| Source | Target | Result |
|---|---|---|
| `namespace App; final class gate` | `App\Gate` | opened |
| `namespace app; final class Gate` | `App\Gate` | opened |
| `namespace App; final class Gate` | `APP\GATE` | opened |
| `namespace App; final class Wall` | `app\gate` | untouched |
| `namespace Other; final class Gate` | `app\gate` | untouched |

And end to end, in a process of its own, because a class is read from disk once per process: the fixture declares `final class lowercasegate`, the scenario asks for `LowercaseGate::class`, and the double has to come back. Reverting the comparison reddens exactly that scenario and nothing else.

## Verification

- `composer build` green, integration suite included.
- `composer mutation` on PHP 8.4: 2590 + 279 + 4 of 3044 killed, escaped 173 — the same 173 as before this branch.
- `bin/package-audit`: 0 errors, 0 warnings.

A patch: a class that used to stay final is now opened, which is the thing the caller asked for.

Fixes #97