### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.7.1 — 2026-09-04
 
 - **`bypassFinals()` missed a target whose declaration is written in another
   case.** `final class gate` in `namespace App` IS `App\Gate` to PHP —


### PR DESCRIPTION
A patch: a class the strip should have opened stayed final.

`bypassFinals(\App\Gate::class)` accepted the name, installed the target, and then walked past a declaration written as `final class gate` — the same class to PHP, and to `class_exists()`. Nothing said so until `for()` refused it. Both halves of the name are compared the way PHP compares them now (#98, fixes #97).

Pinned in the stripper across five cases, and end to end in a process of its own — where the second pass, under `--classmap-authoritative`, also caught that Composer keys a classmap by the case a class was *declared* in, so the fixture is required by hand rather than autoloaded.