### PR TITLE
Document the 0.x mutation release policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,10 @@ seconds instead of the full run's minute — and the full run stays the gate.
   tests grow the numerator. Read the reasons before moving the number, and add
   one when you do — a gate whose verdict flips on which PHP built the run is
   measuring the environment, not the suite.
+  For the published `0.x` line, `minMsi: 92` is therefore the explicit release
+  policy: a single local run at 94.1% is evidence, not a new gate. Before the
+  `1.0` release, rerun a reproducible CI-like matrix and raise the threshold
+  only when it has stable headroom above the new value.
 - **The only `&` in the package is in generated code, and that is deliberate.**
   Psalm cannot follow a reference into an object property and says so by name;
   the way out is not a suppression but moving the reference to where Psalm never

--- a/README.md
+++ b/README.md
@@ -906,7 +906,7 @@ make build          # validate, normalize, require-checker, cs, psalm, unit, int
 make cs-fix
 make psalm
 make test
-make mutation       # infection, gate at 92% MSI
+make mutation       # infection, release gate at 92% MSI for the 0.x line
 make release-check
 
 make perf-install   # once: the comparative benchmark harness in perf/
@@ -914,6 +914,11 @@ make perf           # against Mockery, Prophecy and PHPUnit
 make perf-cold      # cold start, one process per double
 make perf-memory    # bytes retained per live double
 ```
+
+The `0.x` release policy keeps Infection's Covered Code gate at 92% MSI. A
+single local run above that value does not change the gate because mutant
+counts vary across environments. Before `1.0`, the threshold will be
+reconsidered only after a reproducible CI-like matrix shows stable headroom.
 
 Or through Docker directly:
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -906,7 +906,7 @@ make build          # validate, normalize, require-checker, cs, psalm, unit, int
 make cs-fix
 make psalm
 make test
-make mutation       # infection, гейт 92% MSI
+make mutation       # infection, релизный гейт 92% MSI для линии 0.x
 make release-check
 
 make perf-install   # один раз: сравнительный харнесс в perf/
@@ -914,6 +914,11 @@ make perf           # против Mockery, Prophecy и PHPUnit
 make perf-cold      # холодный старт, один процесс на дубль
 make perf-memory    # память на живой дубль
 ```
+
+Для релизов линии `0.x` политика оставляет гейт Covered Code в Infection на
+уровне 92% MSI. Один локальный прогон выше этого значения сам по себе гейт не
+меняет: число мутантов зависит от окружения. Перед `1.0` порог пересмотрим
+только после воспроизводимой CI-подобной матрицы со стабильным запасом.
 
 Или напрямую через Docker:
 


### PR DESCRIPTION
Closes the review policy gap for H-6.

- records that `minMsi: 92` is intentional for the published 0.x line;
- explains why one local 94.1% run does not change the gate;
- requires a reproducible CI-like matrix with stable headroom before raising it for 1.0;
- keeps English and Russian README guidance aligned.

Verification: Docker `composer build` (exit 0), `git diff --check`.
