### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.7.2 — 2026-09-04
 
 - **Documentation review fixes.** llms.txt no longer claims `bypassFinals()`
   and the runner adapters are «being built next» (both shipped long ago), and


### PR DESCRIPTION
Dates the documentation-review CHANGELOG entry. Docs-only patch; dist changes via README/README.ru/llms.txt/MIGRATION.md/CHANGELOG.