### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.0 — 2026-09-05
 
 - **`Understudy::for()` no longer kills the process on five built-in
   interfaces.** `Throwable`, `UnitEnum`, `BackedEnum`, `DateTimeInterface` and


### PR DESCRIPTION
Cuts 0.8.0 from what #112 merged.

A minor rather than a patch, on three counts a consumer can observe:

- `Arg::instanceOf()` refuses a class that is not loadable, where it used to match nothing forever;
- `Cardinality` and `returns()` throw `InvalidSpecificationArgument` instead of a bare `\InvalidArgumentException` (compatible — it extends that class — but the type a `catch` sees is new);
- failure messages and `transcript()` render a `#[\SensitiveParameter]` as its type, and escape control bytes.

The five uncatchable fatals and the duplicate-contract fatal are the reason to release it promptly: `Understudy::for(DateTimeInterface::class)` took the whole suite run down.

Satellites follow with `^0.8` as a single term — the accumulating `^0.4 || ^0.5 || …` they carry today is what leaves them uninstallable beside a new core.