### PR TITLE
Complete Understudy API method summaries

### DIFF
--- a/docs/scripts/api-snapshot.json
+++ b/docs/scripts/api-snapshot.json
@@ -2,7 +2,7 @@
     "classes": [
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Arg",
             "kind": "class",
@@ -238,7 +238,7 @@
                         }
                     ],
                     "returnType": "mixed",
-                    "summary": "",
+                    "summary": "Matches an object by its class or interface.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -246,7 +246,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 145
+                    "startLine": 147
                 },
                 {
                     "name": "captor",
@@ -269,7 +269,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 177
+                    "startLine": 179
                 },
                 {
                     "name": "satisfies",
@@ -299,7 +299,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 196
+                    "startLine": 198
                 },
                 {
                     "name": "containing",
@@ -322,7 +322,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 207
+                    "startLine": 209
                 },
                 {
                     "name": "count",
@@ -352,7 +352,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 218
+                    "startLine": 220
                 },
                 {
                     "name": "which",
@@ -382,7 +382,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 230
+                    "startLine": 232
                 },
                 {
                     "name": "none",
@@ -397,7 +397,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 334
+                    "startLine": 336
                 },
                 {
                     "name": "remaining",
@@ -412,7 +412,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 343
+                    "startLine": 345
                 },
                 {
                     "name": "rest",
@@ -427,7 +427,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 364
+                    "startLine": 366
                 }
             ],
             "constants": [],
@@ -437,7 +437,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Bypass\\FileWrapper",
             "kind": "class",
@@ -1099,7 +1099,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Bypass\\FinalStripper",
             "kind": "class",
@@ -1159,7 +1159,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Captor",
             "kind": "class",
@@ -1254,7 +1254,7 @@
                         }
                     ],
                     "returnType": "void",
-                    "summary": "",
+                    "summary": "Records a value captured by a matched specification.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -1262,14 +1262,14 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 92
+                    "startLine": 94
                 },
                 {
                     "name": "discard",
                     "static": false,
                     "params": [],
                     "returnType": "void",
-                    "summary": "",
+                    "summary": "Clears values captured in a finished runtime context.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -1277,7 +1277,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 101
+                    "startLine": 105
                 }
             ],
             "constants": [],
@@ -1287,7 +1287,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Cardinality",
             "kind": "class",
@@ -1480,7 +1480,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Codegen\\Blueprint",
             "kind": "class",
@@ -1617,7 +1617,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Codegen\\DoubleFactory",
             "kind": "class",
@@ -1746,7 +1746,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Codegen\\MethodSignature",
             "kind": "class",
@@ -1875,7 +1875,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Codegen\\PropertyDefaults",
             "kind": "class",
@@ -1928,7 +1928,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Codegen\\PropertySignature",
             "kind": "class",
@@ -2018,7 +2018,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Codegen\\TargetUnifier",
             "kind": "class",
@@ -2071,7 +2071,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Codegen\\TypeRenderer",
             "kind": "class",
@@ -2191,7 +2191,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Defaults\\DefaultFactories",
             "kind": "class",
@@ -2296,7 +2296,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Defaults\\TypeDefaultResolver",
             "kind": "class",
@@ -2435,7 +2435,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\AmbiguousDefaultFactory",
             "kind": "class",
@@ -2477,7 +2477,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\AmbiguousDefaultFactory",
-                    "summary": "",
+                    "summary": "Builds the error for equally close default factories.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2485,7 +2485,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 18
+                    "startLine": 20
                 }
             ],
             "constants": [],
@@ -2495,7 +2495,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\BypassUnavailable",
             "kind": "class",
@@ -2530,7 +2530,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\BypassUnavailable",
-                    "summary": "",
+                    "summary": "Builds the error for a class loaded before bypass could be installed.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2538,7 +2538,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 17
+                    "startLine": 19
                 },
                 {
                     "name": "notAClass",
@@ -2560,7 +2560,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\BypassUnavailable",
-                    "summary": "",
+                    "summary": "Builds the error for a target that is not a class.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2568,7 +2568,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 31
+                    "startLine": 35
                 },
                 {
                     "name": "foreignWrapper",
@@ -2583,15 +2583,15 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\BypassUnavailable",
-                    "summary": "Something else already transforms PHP source on `file://`; replacing it\nwould silently disable whatever it does.",
-                    "description": "",
+                    "summary": "Builds the error for an already-installed foreign source wrapper.",
+                    "description": "Something else already transforms PHP source on `file://`; replacing it\nwould silently disable whatever it does.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 45
+                    "startLine": 51
                 }
             ],
             "constants": [],
@@ -2601,7 +2601,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\CannotWire",
             "kind": "class",
@@ -2643,15 +2643,15 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\CannotWire",
-                    "summary": "Takes a plain string, not a `class-string`: \"there is no such class\" is\none of the reasons it reports.",
-                    "description": "",
+                    "summary": "Builds the error for a subject that cannot be wired as a concrete class.",
+                    "description": "Takes a plain string, not a `class-string`: \"there is no such class\" is\none of the reasons it reports.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 18
+                    "startLine": 20
                 },
                 {
                     "name": "inaccessibleConstructor",
@@ -2673,7 +2673,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\CannotWire",
-                    "summary": "",
+                    "summary": "Builds the error for an inaccessible subject constructor.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2681,7 +2681,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 31
+                    "startLine": 35
                 },
                 {
                     "name": "unknownOverride",
@@ -2710,7 +2710,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\CannotWire",
-                    "summary": "",
+                    "summary": "Builds the error for an unknown constructor override.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2718,7 +2718,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 45
+                    "startLine": 51
                 },
                 {
                     "name": "incompatibleOverride",
@@ -2754,7 +2754,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\CannotWire",
-                    "summary": "",
+                    "summary": "Builds the error for an override with an incompatible type.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2762,7 +2762,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 59
+                    "startLine": 67
                 },
                 {
                     "name": "undecidableParameter",
@@ -2798,7 +2798,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\CannotWire",
-                    "summary": "",
+                    "summary": "Builds the error for a constructor parameter with no safe answer.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2806,7 +2806,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 75
+                    "startLine": 85
                 },
                 {
                     "name": "referenceParameter",
@@ -2828,7 +2828,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\CannotWire",
-                    "summary": "",
+                    "summary": "Builds the error for a by-reference constructor parameter.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2836,7 +2836,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 92
+                    "startLine": 104
                 }
             ],
             "constants": [],
@@ -2846,7 +2846,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\ConflictingExpectation",
             "kind": "class",
@@ -2888,7 +2888,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ConflictingExpectation",
-                    "summary": "",
+                    "summary": "Builds the error for a claim registered after an identical stub.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2896,7 +2896,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 27
+                    "startLine": 29
                 },
                 {
                     "name": "stubAfterCountedExpectation",
@@ -2918,7 +2918,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ConflictingExpectation",
-                    "summary": "",
+                    "summary": "Builds the error for a stub registered after a counted expectation.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2926,7 +2926,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 43
+                    "startLine": 47
                 },
                 {
                     "name": "duplicateCountedExpectation",
@@ -2948,7 +2948,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ConflictingExpectation",
-                    "summary": "",
+                    "summary": "Builds the error for duplicate counted expectations.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -2956,7 +2956,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 59
+                    "startLine": 65
                 }
             ],
             "constants": [],
@@ -2966,7 +2966,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\ContextOwnershipViolation",
             "kind": "class",
@@ -2993,15 +2993,15 @@
                     "static": true,
                     "params": [],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ContextOwnershipViolation",
-                    "summary": "A double was configured or verified from a context other than the one\nthat created it — another Fiber, or outside the scope it was built in.",
-                    "description": "",
+                    "summary": "Builds the error for using a double from another runtime context.",
+                    "description": "A double was configured or verified from a context other than the one\nthat created it — another Fiber, or outside the scope it was built in.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 20
+                    "startLine": 22
                 }
             ],
             "constants": [],
@@ -3011,7 +3011,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\ForgottenDouble",
             "kind": "class",
@@ -3046,7 +3046,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ForgottenDouble",
-                    "summary": "",
+                    "summary": "Builds the error for calling a double after its context was reset.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3054,7 +3054,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 21
+                    "startLine": 23
                 },
                 {
                     "name": "onPurpose",
@@ -3069,7 +3069,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ForgottenDouble",
-                    "summary": "",
+                    "summary": "Builds the error for calling a deliberately retired double.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3077,7 +3077,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 34
+                    "startLine": 38
                 },
                 {
                     "name": "propertyAfterReset",
@@ -3092,7 +3092,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ForgottenDouble",
-                    "summary": "",
+                    "summary": "Builds the error for reading a property after reset.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3100,22 +3100,22 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 46
+                    "startLine": 52
                 },
                 {
                     "name": "retired",
                     "static": true,
                     "params": [],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ForgottenDouble",
-                    "summary": "A facade — `strict()`, `verify()`, `nothingElse()`, `forget()` itself —\nwas asked about a double that `Understudy::forget()` retired.",
-                    "description": "",
+                    "summary": "Builds the error for asking a retired double through the facade.",
+                    "description": "A facade — `strict()`, `verify()`, `nothingElse()`, `forget()` itself —\nwas asked about a double that `Understudy::forget()` retired.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 60
+                    "startLine": 68
                 },
                 {
                     "name": "fromDefaultFactory",
@@ -3130,7 +3130,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ForgottenDouble",
-                    "summary": "",
+                    "summary": "Builds the error for a default factory returning a retired double.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3138,7 +3138,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 72
+                    "startLine": 82
                 }
             ],
             "constants": [],
@@ -3148,7 +3148,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\ForwardingTargetMismatch",
             "kind": "class",
@@ -3183,7 +3183,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ForwardingTargetMismatch",
-                    "summary": "",
+                    "summary": "Builds the error for forwarding to another understudy.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3191,7 +3191,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 18
+                    "startLine": 20
                 },
                 {
                     "name": "missingContract",
@@ -3220,7 +3220,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\ForwardingTargetMismatch",
-                    "summary": "",
+                    "summary": "Builds the error for a forwarding target missing a contract.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3228,7 +3228,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 32
+                    "startLine": 36
                 }
             ],
             "constants": [],
@@ -3238,7 +3238,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
             "kind": "class",
@@ -3363,7 +3363,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
-                    "summary": "",
+                    "summary": "Builds the error for a tail matcher in the wrong position.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3371,7 +3371,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 87
+                    "startLine": 89
                 },
                 {
                     "name": "emptyCombinator",
@@ -3386,7 +3386,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
-                    "summary": "",
+                    "summary": "Builds the error for an empty matcher combinator.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3394,7 +3394,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 102
+                    "startLine": 106
                 },
                 {
                     "name": "tailMatcherInCombinator",
@@ -3416,7 +3416,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
-                    "summary": "",
+                    "summary": "Builds the error for putting a tail matcher inside a combinator.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3424,7 +3424,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 116
+                    "startLine": 122
                 },
                 {
                     "name": "emptySequence",
@@ -3439,7 +3439,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 131
+                    "startLine": 137
                 },
                 {
                     "name": "protocolAlreadyArmed",
@@ -3461,7 +3461,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
-                    "summary": "",
+                    "summary": "Builds the error for arming a protocol while another is active.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3469,7 +3469,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 143
+                    "startLine": 151
                 },
                 {
                     "name": "incompleteSpecification",
@@ -3498,7 +3498,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
-                    "summary": "",
+                    "summary": "Builds the error for an incomplete call specification.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3506,7 +3506,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 159
+                    "startLine": 169
                 },
                 {
                     "name": "omittedBeforeSpecified",
@@ -3535,7 +3535,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
-                    "summary": "",
+                    "summary": "Builds the error for an omitted argument before a specified one.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3543,7 +3543,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 175
+                    "startLine": 187
                 },
                 {
                     "name": "omittedTailNeedsRest",
@@ -3565,7 +3565,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
-                    "summary": "",
+                    "summary": "Builds the error for an omitted required tail without `Arg::rest()`.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3573,7 +3573,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 190
+                    "startLine": 204
                 },
                 {
                     "name": "closureFailed",
@@ -3596,7 +3596,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 205
+                    "startLine": 219
                 },
                 {
                     "name": "staticMethodCalled",
@@ -3611,7 +3611,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidCallSpecification",
-                    "summary": "",
+                    "summary": "Builds the error for a static method used in a specification.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3619,7 +3619,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 217
+                    "startLine": 233
                 }
             ],
             "constants": [],
@@ -3629,7 +3629,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\InvalidDefaultValue",
             "kind": "class",
@@ -3671,7 +3671,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\InvalidDefaultValue",
-                    "summary": "",
+                    "summary": "Builds the error for a factory value with the wrong type.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3679,7 +3679,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 17
+                    "startLine": 19
                 }
             ],
             "constants": [],
@@ -3689,7 +3689,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\InvalidSpecificationArgument",
             "kind": "class",
@@ -3877,7 +3877,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\MatcherLeaked",
             "kind": "class",
@@ -3926,7 +3926,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\MatcherLeaked",
-                    "summary": "",
+                    "summary": "Builds the error for a matcher used in a real call.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3934,7 +3934,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 20
+                    "startLine": 22
                 }
             ],
             "constants": [],
@@ -3944,7 +3944,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\NeverMethodCalled",
             "kind": "class",
@@ -3986,7 +3986,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\NeverMethodCalled",
-                    "summary": "",
+                    "summary": "Builds the error for an unconfigured `never` method call.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -3994,7 +3994,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 20
+                    "startLine": 22
                 },
                 {
                     "name": "withoutAnAction",
@@ -4016,7 +4016,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\NeverMethodCalled",
-                    "summary": "",
+                    "summary": "Builds the error for a `never` expectation with no action.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4024,7 +4024,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 35
+                    "startLine": 39
                 },
                 {
                     "name": "configuredToReturn",
@@ -4046,7 +4046,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\NeverMethodCalled",
-                    "summary": "",
+                    "summary": "Builds the error for a `never` method configured to return.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4054,7 +4054,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 50
+                    "startLine": 56
                 }
             ],
             "constants": [],
@@ -4064,7 +4064,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\NoDefaultValue",
             "kind": "class",
@@ -4113,7 +4113,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\NoDefaultValue",
-                    "summary": "",
+                    "summary": "Builds the error for a return type with no safe default.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4121,7 +4121,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 20
+                    "startLine": 22
                 }
             ],
             "constants": [],
@@ -4131,7 +4131,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\NothingCaptured",
             "kind": "class",
@@ -4166,7 +4166,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\NothingCaptured",
-                    "summary": "",
+                    "summary": "Builds the error for reading an empty captor.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4174,7 +4174,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 18
+                    "startLine": 20
                 }
             ],
             "constants": [],
@@ -4184,7 +4184,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\OriginalCallUnavailable",
             "kind": "class",
@@ -4219,7 +4219,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\OriginalCallUnavailable",
-                    "summary": "",
+                    "summary": "Builds the error for forwarding without a real instance.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4227,7 +4227,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 17
+                    "startLine": 19
                 },
                 {
                     "name": "withoutTarget",
@@ -4249,7 +4249,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\OriginalCallUnavailable",
-                    "summary": "",
+                    "summary": "Builds the error for delegating a call without a target.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4257,7 +4257,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 32
+                    "startLine": 36
                 }
             ],
             "constants": [],
@@ -4267,7 +4267,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\OriginalReturnTypeViolation",
             "kind": "class",
@@ -4316,7 +4316,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\OriginalReturnTypeViolation",
-                    "summary": "",
+                    "summary": "Builds the error for a forwarded fluent call returning another object.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4324,7 +4324,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 18
+                    "startLine": 20
                 }
             ],
             "constants": [],
@@ -4334,7 +4334,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\OutcomeUnavailable",
             "kind": "class",
@@ -4376,7 +4376,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\OutcomeUnavailable",
-                    "summary": "",
+                    "summary": "Builds the error for reading a return value after a throw.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4384,7 +4384,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 19
+                    "startLine": 21
                 },
                 {
                     "name": "discardedByLean",
@@ -4399,7 +4399,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\OutcomeUnavailable",
-                    "summary": "",
+                    "summary": "Builds the error for reading a value discarded by lean mode.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4407,7 +4407,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 31
+                    "startLine": 35
                 }
             ],
             "constants": [],
@@ -4417,7 +4417,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\StrictModeViolation",
             "kind": "class",
@@ -4484,7 +4484,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\UnderstudyError",
             "kind": "interface",
@@ -4533,7 +4533,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\UnsupportedTarget",
             "kind": "class",
@@ -4598,7 +4598,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\UnsupportedTarget",
-                    "summary": "",
+                    "summary": "Builds the error for a target that cannot be doubled.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4606,7 +4606,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 30
+                    "startLine": 32
                 },
                 {
                     "name": "signatureConflict",
@@ -4635,7 +4635,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\UnsupportedTarget",
-                    "summary": "",
+                    "summary": "Builds the error for incompatible target signatures.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4643,7 +4643,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 42
+                    "startLine": 46
                 }
             ],
             "constants": [],
@@ -4653,7 +4653,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Exception\\VerificationFailed",
             "kind": "class",
@@ -4707,7 +4707,7 @@
                         }
                     ],
                     "returnType": "Rasuvaeff\\Understudy\\Exception\\VerificationFailed",
-                    "summary": "",
+                    "summary": "Builds a verification failure from its structured records.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -4715,7 +4715,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 35
+                    "startLine": 37
                 },
                 {
                     "name": "failures",
@@ -4730,7 +4730,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 52
+                    "startLine": 54
                 }
             ],
             "constants": [],
@@ -4740,7 +4740,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\ExpectBuilder",
             "kind": "class",
@@ -4788,7 +4788,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Expectation\\Action",
             "kind": "interface",
@@ -4845,7 +4845,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Expectation\\ArgumentFormatter",
             "kind": "class",
@@ -4928,7 +4928,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Expectation\\ComputeAnswer",
             "kind": "class",
@@ -4995,7 +4995,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Expectation\\Expectation",
             "kind": "class",
@@ -5453,7 +5453,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Expectation\\ReturnValue",
             "kind": "class",
@@ -5520,7 +5520,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Expectation\\ThrowError",
             "kind": "class",
@@ -5587,7 +5587,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\FailureKind",
             "kind": "enum",
@@ -5676,7 +5676,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\FailureReport",
             "kind": "class",
@@ -5861,7 +5861,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Invocation",
             "kind": "class",
@@ -5962,7 +5962,7 @@
                         }
                     ],
                     "returnType": "void",
-                    "summary": "",
+                    "summary": "Stores the arguments after a by-reference call has returned.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -5970,7 +5970,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 80
+                    "startLine": 82
                 },
                 {
                     "name": "belongsTo",
@@ -5985,7 +5985,7 @@
                         }
                     ],
                     "returnType": "bool",
-                    "summary": "",
+                    "summary": "Checks whether this invocation belongs to a given double.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -5993,7 +5993,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 88
+                    "startLine": 92
                 },
                 {
                     "name": "callOriginal",
@@ -6013,7 +6013,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 104
+                    "startLine": 108
                 },
                 {
                     "name": "recordOutcome",
@@ -6028,15 +6028,15 @@
                         }
                     ],
                     "returnType": "void",
-                    "summary": "The wrapped form of recordReturned() and recordThrown(),\nkept for the callers that still hand over an `Outcome`; dispatch itself\nuses the scalar recorders because every call reaches them.",
-                    "description": "",
+                    "summary": "Records an outcome wrapper for internal compatibility.",
+                    "description": "The wrapped form of \\Rasuvaeff\\Understudy\\recordReturned() and \\Rasuvaeff\\Understudy\\recordThrown(),\nkept for the callers that still hand over an `Outcome`; dispatch itself\nuses the scalar recorders because every call reaches them.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 125
+                    "startLine": 131
                 },
                 {
                     "name": "recordReturned",
@@ -6051,37 +6051,37 @@
                         }
                     ],
                     "returnType": "void",
-                    "summary": "Records a returned value without allocating an Outcome wrapper. The\nwrapper remains supported by recordOutcome() for internal compatibility;\ndispatch uses this scalar path because every call reaches it.",
-                    "description": "",
+                    "summary": "Records a returned value without retaining an outcome wrapper.",
+                    "description": "Records a returned value without allocating an Outcome wrapper. The\nwrapper remains supported by recordOutcome() for internal compatibility;\ndispatch uses this scalar path because every call reaches it.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 137
+                    "startLine": 145
                 },
                 {
                     "name": "recordDiscardedReturn",
                     "static": false,
                     "params": [],
                     "returnType": "void",
-                    "summary": "Records that the call returned without keeping what it returned — the\nlean double's reading of an outcome. The distinction from \"threw\" and\nfrom \"returned null\" is kept: `didReturn()` stays true, and `returned()`\nrefuses by name instead of inventing a value.",
-                    "description": "",
+                    "summary": "Records that the call returned but its value was discarded.",
+                    "description": "Records that the call returned without keeping what it returned — the\nlean double's reading of an outcome. The distinction from \"threw\" and\nfrom \"returned null\" is kept: `didReturn()` stays true, and `returned()`\nrefuses by name instead of inventing a value.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 155
+                    "startLine": 165
                 },
                 {
                     "name": "isReturnDiscarded",
                     "static": false,
                     "params": [],
                     "returnType": "bool",
-                    "summary": "",
+                    "summary": "Reports whether the returned value was discarded.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -6089,7 +6089,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 168
+                    "startLine": 180
                 },
                 {
                     "name": "recordThrown",
@@ -6104,7 +6104,7 @@
                         }
                     ],
                     "returnType": "void",
-                    "summary": "",
+                    "summary": "Records the throwable produced by the call.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -6112,29 +6112,29 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 176
+                    "startLine": 190
                 },
                 {
                     "name": "markAccounted",
                     "static": false,
                     "params": [],
                     "returnType": "void",
-                    "summary": "Marks this call as accounted for: an expectation matched it, or a\nverification claimed it. `nothingElse()` is the question this answers.",
-                    "description": "",
+                    "summary": "Marks this invocation as claimed by verification or an expectation.",
+                    "description": "Marks this call as accounted for: an expectation matched it, or a\nverification claimed it. `nothingElse()` is the question this answers.",
                     "throws": [],
                     "throwsInBody": false,
                     "inheritedFrom": null,
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 192
+                    "startLine": 208
                 },
                 {
                     "name": "isAccounted",
                     "static": false,
                     "params": [],
                     "returnType": "bool",
-                    "summary": "",
+                    "summary": "Reports whether verification or an expectation claimed this invocation.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -6142,7 +6142,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 200
+                    "startLine": 218
                 },
                 {
                     "name": "didReturn",
@@ -6157,7 +6157,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 209
+                    "startLine": 227
                 },
                 {
                     "name": "didThrow",
@@ -6172,7 +6172,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 217
+                    "startLine": 235
                 },
                 {
                     "name": "returned",
@@ -6192,7 +6192,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 230
+                    "startLine": 248
                 },
                 {
                     "name": "thrown",
@@ -6207,7 +6207,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 252
+                    "startLine": 270
                 }
             ],
             "constants": [],
@@ -6217,7 +6217,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\AllOf",
             "kind": "class",
@@ -6301,7 +6301,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\AnyArgument",
             "kind": "class",
@@ -6375,7 +6375,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\AnyOf",
             "kind": "class",
@@ -6459,7 +6459,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\AnyRest",
             "kind": "class",
@@ -6559,7 +6559,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\AnyTail",
             "kind": "class",
@@ -6659,7 +6659,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\ArgumentMatcher",
             "kind": "interface",
@@ -6747,7 +6747,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\ArrayContaining",
             "kind": "class",
@@ -6831,7 +6831,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\BooleanValue",
             "kind": "class",
@@ -6905,7 +6905,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\Bounds",
             "kind": "class",
@@ -6965,7 +6965,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\Capturing",
             "kind": "class",
@@ -7058,7 +7058,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\CountBetween",
             "kind": "class",
@@ -7151,7 +7151,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\EmptyTail",
             "kind": "class",
@@ -7251,7 +7251,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\FloatInRange",
             "kind": "class",
@@ -7344,7 +7344,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\IdenticalTo",
             "kind": "class",
@@ -7428,7 +7428,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\InstanceOfType",
             "kind": "class",
@@ -7512,7 +7512,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\IntInRange",
             "kind": "class",
@@ -7605,7 +7605,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\Negated",
             "kind": "class",
@@ -7689,7 +7689,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\Operand",
             "kind": "class",
@@ -7772,7 +7772,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\QueryEquals",
             "kind": "class",
@@ -7865,7 +7865,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\Satisfying",
             "kind": "class",
@@ -7958,7 +7958,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\StringMatching",
             "kind": "class",
@@ -8042,7 +8042,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Matcher\\TailMatcher",
             "kind": "interface",
@@ -8101,7 +8101,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Outcome",
             "kind": "class",
@@ -11607,7 +11607,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Runtime\\Absent",
             "kind": "enum",
@@ -11650,7 +11650,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Runtime\\ArmedSequence",
             "kind": "class",
@@ -11818,7 +11818,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Runtime\\DoubleState",
             "kind": "class",
@@ -12299,7 +12299,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Runtime\\InvocationSignal",
             "kind": "class",
@@ -12375,7 +12375,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Runtime\\Mode",
             "kind": "enum",
@@ -12438,7 +12438,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Runtime\\ReferenceSlot",
             "kind": "class",
@@ -12474,7 +12474,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Runtime\\Runtime",
             "kind": "class",
@@ -13023,7 +13023,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Runtime\\RuntimeContext",
             "kind": "class",
@@ -13370,7 +13370,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Runtime\\SequenceVerdict",
             "kind": "enum",
@@ -13579,7 +13579,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Understudy",
             "kind": "class",
@@ -14276,7 +14276,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\VerificationFailure",
             "kind": "class",
@@ -14383,7 +14383,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\WhenBuilder",
             "kind": "class",
@@ -14474,7 +14474,7 @@
                         }
                     ],
                     "returnType": "static",
-                    "summary": "",
+                    "summary": "Computes the return value for each matching call.",
                     "description": "",
                     "throws": [],
                     "throwsInBody": false,
@@ -14482,7 +14482,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 92
+                    "startLine": 94
                 },
                 {
                     "name": "then",
@@ -14497,7 +14497,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 111
+                    "startLine": 113
                 },
                 {
                     "name": "times",
@@ -14527,7 +14527,7 @@
                     "see": [],
                     "deprecated": null,
                     "attributes": [],
-                    "startLine": 128
+                    "startLine": 130
                 }
             ],
             "constants": [],
@@ -14537,7 +14537,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "class": "Rasuvaeff\\Understudy\\Wiring\\Wire",
             "kind": "class",
@@ -14602,7 +14602,7 @@
     "functions": [
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "kind": "function",
             "function": "Rasuvaeff\\Understudy\\expect",
@@ -14626,7 +14626,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "kind": "function",
             "function": "Rasuvaeff\\Understudy\\expectSequence",
@@ -14650,7 +14650,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "kind": "function",
             "function": "Rasuvaeff\\Understudy\\verify",
@@ -14702,7 +14702,7 @@
         },
         {
             "root": "core",
-            "rootVersion": "v0.9.0",
+            "rootVersion": "v0.9.0-2-g2ad61e3",
             "rootReference": null,
             "kind": "function",
             "function": "Rasuvaeff\\Understudy\\when",

--- a/docs/src/adapters/phpstan.md
+++ b/docs/src/adapters/phpstan.md
@@ -42,7 +42,7 @@ Below level 9 there is nothing to fix here — PHPStan does not check `mixed`
 against a declared parameter — and the rest of the extension works at every
 level.
 
-The two 0.4 idioms are covered the same way: `Arg::rest()` makes the
+The two matcher idioms are covered the same way: `Arg::rest()` makes the
 `arguments.count` report go quiet wherever a call's last written argument is
 `Arg::rest()`, and `$captor->capture()` is typed `never` like the `Arg::`
 factories (the receiver's type is what decides — a foreign `capture()` is left

--- a/docs/src/adapters/psalm.md
+++ b/docs/src/adapters/psalm.md
@@ -45,7 +45,7 @@ matcher that reaches its specification through a variable, a property or a
 helper.
 :::
 
-## The two 0.4 idioms
+## The two matcher idioms
 
 - **`Arg::rest()`** legitimately passes fewer arguments than the contract
   declares, so `TooFewArguments` goes quiet on that call — but only when the

--- a/docs/src/api/classes/Arg.md
+++ b/docs/src/api/classes/Arg.md
@@ -9,7 +9,7 @@ description: "Argument matchers, usable only inside a specification closure:"
 
 `Rasuvaeff\Understudy\Arg`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Arg.php#L49) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Arg.php#L49) — **Version:** v0.9.0-2-g2ad61e3
 
 Argument matchers, usable only inside a specification closure:
 
@@ -117,6 +117,8 @@ as a set: `anyOf('draft', 'review')`.
 ```php
 static instanceOf(class-string $type): mixed
 ```
+
+Matches an object by its class or interface.
 
 ### captor()
 

--- a/docs/src/api/classes/Captor.md
+++ b/docs/src/api/classes/Captor.md
@@ -9,7 +9,7 @@ description: "A typed argument captor, built by Arg::captor()."
 
 `Rasuvaeff\Understudy\Captor`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Captor.php#L38) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Captor.php#L38) — **Version:** v0.9.0-2-g2ad61e3
 
 **Type parameters:**
 
@@ -88,9 +88,13 @@ Every captured value, in call order.
 record(mixed $value): void
 ```
 
+Records a value captured by a matched specification.
+
 ### discard()
 
 ```php
 discard(): void
 ```
+
+Clears values captured in a finished runtime context.
 

--- a/docs/src/api/classes/Exception/AmbiguousDefaultFactory.md
+++ b/docs/src/api/classes/Exception/AmbiguousDefaultFactory.md
@@ -9,7 +9,7 @@ description: "Two registered default factories are equally close to the requeste
 
 `Rasuvaeff\Understudy\Exception\AmbiguousDefaultFactory`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/AmbiguousDefaultFactory.php#L12) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/AmbiguousDefaultFactory.php#L12) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -27,4 +27,6 @@ static between(
     non-empty-list<class-string> $candidates,
 ): Exception\AmbiguousDefaultFactory
 ```
+
+Builds the error for equally close default factories.
 

--- a/docs/src/api/classes/Exception/BypassUnavailable.md
+++ b/docs/src/api/classes/Exception/BypassUnavailable.md
@@ -9,7 +9,7 @@ description: "`bypassFinals()` cannot do what was asked of it."
 
 `Rasuvaeff\Understudy\Exception\BypassUnavailable`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/BypassUnavailable.php#L12) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/BypassUnavailable.php#L12) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -25,17 +25,23 @@ description: "`bypassFinals()` cannot do what was asked of it."
 static alreadyLoaded(class-string $class): Exception\BypassUnavailable
 ```
 
+Builds the error for a class loaded before bypass could be installed.
+
 ### notAClass()
 
 ```php
 static notAClass(class-string $class, string $kind): Exception\BypassUnavailable
 ```
 
+Builds the error for a target that is not a class.
+
 ### foreignWrapper()
 
 ```php
 static foreignWrapper(string $owner): Exception\BypassUnavailable
 ```
+
+Builds the error for an already-installed foreign source wrapper.
 
 Something else already transforms PHP source on `file://`; replacing it
 would silently disable whatever it does.

--- a/docs/src/api/classes/Exception/CannotWire.md
+++ b/docs/src/api/classes/Exception/CannotWire.md
@@ -9,7 +9,7 @@ description: "`wire()` cannot build the subject, or cannot decide what to pass i
 
 `Rasuvaeff\Understudy\Exception\CannotWire`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/CannotWire.php#L12) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/CannotWire.php#L12) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `InvalidArgumentException`
 
@@ -25,6 +25,8 @@ description: "`wire()` cannot build the subject, or cannot decide what to pass i
 static notAConcreteClass(string $sut, string $reason): Exception\CannotWire
 ```
 
+Builds the error for a subject that cannot be wired as a concrete class.
+
 Takes a plain string, not a `class-string`: "there is no such class" is
 one of the reasons it reports.
 
@@ -37,6 +39,8 @@ static inaccessibleConstructor(
 ): Exception\CannotWire
 ```
 
+Builds the error for an inaccessible subject constructor.
+
 ### unknownOverride()
 
 ```php
@@ -46,6 +50,8 @@ static unknownOverride(
     string $known,
 ): Exception\CannotWire
 ```
+
+Builds the error for an unknown constructor override.
 
 ### incompatibleOverride()
 
@@ -58,6 +64,8 @@ static incompatibleOverride(
 ): Exception\CannotWire
 ```
 
+Builds the error for an override with an incompatible type.
+
 ### undecidableParameter()
 
 ```php
@@ -69,9 +77,13 @@ static undecidableParameter(
 ): Exception\CannotWire
 ```
 
+Builds the error for a constructor parameter with no safe answer.
+
 ### referenceParameter()
 
 ```php
 static referenceParameter(class-string $sut, string $name): Exception\CannotWire
 ```
+
+Builds the error for a by-reference constructor parameter.
 

--- a/docs/src/api/classes/Exception/ConflictingExpectation.md
+++ b/docs/src/api/classes/Exception/ConflictingExpectation.md
@@ -9,7 +9,7 @@ description: "A `when()` or `expect()` names a call another registration already
 
 `Rasuvaeff\Understudy\Exception\ConflictingExpectation`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/ConflictingExpectation.php#L21) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/ConflictingExpectation.php#L21) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -37,6 +37,8 @@ static claimAfterStub(
 ): Exception\ConflictingExpectation
 ```
 
+Builds the error for a claim registered after an identical stub.
+
 ### stubAfterCountedExpectation()
 
 ```php
@@ -46,6 +48,8 @@ static stubAfterCountedExpectation(
 ): Exception\ConflictingExpectation
 ```
 
+Builds the error for a stub registered after a counted expectation.
+
 ### duplicateCountedExpectation()
 
 ```php
@@ -54,4 +58,6 @@ static duplicateCountedExpectation(
     non-empty-string $spec,
 ): Exception\ConflictingExpectation
 ```
+
+Builds the error for duplicate counted expectations.
 

--- a/docs/src/api/classes/Exception/ContextOwnershipViolation.md
+++ b/docs/src/api/classes/Exception/ContextOwnershipViolation.md
@@ -9,7 +9,7 @@ description: "Configuration and verification belong to the context that created 
 
 `Rasuvaeff\Understudy\Exception\ContextOwnershipViolation`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/ContextOwnershipViolation.php#L14) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/ContextOwnershipViolation.php#L14) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -27,6 +27,8 @@ make lifecycle verification race with work owned elsewhere.
 ```php
 static forDouble(): Exception\ContextOwnershipViolation
 ```
+
+Builds the error for using a double from another runtime context.
 
 A double was configured or verified from a context other than the one
 that created it — another Fiber, or outside the scope it was built in.

--- a/docs/src/api/classes/Exception/ForgottenDouble.md
+++ b/docs/src/api/classes/Exception/ForgottenDouble.md
@@ -9,7 +9,7 @@ description: "A double outlived the context that created it — almost always a 
 
 `Rasuvaeff\Understudy\Exception\ForgottenDouble`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/ForgottenDouble.php#L16) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/ForgottenDouble.php#L16) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -29,11 +29,15 @@ non-nullable method and surface far from the actual mistake.
 static afterReset(non-empty-string $method): Exception\ForgottenDouble
 ```
 
+Builds the error for calling a double after its context was reset.
+
 ### onPurpose()
 
 ```php
 static onPurpose(non-empty-string $method): Exception\ForgottenDouble
 ```
+
+Builds the error for calling a deliberately retired double.
 
 ### propertyAfterReset()
 
@@ -41,11 +45,15 @@ static onPurpose(non-empty-string $method): Exception\ForgottenDouble
 static propertyAfterReset(non-empty-string $property): Exception\ForgottenDouble
 ```
 
+Builds the error for reading a property after reset.
+
 ### retired()
 
 ```php
 static retired(): Exception\ForgottenDouble
 ```
+
+Builds the error for asking a retired double through the facade.
 
 A facade — `strict()`, `verify()`, `nothingElse()`, `forget()` itself —
 was asked about a double that `Understudy::forget()` retired.
@@ -55,4 +63,6 @@ was asked about a double that `Understudy::forget()` retired.
 ```php
 static fromDefaultFactory(class-string $contract): Exception\ForgottenDouble
 ```
+
+Builds the error for a default factory returning a retired double.
 

--- a/docs/src/api/classes/Exception/ForwardingTargetMismatch.md
+++ b/docs/src/api/classes/Exception/ForwardingTargetMismatch.md
@@ -9,7 +9,7 @@ description: "The instance offered as a forwarding target does not satisfy what 
 
 `Rasuvaeff\Understudy\Exception\ForwardingTargetMismatch`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/ForwardingTargetMismatch.php#L13) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/ForwardingTargetMismatch.php#L13) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `InvalidArgumentException`
 
@@ -26,6 +26,8 @@ stands in for.
 static understudyTarget(non-empty-string $label): Exception\ForwardingTargetMismatch
 ```
 
+Builds the error for forwarding to another understudy.
+
 ### missingContract()
 
 ```php
@@ -35,4 +37,6 @@ static missingContract(
     string $given,
 ): Exception\ForwardingTargetMismatch
 ```
+
+Builds the error for a forwarding target missing a contract.
 

--- a/docs/src/api/classes/Exception/InvalidCallSpecification.md
+++ b/docs/src/api/classes/Exception/InvalidCallSpecification.md
@@ -9,7 +9,7 @@ description: "A specification of the wrong SHAPE: the closure handed to when()/v
 
 `Rasuvaeff\Understudy\Exception\InvalidCallSpecification`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidCallSpecification.php#L25) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidCallSpecification.php#L25) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -83,11 +83,15 @@ static misplacedTailMatcher(
 ): Exception\InvalidCallSpecification
 ```
 
+Builds the error for a tail matcher in the wrong position.
+
 ### emptyCombinator()
 
 ```php
 static emptyCombinator(non-empty-string $matcher): Exception\InvalidCallSpecification
 ```
+
+Builds the error for an empty matcher combinator.
 
 ### tailMatcherInCombinator()
 
@@ -97,6 +101,8 @@ static tailMatcherInCombinator(
     non-empty-string $operand,
 ): Exception\InvalidCallSpecification
 ```
+
+Builds the error for putting a tail matcher inside a combinator.
 
 ### emptySequence()
 
@@ -116,6 +122,8 @@ static protocolAlreadyArmed(
 ): Exception\InvalidCallSpecification
 ```
 
+Builds the error for arming a protocol while another is active.
+
 ### incompleteSpecification()
 
 ```php
@@ -125,6 +133,8 @@ static incompleteSpecification(
     int<0, max> $declared,
 ): Exception\InvalidCallSpecification
 ```
+
+Builds the error for an incomplete call specification.
 
 ### omittedBeforeSpecified()
 
@@ -136,6 +146,8 @@ static omittedBeforeSpecified(
 ): Exception\InvalidCallSpecification
 ```
 
+Builds the error for an omitted argument before a specified one.
+
 ### omittedTailNeedsRest()
 
 ```php
@@ -144,6 +156,8 @@ static omittedTailNeedsRest(
     non-empty-string $matcher,
 ): Exception\InvalidCallSpecification
 ```
+
+Builds the error for an omitted required tail without `Arg::rest()`.
 
 ### closureFailed()
 
@@ -159,4 +173,6 @@ the original is kept as `previous`, because it is the actual mistake.
 ```php
 static staticMethodCalled(non-empty-string $method): Exception\InvalidCallSpecification
 ```
+
+Builds the error for a static method used in a specification.
 

--- a/docs/src/api/classes/Exception/InvalidDefaultValue.md
+++ b/docs/src/api/classes/Exception/InvalidDefaultValue.md
@@ -9,7 +9,7 @@ description: "A registered default factory produced a value the contract cannot 
 
 `Rasuvaeff\Understudy\Exception\InvalidDefaultValue`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidDefaultValue.php#L12) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidDefaultValue.php#L12) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `RuntimeException`
 
@@ -27,4 +27,6 @@ static ofWrongType(
     string $produced,
 ): Exception\InvalidDefaultValue
 ```
+
+Builds the error for a factory value with the wrong type.
 

--- a/docs/src/api/classes/Exception/InvalidSpecificationArgument.md
+++ b/docs/src/api/classes/Exception/InvalidSpecificationArgument.md
@@ -9,7 +9,7 @@ description: "A VALUE inside a specification that no run could act on: a maximum
 
 `Rasuvaeff\Understudy\Exception\InvalidSpecificationArgument`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidSpecificationArgument.php#L24) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/InvalidSpecificationArgument.php#L24) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `InvalidArgumentException`
 

--- a/docs/src/api/classes/Exception/MatcherLeaked.md
+++ b/docs/src/api/classes/Exception/MatcherLeaked.md
@@ -9,7 +9,7 @@ description: "A matcher reached a real call instead of a specification closure."
 
 `Rasuvaeff\Understudy\Exception\MatcherLeaked`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/MatcherLeaked.php#L14) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/MatcherLeaked.php#L14) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -30,4 +30,6 @@ static intoRealCall(
     non-empty-string $matcher,
 ): Exception\MatcherLeaked
 ```
+
+Builds the error for a matcher used in a real call.
 

--- a/docs/src/api/classes/Exception/NeverMethodCalled.md
+++ b/docs/src/api/classes/Exception/NeverMethodCalled.md
@@ -9,7 +9,7 @@ description: "A method declared `: never` was called without an expectation that
 
 `Rasuvaeff\Understudy\Exception\NeverMethodCalled`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/NeverMethodCalled.php#L14) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/NeverMethodCalled.php#L14) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `RuntimeException`
 
@@ -31,6 +31,8 @@ static withoutExpectation(
 ): Exception\NeverMethodCalled
 ```
 
+Builds the error for an unconfigured `never` method call.
+
 ### withoutAnAction()
 
 ```php
@@ -40,6 +42,8 @@ static withoutAnAction(
 ): Exception\NeverMethodCalled
 ```
 
+Builds the error for a `never` expectation with no action.
+
 ### configuredToReturn()
 
 ```php
@@ -48,4 +52,6 @@ static configuredToReturn(
     non-empty-string $method,
 ): Exception\NeverMethodCalled
 ```
+
+Builds the error for a `never` method configured to return.
 

--- a/docs/src/api/classes/Exception/NoDefaultValue.md
+++ b/docs/src/api/classes/Exception/NoDefaultValue.md
@@ -9,7 +9,7 @@ description: "A loose understudy had to answer a call, but the declared return t
 
 `Rasuvaeff\Understudy\Exception\NoDefaultValue`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/NoDefaultValue.php#L14) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/NoDefaultValue.php#L14) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `RuntimeException`
 
@@ -30,4 +30,6 @@ static forReturnType(
     string $type,
 ): Exception\NoDefaultValue
 ```
+
+Builds the error for a return type with no safe default.
 

--- a/docs/src/api/classes/Exception/NothingCaptured.md
+++ b/docs/src/api/classes/Exception/NothingCaptured.md
@@ -9,7 +9,7 @@ description: "`Captor::last()` was read before any matched call carried a value 
 
 `Rasuvaeff\Understudy\Exception\NothingCaptured`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/NothingCaptured.php#L13) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/NothingCaptured.php#L13) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -25,4 +25,6 @@ its `capture()` argument.
 ```php
 static forCaptor(class-string|null $class): Exception\NothingCaptured
 ```
+
+Builds the error for reading an empty captor.
 

--- a/docs/src/api/classes/Exception/OriginalCallUnavailable.md
+++ b/docs/src/api/classes/Exception/OriginalCallUnavailable.md
@@ -9,7 +9,7 @@ description: "`callOriginal()` was asked to delegate, and there is nothing to de
 
 `Rasuvaeff\Understudy\Exception\OriginalCallUnavailable`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/OriginalCallUnavailable.php#L12) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/OriginalCallUnavailable.php#L12) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -25,6 +25,8 @@ description: "`callOriginal()` was asked to delegate, and there is nothing to de
 static forMode(non-empty-string $label): Exception\OriginalCallUnavailable
 ```
 
+Builds the error for forwarding without a real instance.
+
 ### withoutTarget()
 
 ```php
@@ -33,4 +35,6 @@ static withoutTarget(
     non-empty-string $method,
 ): Exception\OriginalCallUnavailable
 ```
+
+Builds the error for delegating a call without a target.
 

--- a/docs/src/api/classes/Exception/OriginalReturnTypeViolation.md
+++ b/docs/src/api/classes/Exception/OriginalReturnTypeViolation.md
@@ -9,7 +9,7 @@ description: "A forwarded call returned an object the double cannot stand in for
 
 `Rasuvaeff\Understudy\Exception\OriginalReturnTypeViolation`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/OriginalReturnTypeViolation.php#L12) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/OriginalReturnTypeViolation.php#L12) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `RuntimeException`
 
@@ -28,4 +28,6 @@ static foreignInstance(
     string $returned,
 ): Exception\OriginalReturnTypeViolation
 ```
+
+Builds the error for a forwarded fluent call returning another object.
 

--- a/docs/src/api/classes/Exception/OutcomeUnavailable.md
+++ b/docs/src/api/classes/Exception/OutcomeUnavailable.md
@@ -9,7 +9,7 @@ description: "An invocation's outcome was read as the wrong kind: a returned val
 
 `Rasuvaeff\Understudy\Exception\OutcomeUnavailable`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/OutcomeUnavailable.php#L14) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/OutcomeUnavailable.php#L14) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -30,9 +30,13 @@ static threwInstead(
 ): Exception\OutcomeUnavailable
 ```
 
+Builds the error for reading a return value after a throw.
+
 ### discardedByLean()
 
 ```php
 static discardedByLean(non-empty-string $method): Exception\OutcomeUnavailable
 ```
+
+Builds the error for reading a value discarded by lean mode.
 

--- a/docs/src/api/classes/Exception/StrictModeViolation.md
+++ b/docs/src/api/classes/Exception/StrictModeViolation.md
@@ -9,7 +9,7 @@ description: "A strict understudy received a call no expectation matched."
 
 `Rasuvaeff\Understudy\Exception\StrictModeViolation`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/StrictModeViolation.php#L12) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/StrictModeViolation.php#L12) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `RuntimeException`
 

--- a/docs/src/api/classes/Exception/UnderstudyError.md
+++ b/docs/src/api/classes/Exception/UnderstudyError.md
@@ -9,7 +9,7 @@ description: "Implemented by every exception this library throws, so a test can 
 
 `Rasuvaeff\Understudy\Exception\UnderstudyError`
 
-**Interface** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/UnderstudyError.php#L14) — **Version:** v0.9.0
+**Interface** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/UnderstudyError.php#L14) — **Version:** v0.9.0-2-g2ad61e3
 
 **Implements:** `Throwable`, `Stringable`
 

--- a/docs/src/api/classes/Exception/UnsupportedTarget.md
+++ b/docs/src/api/classes/Exception/UnsupportedTarget.md
@@ -9,7 +9,7 @@ description: "The requested target cannot be doubled, and no option would make i
 
 `Rasuvaeff\Understudy\Exception\UnsupportedTarget`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/UnsupportedTarget.php#L13) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/UnsupportedTarget.php#L13) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `LogicException`
 
@@ -38,6 +38,8 @@ static notDoublable(
 ): Exception\UnsupportedTarget
 ```
 
+Builds the error for a target that cannot be doubled.
+
 ### signatureConflict()
 
 ```php
@@ -47,4 +49,6 @@ static signatureConflict(
     string $right,
 ): Exception\UnsupportedTarget
 ```
+
+Builds the error for incompatible target signatures.
 

--- a/docs/src/api/classes/Exception/VerificationFailed.md
+++ b/docs/src/api/classes/Exception/VerificationFailed.md
@@ -9,7 +9,7 @@ description: "A verification about what the code under test did (or did not) do 
 
 `Rasuvaeff\Understudy\Exception\VerificationFailed`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/VerificationFailed.php#L20) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Exception/VerificationFailed.php#L20) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** `RuntimeException`
 
@@ -45,6 +45,8 @@ __construct(
 ```php
 static of(non-empty-list<\VerificationFailure> $failures): Exception\VerificationFailed
 ```
+
+Builds a verification failure from its structured records.
 
 ### failures()
 

--- a/docs/src/api/classes/ExpectBuilder.md
+++ b/docs/src/api/classes/ExpectBuilder.md
@@ -9,7 +9,7 @@ description: "Configures a call the code under test is expected to make."
 
 `Rasuvaeff\Understudy\ExpectBuilder`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/ExpectBuilder.php#L19) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/ExpectBuilder.php#L19) — **Version:** v0.9.0-2-g2ad61e3
 
 **Extends:** [`WhenBuilder`](/api/classes/WhenBuilder)
 

--- a/docs/src/api/classes/FailureKind.md
+++ b/docs/src/api/classes/FailureKind.md
@@ -9,7 +9,7 @@ description: "What kind of verification claim a VerificationFailure reports."
 
 `Rasuvaeff\Understudy\FailureKind`
 
-**Enum** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/FailureKind.php#L12) — **Version:** v0.9.0
+**Enum** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/FailureKind.php#L12) — **Version:** v0.9.0-2-g2ad61e3
 
 **Implements:** `UnitEnum`
 

--- a/docs/src/api/classes/Invocation.md
+++ b/docs/src/api/classes/Invocation.md
@@ -9,7 +9,7 @@ description: "One recorded call on an understudy."
 
 `Rasuvaeff\Understudy\Invocation`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Invocation.php#L20) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Invocation.php#L20) — **Version:** v0.9.0-2-g2ad61e3
 
 One recorded call on an understudy.
 
@@ -60,11 +60,15 @@ $args".
 recordFinalArguments(list $args): void
 ```
 
+Stores the arguments after a by-reference call has returned.
+
 ### belongsTo()
 
 ```php
 belongsTo(object $double): bool
 ```
+
+Checks whether this invocation belongs to a given double.
 
 ### callOriginal()
 
@@ -90,7 +94,9 @@ never ran, so the parent body would work over state that does not exist.
 recordOutcome(Outcome $outcome): void
 ```
 
-The wrapped form of recordReturned() and recordThrown(),
+Records an outcome wrapper for internal compatibility.
+
+The wrapped form of `recordReturned`() and `recordThrown`(),
 kept for the callers that still hand over an `Outcome`; dispatch itself
 uses the scalar recorders because every call reaches them.
 
@@ -99,6 +105,8 @@ uses the scalar recorders because every call reaches them.
 ```php
 recordReturned(mixed $value): void
 ```
+
+Records a returned value without retaining an outcome wrapper.
 
 Records a returned value without allocating an Outcome wrapper. The
 wrapper remains supported by recordOutcome() for internal compatibility;
@@ -109,6 +117,8 @@ dispatch uses this scalar path because every call reaches it.
 ```php
 recordDiscardedReturn(): void
 ```
+
+Records that the call returned but its value was discarded.
 
 Records that the call returned without keeping what it returned — the
 lean double's reading of an outcome. The distinction from "threw" and
@@ -121,17 +131,23 @@ refuses by name instead of inventing a value.
 isReturnDiscarded(): bool
 ```
 
+Reports whether the returned value was discarded.
+
 ### recordThrown()
 
 ```php
 recordThrown(Throwable $thrown): void
 ```
 
+Records the throwable produced by the call.
+
 ### markAccounted()
 
 ```php
 markAccounted(): void
 ```
+
+Marks this invocation as claimed by verification or an expectation.
 
 Marks this call as accounted for: an expectation matched it, or a
 verification claimed it. `nothingElse()` is the question this answers.
@@ -141,6 +157,8 @@ verification claimed it. `nothingElse()` is the question this answers.
 ```php
 isAccounted(): bool
 ```
+
+Reports whether verification or an expectation claimed this invocation.
 
 ### didReturn()
 

--- a/docs/src/api/classes/Understudy.md
+++ b/docs/src/api/classes/Understudy.md
@@ -9,7 +9,7 @@ description: "The whole public surface, as static methods so that an understudy 
 
 `Rasuvaeff\Understudy\Understudy`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Understudy.php#L39) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/Understudy.php#L39) — **Version:** v0.9.0-2-g2ad61e3
 
 The whole public surface, as static methods so that an understudy itself can
 stay free of service members: every one of them would be a name the doubled

--- a/docs/src/api/classes/VerificationFailure.md
+++ b/docs/src/api/classes/VerificationFailure.md
@@ -9,7 +9,7 @@ description: "The structured half of one verification failure — the same facts
 
 `Rasuvaeff\Understudy\VerificationFailure`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/VerificationFailure.php#L34) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/VerificationFailure.php#L34) — **Version:** v0.9.0-2-g2ad61e3
 
 The structured half of one verification failure — the same facts the
 rendered message states, addressable by field.

--- a/docs/src/api/classes/WhenBuilder.md
+++ b/docs/src/api/classes/WhenBuilder.md
@@ -9,7 +9,7 @@ description: "Configures what a stubbed call does."
 
 `Rasuvaeff\Understudy\WhenBuilder`
 
-**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/WhenBuilder.php#L36) — **Version:** v0.9.0
+**Class** — **Package:** [rasuvaeff/understudy](https://github.com/rasuvaeff/understudy) — [Source](https://github.com/rasuvaeff/understudy/blob/master/src/WhenBuilder.php#L36) — **Version:** v0.9.0-2-g2ad61e3
 
 **Type parameters:**
 
@@ -70,6 +70,8 @@ link answers, which is what a test holding a reference to it expects.
 ```php
 answers(callable $answer): static
 ```
+
+Computes the return value for each matching call.
 
 ### then()
 

--- a/src/Arg.php
+++ b/src/Arg.php
@@ -140,6 +140,8 @@ final class Arg
     }
 
     /**
+     * Matches an object by its class or interface.
+     *
      * @param class-string $type
      */
     public static function instanceOf(string $type): mixed

--- a/src/Captor.php
+++ b/src/Captor.php
@@ -87,6 +87,8 @@ final class Captor
     }
 
     /**
+     * Records a value captured by a matched specification.
+     *
      * @internal called by the dispatcher once the whole specification matched
      */
     public function record(mixed $value): void
@@ -96,6 +98,8 @@ final class Captor
     }
 
     /**
+     * Clears values captured in a finished runtime context.
+     *
      * @internal called when the context the values were captured in ends
      */
     public function discard(): void

--- a/src/Exception/AmbiguousDefaultFactory.php
+++ b/src/Exception/AmbiguousDefaultFactory.php
@@ -12,6 +12,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class AmbiguousDefaultFactory extends \LogicException implements UnderstudyError
 {
     /**
+     * Builds the error for equally close default factories.
+     *
      * @param class-string            $requested
      * @param non-empty-list<class-string> $candidates
      */

--- a/src/Exception/BypassUnavailable.php
+++ b/src/Exception/BypassUnavailable.php
@@ -12,6 +12,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class BypassUnavailable extends \LogicException implements UnderstudyError
 {
     /**
+     * Builds the error for a class loaded before bypass could be installed.
+     *
      * @param class-string $class
      */
     public static function alreadyLoaded(string $class): self
@@ -26,6 +28,8 @@ final class BypassUnavailable extends \LogicException implements UnderstudyError
     }
 
     /**
+     * Builds the error for a target that is not a class.
+     *
      * @param class-string $class
      */
     public static function notAClass(string $class, string $kind): self
@@ -39,6 +43,8 @@ final class BypassUnavailable extends \LogicException implements UnderstudyError
     }
 
     /**
+     * Builds the error for an already-installed foreign source wrapper.
+     *
      * Something else already transforms PHP source on `file://`; replacing it
      * would silently disable whatever it does.
      */

--- a/src/Exception/CannotWire.php
+++ b/src/Exception/CannotWire.php
@@ -12,6 +12,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class CannotWire extends \InvalidArgumentException implements UnderstudyError
 {
     /**
+     * Builds the error for a subject that cannot be wired as a concrete class.
+     *
      * Takes a plain string, not a `class-string`: "there is no such class" is
      * one of the reasons it reports.
      */
@@ -26,6 +28,8 @@ final class CannotWire extends \InvalidArgumentException implements UnderstudyEr
     }
 
     /**
+     * Builds the error for an inaccessible subject constructor.
+     *
      * @param class-string $sut
      */
     public static function inaccessibleConstructor(string $sut, string $visibility): self
@@ -40,6 +44,8 @@ final class CannotWire extends \InvalidArgumentException implements UnderstudyEr
     }
 
     /**
+     * Builds the error for an unknown constructor override.
+     *
      * @param class-string $sut
      */
     public static function unknownOverride(string $sut, string $name, string $known): self
@@ -54,6 +60,8 @@ final class CannotWire extends \InvalidArgumentException implements UnderstudyEr
     }
 
     /**
+     * Builds the error for an override with an incompatible type.
+     *
      * @param class-string $sut
      */
     public static function incompatibleOverride(string $sut, string $name, string $expected, string $given): self
@@ -70,6 +78,8 @@ final class CannotWire extends \InvalidArgumentException implements UnderstudyEr
     }
 
     /**
+     * Builds the error for a constructor parameter with no safe answer.
+     *
      * @param class-string $sut
      */
     public static function undecidableParameter(string $sut, string $name, string $type, string $reason): self
@@ -87,6 +97,8 @@ final class CannotWire extends \InvalidArgumentException implements UnderstudyEr
     }
 
     /**
+     * Builds the error for a by-reference constructor parameter.
+     *
      * @param class-string $sut
      */
     public static function referenceParameter(string $sut, string $name): self

--- a/src/Exception/ConflictingExpectation.php
+++ b/src/Exception/ConflictingExpectation.php
@@ -21,6 +21,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class ConflictingExpectation extends \LogicException implements UnderstudyError
 {
     /**
+     * Builds the error for a claim registered after an identical stub.
+     *
      * @param non-empty-string $label
      * @param non-empty-string $spec
      */
@@ -37,6 +39,8 @@ final class ConflictingExpectation extends \LogicException implements Understudy
     }
 
     /**
+     * Builds the error for a stub registered after a counted expectation.
+     *
      * @param non-empty-string $label
      * @param non-empty-string $spec
      */
@@ -53,6 +57,8 @@ final class ConflictingExpectation extends \LogicException implements Understudy
     }
 
     /**
+     * Builds the error for duplicate counted expectations.
+     *
      * @param non-empty-string $label
      * @param non-empty-string $spec
      */

--- a/src/Exception/ContextOwnershipViolation.php
+++ b/src/Exception/ContextOwnershipViolation.php
@@ -14,6 +14,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class ContextOwnershipViolation extends \LogicException implements UnderstudyError
 {
     /**
+     * Builds the error for using a double from another runtime context.
+     *
      * A double was configured or verified from a context other than the one
      * that created it — another Fiber, or outside the scope it was built in.
      */

--- a/src/Exception/ForgottenDouble.php
+++ b/src/Exception/ForgottenDouble.php
@@ -16,6 +16,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class ForgottenDouble extends \LogicException implements UnderstudyError
 {
     /**
+     * Builds the error for calling a double after its context was reset.
+     *
      * @param non-empty-string $method
      */
     public static function afterReset(string $method): self
@@ -29,6 +31,8 @@ final class ForgottenDouble extends \LogicException implements UnderstudyError
     }
 
     /**
+     * Builds the error for calling a deliberately retired double.
+     *
      * @param non-empty-string $method
      */
     public static function onPurpose(string $method): self
@@ -41,6 +45,8 @@ final class ForgottenDouble extends \LogicException implements UnderstudyError
     }
 
     /**
+     * Builds the error for reading a property after reset.
+     *
      * @param non-empty-string $property
      */
     public static function propertyAfterReset(string $property): self
@@ -54,6 +60,8 @@ final class ForgottenDouble extends \LogicException implements UnderstudyError
     }
 
     /**
+     * Builds the error for asking a retired double through the facade.
+     *
      * A facade — `strict()`, `verify()`, `nothingElse()`, `forget()` itself —
      * was asked about a double that `Understudy::forget()` retired.
      */
@@ -67,6 +75,8 @@ final class ForgottenDouble extends \LogicException implements UnderstudyError
     }
 
     /**
+     * Builds the error for a default factory returning a retired double.
+     *
      * @param class-string $contract
      */
     public static function fromDefaultFactory(string $contract): self

--- a/src/Exception/ForwardingTargetMismatch.php
+++ b/src/Exception/ForwardingTargetMismatch.php
@@ -13,6 +13,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class ForwardingTargetMismatch extends \InvalidArgumentException implements UnderstudyError
 {
     /**
+     * Builds the error for forwarding to another understudy.
+     *
      * @param non-empty-string $label
      */
     public static function understudyTarget(string $label): self
@@ -26,6 +28,8 @@ final class ForwardingTargetMismatch extends \InvalidArgumentException implement
     }
 
     /**
+     * Builds the error for a forwarding target missing a contract.
+     *
      * @param non-empty-string $label
      * @param class-string     $contract
      */

--- a/src/Exception/InvalidCallSpecification.php
+++ b/src/Exception/InvalidCallSpecification.php
@@ -81,6 +81,8 @@ final class InvalidCallSpecification extends \LogicException implements Understu
     }
 
     /**
+     * Builds the error for a tail matcher in the wrong position.
+     *
      * @param non-empty-string $method
      * @param non-empty-string $matcher
      */
@@ -97,6 +99,8 @@ final class InvalidCallSpecification extends \LogicException implements Understu
     }
 
     /**
+     * Builds the error for an empty matcher combinator.
+     *
      * @param non-empty-string $matcher
      */
     public static function emptyCombinator(string $matcher): self
@@ -110,6 +114,8 @@ final class InvalidCallSpecification extends \LogicException implements Understu
     }
 
     /**
+     * Builds the error for putting a tail matcher inside a combinator.
+     *
      * @param non-empty-string $matcher
      * @param non-empty-string $operand
      */
@@ -137,6 +143,8 @@ final class InvalidCallSpecification extends \LogicException implements Understu
     }
 
     /**
+     * Builds the error for arming a protocol while another is active.
+     *
      * @param positive-int $position
      * @param positive-int $length
      */
@@ -152,6 +160,8 @@ final class InvalidCallSpecification extends \LogicException implements Understu
     }
 
     /**
+     * Builds the error for an incomplete call specification.
+     *
      * @param non-empty-string $method
      * @param int<0, max>      $given
      * @param int<0, max>      $declared
@@ -168,6 +178,8 @@ final class InvalidCallSpecification extends \LogicException implements Understu
     }
 
     /**
+     * Builds the error for an omitted argument before a specified one.
+     *
      * @param non-empty-string $method
      * @param int<0, max>      $omitted
      * @param int<0, max>      $specified
@@ -184,6 +196,8 @@ final class InvalidCallSpecification extends \LogicException implements Understu
     }
 
     /**
+     * Builds the error for an omitted required tail without `Arg::rest()`.
+     *
      * @param non-empty-string $method
      * @param non-empty-string $matcher
      */
@@ -212,6 +226,8 @@ final class InvalidCallSpecification extends \LogicException implements Understu
     }
 
     /**
+     * Builds the error for a static method used in a specification.
+     *
      * @param non-empty-string $method
      */
     public static function staticMethodCalled(string $method): self

--- a/src/Exception/InvalidDefaultValue.php
+++ b/src/Exception/InvalidDefaultValue.php
@@ -12,6 +12,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class InvalidDefaultValue extends \RuntimeException implements UnderstudyError
 {
     /**
+     * Builds the error for a factory value with the wrong type.
+     *
      * @param class-string $requested
      */
     public static function ofWrongType(string $requested, string $produced): self

--- a/src/Exception/MatcherLeaked.php
+++ b/src/Exception/MatcherLeaked.php
@@ -14,6 +14,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class MatcherLeaked extends \LogicException implements UnderstudyError
 {
     /**
+     * Builds the error for a matcher used in a real call.
+     *
      * @param non-empty-string $method
      * @param non-empty-string $matcher
      */

--- a/src/Exception/NeverMethodCalled.php
+++ b/src/Exception/NeverMethodCalled.php
@@ -14,6 +14,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class NeverMethodCalled extends \RuntimeException implements UnderstudyError
 {
     /**
+     * Builds the error for an unconfigured `never` method call.
+     *
      * @param non-empty-string $label
      * @param non-empty-string $method
      */
@@ -29,6 +31,8 @@ final class NeverMethodCalled extends \RuntimeException implements UnderstudyErr
     }
 
     /**
+     * Builds the error for a `never` expectation with no action.
+     *
      * @param non-empty-string $label
      * @param non-empty-string $method
      */
@@ -44,6 +48,8 @@ final class NeverMethodCalled extends \RuntimeException implements UnderstudyErr
     }
 
     /**
+     * Builds the error for a `never` method configured to return.
+     *
      * @param non-empty-string $label
      * @param non-empty-string $method
      */

--- a/src/Exception/NoDefaultValue.php
+++ b/src/Exception/NoDefaultValue.php
@@ -14,6 +14,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class NoDefaultValue extends \RuntimeException implements UnderstudyError
 {
     /**
+     * Builds the error for a return type with no safe default.
+     *
      * @param non-empty-string $label
      * @param non-empty-string $method
      */

--- a/src/Exception/NothingCaptured.php
+++ b/src/Exception/NothingCaptured.php
@@ -13,6 +13,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class NothingCaptured extends \LogicException implements UnderstudyError
 {
     /**
+     * Builds the error for reading an empty captor.
+     *
      * @param class-string|null $class
      */
     public static function forCaptor(?string $class): self

--- a/src/Exception/OriginalCallUnavailable.php
+++ b/src/Exception/OriginalCallUnavailable.php
@@ -12,6 +12,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class OriginalCallUnavailable extends \LogicException implements UnderstudyError
 {
     /**
+     * Builds the error for forwarding without a real instance.
+     *
      * @param non-empty-string $label
      */
     public static function forMode(string $label): self
@@ -26,6 +28,8 @@ final class OriginalCallUnavailable extends \LogicException implements Understud
     }
 
     /**
+     * Builds the error for delegating a call without a target.
+     *
      * @param non-empty-string $label
      * @param non-empty-string $method
      */

--- a/src/Exception/OriginalReturnTypeViolation.php
+++ b/src/Exception/OriginalReturnTypeViolation.php
@@ -12,6 +12,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class OriginalReturnTypeViolation extends \RuntimeException implements UnderstudyError
 {
     /**
+     * Builds the error for a forwarded fluent call returning another object.
+     *
      * @param non-empty-string $label
      * @param non-empty-string $method
      */

--- a/src/Exception/OutcomeUnavailable.php
+++ b/src/Exception/OutcomeUnavailable.php
@@ -14,6 +14,8 @@ namespace Rasuvaeff\Understudy\Exception;
 final class OutcomeUnavailable extends \LogicException implements UnderstudyError
 {
     /**
+     * Builds the error for reading a return value after a throw.
+     *
      * @param non-empty-string $method
      */
     public static function threwInstead(string $method, \Throwable $thrown): self
@@ -26,6 +28,8 @@ final class OutcomeUnavailable extends \LogicException implements UnderstudyErro
     }
 
     /**
+     * Builds the error for reading a value discarded by lean mode.
+     *
      * @param non-empty-string $method
      */
     public static function discardedByLean(string $method): self

--- a/src/Exception/UnsupportedTarget.php
+++ b/src/Exception/UnsupportedTarget.php
@@ -25,6 +25,8 @@ final class UnsupportedTarget extends \LogicException implements UnderstudyError
     }
 
     /**
+     * Builds the error for a target that cannot be doubled.
+     *
      * @param non-empty-string $target
      */
     public static function notDoublable(string $target, string $reason): self
@@ -37,6 +39,8 @@ final class UnsupportedTarget extends \LogicException implements UnderstudyError
     }
 
     /**
+     * Builds the error for incompatible target signatures.
+     *
      * @param non-empty-string $method
      */
     public static function signatureConflict(string $method, string $left, string $right): self

--- a/src/Exception/VerificationFailed.php
+++ b/src/Exception/VerificationFailed.php
@@ -30,6 +30,8 @@ final class VerificationFailed extends \RuntimeException implements UnderstudyEr
     }
 
     /**
+     * Builds a verification failure from its structured records.
+     *
      * @param non-empty-list<VerificationFailure> $failures
      */
     public static function of(array $failures): self

--- a/src/Invocation.php
+++ b/src/Invocation.php
@@ -73,6 +73,8 @@ final class Invocation
     }
 
     /**
+     * Stores the arguments after a by-reference call has returned.
+     *
      * @param list<mixed> $args
      *
      * @internal
@@ -83,6 +85,8 @@ final class Invocation
     }
 
     /**
+     * Checks whether this invocation belongs to a given double.
+     *
      * @internal
      */
     public function belongsTo(object $double): bool
@@ -116,6 +120,8 @@ final class Invocation
     }
 
     /**
+     * Records an outcome wrapper for internal compatibility.
+     *
      * The wrapped form of {@see recordReturned()} and {@see recordThrown()},
      * kept for the callers that still hand over an `Outcome`; dispatch itself
      * uses the scalar recorders because every call reaches them.
@@ -128,6 +134,8 @@ final class Invocation
     }
 
     /**
+     * Records a returned value without retaining an outcome wrapper.
+     *
      * Records a returned value without allocating an Outcome wrapper. The
      * wrapper remains supported by recordOutcome() for internal compatibility;
      * dispatch uses this scalar path because every call reaches it.
@@ -145,6 +153,8 @@ final class Invocation
     }
 
     /**
+     * Records that the call returned but its value was discarded.
+     *
      * Records that the call returned without keeping what it returned — the
      * lean double's reading of an outcome. The distinction from "threw" and
      * from "returned null" is kept: `didReturn()` stays true, and `returned()`
@@ -163,6 +173,8 @@ final class Invocation
     }
 
     /**
+     * Reports whether the returned value was discarded.
+     *
      * @internal
      */
     public function isReturnDiscarded(): bool
@@ -171,6 +183,8 @@ final class Invocation
     }
 
     /**
+     * Records the throwable produced by the call.
+     *
      * @internal
      */
     public function recordThrown(\Throwable $thrown): void
@@ -184,6 +198,8 @@ final class Invocation
     }
 
     /**
+     * Marks this invocation as claimed by verification or an expectation.
+     *
      * Marks this call as accounted for: an expectation matched it, or a
      * verification claimed it. `nothingElse()` is the question this answers.
      *
@@ -195,6 +211,8 @@ final class Invocation
     }
 
     /**
+     * Reports whether verification or an expectation claimed this invocation.
+     *
      * @internal
      */
     public function isAccounted(): bool

--- a/src/WhenBuilder.php
+++ b/src/WhenBuilder.php
@@ -87,6 +87,8 @@ class WhenBuilder
     }
 
     /**
+     * Computes the return value for each matching call.
+     *
      * @param callable(Invocation): TReturn $answer
      */
     public function answers(callable $answer): static


### PR DESCRIPTION
Documents the remaining core API methods with concise method-level summaries and regenerates the API snapshot/pages. Also removes the stale 0.4 version label from the Psalm and PHPStan adapter pages. Satellite summaries will be picked up when their documentation PRs are released.